### PR TITLE
[MRG] unicode: replace greek mu and omega by micro and ohm signs

### DIFF
--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -22,7 +22,7 @@ Système international (d'unités))
 | coulomb        | C           | electric charge or quantity of electricity |
 | volt           | V           | voltage (electrical potential), emf        |
 | farad          | F           | capacitance                                |
-| ohm            | Ω           | resistance, impedance, reactance           |
+| ohm            | Ω           | resistance, impedance, reactance           |
 | siemens        | S           | electrical conductance                     |
 | weber          | Wb          | magnetic flux                              |
 | tesla          | T           | magnetic flux density                      |
@@ -59,7 +59,7 @@ Système international (d'unités))
 | [deci](https://www.wikiwand.com/en/Deci-)   | d             | 10<sup>-1</sup>  |
 | [centi](https://www.wikiwand.com/en/Centi-) | c             | 10<sup>-2</sup>  |
 | [milli](https://www.wikiwand.com/en/Milli-) | m             | 10<sup>-3</sup>  |
-| [micro](https://www.wikiwand.com/en/Micro-) | μ             | 10<sup>-6</sup>  |
+| [micro](https://www.wikiwand.com/en/Micro-) | µ             | 10<sup>-6</sup>  |
 | [nano](https://www.wikiwand.com/en/Nano-)   | n             | 10<sup>-9</sup>  |
 | [pico](https://www.wikiwand.com/en/Pico-)   | p             | 10<sup>-12</sup> |
 | [femto](https://www.wikiwand.com/en/Femto-) | f             | 10<sup>-15</sup> |


### PR DESCRIPTION
There is actually a difference between [`µ`](https://www.compart.com/en/unicode/U+00B5) and [`μ`](https://www.compart.com/en/unicode/U+03BC).

Previously we had the greek Mu sign, but what we really want is the micro sign.

cf. https://twitter.com/stefanappelhoff/status/1055122338080006144

edit: This same error was also true for the omega sign, which should be an ohm sign:
- https://www.compart.com/en/unicode/U+03A9
- https://www.compart.com/en/unicode/U+2126