### PR TITLE
ENH: First(?) good practice recommendation. No excessive overrides in Inheritance principle

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -186,6 +186,14 @@ apply to all bold runs. However, if there is a key with different value in
 `sub-01/func/sub-01_task-xyz_acq-test1_run-1_bold.json`, the new value will be
 applicable for that particular run/task NIfTI file/s.
 
+### Good practice recommendations
+
+**Try to avoid excessive amount of overrides.**  Do not specify a field
+value in the upper levels if lower levels have more or less even
+distribution of multiple possible values. E.g., if a field `X` has one
+value for all `ses-01/` and another for all `ses-02/` it better not to be
+defined at all in the `.json` at the upper level.
+
 ## File Formation specification
 
 ### Imaging files


### PR DESCRIPTION
It is often useful to look at the top level `task*.json` files to see what is
"common" among all subjects/sessions.  Listing only the fields with common
values is what we also implemented (albeit incorrectly, fix is pending
https://github.com/nipy/heudiconv/pull/279) in ReproIn.

Upon quick search I also found no "good practice" recommendations in the
spec.  It might be arguable either spec should or should not include them.
I think it should since we already RECOMMEND things.  We of cause could
place recommendations into a separate subsection somewhere but then they
would not be linked to the specific topics and thus would not be attended
to. Hence I placed this one right at the section where it is pertinent

This PR is largely an RFC ;-)