### PR TITLE
[INFRA] Use linkchecker to verify URLs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,11 @@ jobs:
           name: generate docs
           command: pipenv run mkdocs build --clean --strict --verbose
       - run:
-          name: check URLs
+          name: quick check URLs
           command: pipenv run linkchecker site/
+      # TODO: ATM 38 errors (and locally got also 43 internal errors)
+      #- run:
+      #    name: thorough check of external URLs
+      #    command: pipenv run linkchecker --check-extern site/
       - store_artifacts:
           path: site

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,5 +23,8 @@ jobs:
       - run:
           name: generate docs
           command: pipenv run mkdocs build --clean --strict --verbose
+      - run:
+          name: check URLs
+          command: pipenv run linkchecker site/
       - store_artifacts:
           path: site

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: |
             sudo pip install pip==18.0
             sudo pip install pipenv==2018.7.1
-            pipenv install
+            pipenv install -d
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ jobs:
           command: pipenv run mkdocs build --clean --strict --verbose
       - run:
           name: quick check URLs
-          command: pipenv run linkchecker site/
+          command: |
+            mkdir -p ~/.linkchecker/ && echo '[AnchorCheck]' >| ~/.linkchecker/linkcheckerrc
+            pipenv run linkchecker site/
       # TODO: ATM 38 errors (and locally got also 43 internal errors)
       #- run:
       #    name: thorough check of external URLs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,11 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.6
+      - image: circleci/python:2.7
     steps:
       - checkout
       - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python*/site-packages
       - restore_cache:  # ensure this step occurs *before* installing dependencies
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:

--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,16 @@ name = "pypi"
 [packages]
 mkdocs = "==1.0.4"
 mkdocs-material = "==3.0.4"
-# Custom version with the fix for anchors
-linkchecker = {file = "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"}
 
 [dev-packages]
+# Custom version with the fix for anchors
+linkchecker = {file = "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"}
+# Installing from a file seems to not pull in all the dependencies linkchecker needs,
+# so installing them manually here
+requests = "*"
+pyxdg = "*"
+dnspython = "*"
+
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 mkdocs = "==1.0.4"
 mkdocs-material = "==3.0.4"
 # Custom version with the fix for anchors
-linkchecker = "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"
+linkchecker = {file = "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"}
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 mkdocs = "==1.0.4"
 mkdocs-material = "==3.0.4"
 # Custom version with the fix for anchors
-linkchecker = "git+https://github.com/yarikoptic/linkchecker@9.4.0.anchorfix1"
+linkchecker = "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,8 @@ name = "pypi"
 [packages]
 mkdocs = "==1.0.4"
 mkdocs-material = "==3.0.4"
-linkchecker = "*"
+# Custom version with the fix for anchors
+linkchecker = "git+https://github.com/yarikoptic/linkchecker@9.4.0.anchorfix1"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,5 @@ dnspython = "*"
 
 
 [requires]
-python_version = "3.6"
+# linkchecker doesn't support python3 yet
+# python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 mkdocs = "==1.0.4"
 mkdocs-material = "==3.0.4"
+linkchecker = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "76afab1f513aea9efdeb66bcbf3749404b3fbd3058b76117144cc7da03e7ab0b"
+            "sha256": "00275565e97c44d3a7b79b6433889579abcad5a87d0648d3be01288e2be7edee"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -29,6 +29,9 @@
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
             "version": "==2.10"
+        },
+        "linkchecker": {
+            "file": "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"
         },
         "livereload": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "580a32c021d6bda5d1823a0bfb462bfbb5dfaa567bcef30b058c3af80cb67896"
