### PR TITLE
Clarifying trial_type and HED columns in event.tsv

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1631,6 +1631,7 @@ Example:
   }
 }
 ```
+When both the trial_type column and the HED column are included, the HED tags from both columns are used to annotate the event instance. This usage allows convenient specification of common event properties while also allowing specification of event instance details in a convenient manner.
 
 Appendix IV: Entity table
 =========================


### PR DESCRIPTION
Added a sentence at end of Appendix III explaining the propose of trial_type and HED columns and why you want to allow both.