+            "sha256": "76afab1f513aea9efdeb66bcbf3749404b3fbd3058b76117144cc7da03e7ab0b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,7 +21,6 @@
                 "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==7.0"
         },
         "jinja2": {
@@ -33,25 +32,50 @@
         },
         "livereload": {
             "hashes": [
-                "sha256:583179dc8d49b040a9da79bd33de59e160d2a8802b939e304eb359a4419f6498",
-                "sha256:dd4469a8f5a6833576e9f5433f1439c306de15dbbfeceabd32479b1123380fa5"
+                "sha256:29cadfabcedd12eed792e0131991235b9d4764d4474bed75cf525f57109ec0a2",
+                "sha256:e632a6cd1d349155c1d7f13a65be873b38f43ef02961804a1bba8d817fa649a7"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*'",
-            "version": "==2.5.2"
+            "version": "==2.6.0"
         },
         "markdown": {
             "hashes": [
                 "sha256:c00429bd503a47ec88d5e30a751e147dcb4c6889663cd3e2ba0afe858e009baa",
                 "sha256:d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==3.0.1"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
+                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
+                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
+                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
+                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
+                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
+                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
+                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
+                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
+                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
+                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
+                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
+                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
+                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
+                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
+                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
+                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
+                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
+                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
+                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
+                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
+                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
+                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
+                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
+                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
+                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
+                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
+                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
-            "version": "==1.0"
+            "version": "==1.1.0"
         },
         "mkdocs": {
             "hashes": [
@@ -78,11 +102,10 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:2e1d8f4a4c351cfa6c5ad88a0f2f4a3a30af481a942fdf8f9db0936e12ff37c2",
-                "sha256:54675680f6ad3ee8242fcb8926703b30ea3dcbeb9e21b7f7f19077f0ec982a82"
+                "sha256:25b0a7967fa697b5035e23340a48594e3e93acb10b06d74574218ace3347d1df",
+                "sha256:6cf0cf36b5a03b291ace22dc2f320f4789ce56fbdb6635a3be5fadbf5d7694dd"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*'",
-            "version": "==5.0"
+            "version": "==6.0"
         },
         "pyyaml": {
             "hashes": [
@@ -117,7 +140,6 @@
                 "sha256:d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb",
                 "sha256:e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==5.1.1"
         }
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "00275565e97c44d3a7b79b6433889579abcad5a87d0648d3be01288e2be7edee"
+            "sha256": "494542c438cc8ba27ff9f4a4b9a05fb36aeddc5873e80af703f766ff7a2bb5d4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -29,9 +29,6 @@
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
             "version": "==2.10"
-        },
-        "linkchecker": {
-            "file": "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"
         },
         "livereload": {
             "hashes": [
@@ -146,5 +143,61 @@
             "version": "==5.1.1"
         }
     },
-    "develop": {}
+    "develop": {
+        "certifi": {
+            "hashes": [
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+            ],
+            "version": "==2018.10.15"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "dnspython": {
+            "hashes": [
+                "sha256:40f563e1f7a7b80dc5a4e76ad75c23da53d62f1e15e6e517293b04e1f84ead7c",
+                "sha256:861e6e58faa730f9845aaaa9c6c832851fbf89382ac52915a51f89c71accdd31"
+            ],
+            "index": "pypi",
+            "version": "==1.15.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "linkchecker": {
+            "file": "https://github.com/yarikoptic/linkchecker/archive/9.4.0.anchorfix1.zip"
+        },
+        "pyxdg": {
+            "hashes": [
+                "sha256:1948ff8e2db02156c0cccd2529b43c0cff56ebaa71f5f021bbd755bc1419190e",
+                "sha256:fe2928d3f532ed32b39c32a482b54136fe766d19936afc96c8f00645f9da1a06"
+            ],
+            "index": "pypi",
+            "version": "==0.26"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+            ],
+            "index": "pypi",
+            "version": "==2.20.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        }
+    }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "494542c438cc8ba27ff9f4a4b9a05fb36aeddc5873e80af703f766ff7a2bb5d4"
+            "sha256": "1c02be30b122d3a8dd3b4e2a44c7e11a10e9681e7c3625d3a9ee8782cc0141f5"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.6"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -171,9 +171,9 @@ inplaneT1, referenced by a defacemask image. E.g.,
 `sub-01_mod-T1w_defacemask.nii.gz`.
 
 Some meta information about the acquisition MAY be provided in an additional
-JSON file. See [Common metadata fields](#common-metadata-fields) for a list of terms and their
-definitions. There are also some OPTIONAL JSON fields specific to anatomical
-scans:
+JSON file. See [Common metadata fields](#common-metadata-fields) for a
+list of terms and their definitions. There are also some OPTIONAL JSON
+fields specific to anatomical scans:
 
 | Field name              | Definition                                                                                                                                         |
 | :---------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -384,8 +384,8 @@ bval example:
 and thus define those values for all sessions and/or subjects in one place (see
 Inheritance principle).
 
-See [Common metadata fields](#common-metadata-fields) for a list of additional terms that can be
-included in the corresponding JSON file.
+See [Common metadata fields](#common-metadata-fields) for a list of
+additional terms that can be included in the corresponding JSON file.
 
 JSON example:
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -171,7 +171,7 @@ inplaneT1, referenced by a defacemask image. E.g.,
 `sub-01_mod-T1w_defacemask.nii.gz`.
 
 Some meta information about the acquisition MAY be provided in an additional
-JSON file. See Common MR metadata fields for a list of terms and their
+JSON file. See [Common metadata fields](#common-metadata-fields) for a list of terms and their
 definitions. There are also some OPTIONAL JSON fields specific to anatomical
 scans:
 
@@ -287,7 +287,7 @@ combined image rather than an image from each coil.
 | CogAtlasID      | RECOMMENDED. URL of the corresponding [Cognitive Atlas](http://www.cognitiveatlas.org/) Task term.                                                                                                         |
 | CogPOID         | RECOMMENDED. URL of the corresponding [CogPO](http://www.cogpo.org/) term.                                                                                                                                 |
 
-See [8.3.1. Common MR metadata fields](#heading=h.5u721tt1h9pe) for a list of
+See [Common metadata fields](#common-metadata-fields) for a list of
 additional terms and their definitions.
 
 Example:
@@ -384,7 +384,7 @@ bval example:
 and thus define those values for all sessions and/or subjects in one place (see
 Inheritance principle).
 
-See Common MR metadata fields for a list of additional terms that can be
+See [Common metadata fields](#common-metadata-fields) for a list of additional terms that can be
 included in the corresponding JSON file.
 
 JSON example:

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -360,7 +360,7 @@ dwi.nii file) and not the magnet’s coordinate system, which means that any
 rotations applied to dwi.nii also need to be applied to the corresponding bvec
 file.
 
-<sup>4</sup>[http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/fdt/fdt_dtifit.html](hhttp://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/fdt/fdt_dtifit.html)
+<sup>4</sup>[http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/fdt/fdt_dtifit.html](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/fdt/fdt_dtifit.html)
 
 bvec example:
 


### PR DESCRIPTION
More TODOs outside the scope of this PR:
- Unfortunately verification of HTML URL anchors seems to be plain broken.  See e.g. ~~https://github.com/wummel/linkchecker/issues/513~~ https://github.com/linkchecker/linkchecker/issues/179 so would be very nice if someone looked into it.  Should be something really fixable
- I have not enabled `--check-extern` because apparently there is quite a number of URLs which seems to be broken, including the ones to cognitive atlas (e.g. http://www.cognitiveatlas.org/term/id/trm_54e69c642d89b) 