### PR TITLE
Adding formal decision-making rules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,9 @@
+# This files DOES NOT list people responsible for maintanance of different parts of 
+# the specification. It merely serves the purpose of notifying interested
+# contributors when a new Pull Request that proposes changes to a particular file
+# is submitted. If you would like to subscribe to such notifications (in a form of a
+# Request for Review) please add your github username next to the file you want to 
+# monitor below.
+
 /src/01-common-principles.md @chrisfilo
 /src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md @chrisfilo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,9 @@
 # Request for Review) please add your github username next to the file you want to 
 # monitor below.
 
+# Add your github name below to get notified about proposed releases
+/src/CHANGES.md @chrisfilo
+
+# Individual sections
 /src/01-common-principles.md @chrisfilo
 /src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md @chrisfilo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/src/01-common-principles.md @chrisfilo
+/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md @chrisfilo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ GitHub has a [nice introduction](https://help.github.com/articles/github-flow/) 
 
 ## How the decision to merge a pull request is made?
 
-The decision-making rules are outlined [here](DECISION-MAKING.md).
+The decision-making rules are outlined in [DECISION-MAKING.md](DECISION-MAKING.md).
 
 ## Recognizing contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,10 @@ GitHub has a [nice introduction](https://help.github.com/articles/github-flow/) 
 
 <br>
 
+## How the decision to merge a pull request is made?
+
+The decision-making rules are outlined [here](DECISION-MAKING.md).
+
 ## Recognizing contributions
 
 BIDS follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification, so we welcome and recognize all contributions from documentation to testing to code development. You can see a list of current contributors in the [BIDS specification](https://github.com/bids-standard/bids-specification/blob/master/src/99-appendices/01-contributors.md).

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -1,0 +1,79 @@
+# Decision-making rules
+## Introduction
+The Brain Imaging Data Structure (BIDS) community set out the following 
+decision-making rules with the intention to:
+
+- Strive for consensus.
+- Promote open discussions.
+- Minimize the administrative burden.
+- Provide a path for when consensus cannot be made.
+- Grow the community.
+- Minimize the [bus factor](https://en.wikipedia.org/wiki/Bus_factor) of the 
+  project.
+
+The rules outlined below are inspired by the [lazy consensus system used in the Apache Foundation](https://www.apache.org/foundation/voting.html) 
+and heavily depends on [GitHub Pull Request Review system](https://help.github.com/articles/about-pull-requests/).
+
+## Definitions
+**Repository** - [https://github.com/bids-standard/bids-specification](https://github.com/bids-standard/bids-specification)
+**Contributor** - a person listed in the Appendix I: Contributors. The 
+community decides on the content of this file using the same process as any 
+other change to the Repository (see below) allowing the meaning of "Contributor"
+to evolve independently of the Decision-making rules.
+
+## Rules
+1. Every modification of the specification (including a correction of a typo, 
+   adding a new Contributor, an extension adding support for a new data type, or
+   others) or proposal to release a new version needs to be done via a Pull 
+   Request (PR) to the Repository.
+1. Anyone can open a PR (this action is not limited to Contributors).
+1. A PR is eligible to be merged if and only if these conditions are met:
+   1. The last commit is at least 5 working days old to allow the community to 
+      evaluate it.
+   1. The PR features at least one [Review that Approves](https://help.github.com/articles/about-pull-request-reviews/#about-pull-request-reviews) 
+      the PR from a Contributor that is not an author of the PR. The review 
+      needs to be made after the last commit in the PR (equivalent to 
+      [Stale review dismissal](https://help.github.com/articles/enabling-required-reviews-for-pull-requests/)
+      option on GitHub).
+   1. Does not feature any [Reviews that Request changes](https://help.github.com/articles/about-required-reviews-for-pull-requests/).
+   1. Does not feature "WIP" in the title (Work in Progress).
+   1. Passes all automated tests.
+1. Any Contributor can Review a PR and Request changes. If a Contributor 
+   Request changes they need to provide an explanation what changes 
+   should be added and justification of their importance. Reviews requesting 
+   changes can also we used to request more time to review a PR.
+1. A Contributor that Requested changes can Dismiss their own review or Approve 
+   changes added by the Contributor who opened the PR.
+1. If the author of a PR and Contributor who provided Review that Requests 
+   changes cannot find a solution that would lead to the Contributor dismissing 
+   their review or accepting the changes the Review can be Dismissed with a 
+   vote. Rules governing voting:
+   1. A Vote can be triggered by any Contributor, but only after 5 working days 
+      from the time a Review Requesting Changes has been raised and in case a 
+      Vote has been triggered previously no sooner than 15 working days since 
+      its conclusion.
+   1. Only Contributors can vote, each contributor gets one vote.
+   1. A Vote ends after 5 working days or when all Contributors have voted 
+      (whichever comes first).
+   1. A Vote freezes the PR - no new commits or Reviews Requesting changes can 
+      be added to it while a vote is ongoing. If a commit is accidentally made 
+      during that period it should be reverted.
+   1. The quorum for a Vote is 30% of all Contributors.
+   1. The outcome of the vote is decided based on a simple majority.
+
+## Comments
+
+1. There are no restrictions on how the content of the PR is prepared. For 
+   example it is perfectly fine for a PR to consist of content developed by a 
+   group of experts over an extended period of time via in person meetings and 
+   online collaborations using a Google Document.
+1. To facilitate triaging of incoming PR you can subscribe to 
+   notifications for new PRs proposing changes to specific files. To do this
+   add your Github name next to the file you want to subscribe to in the 
+   [CODEOWNERS](CODEOWNERS). This way you will be ask to review each relevant
+   PR. Please mind that lack of your review will not prevent the PR from being
+   merged so if you think the PR needs you attention review it promptly or
+   request more time via Request changes.
+1. Releases are triggered the same way as any other change - via a PR.
+
+

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -8,7 +8,7 @@ decision-making rules with the intention to:
 - Minimize the administrative burden.
 - Provide a path for when consensus cannot be made.
 - Grow the community.
-- Minimize the [bus factor](https://en.wikipedia.org/wiki/Bus_factor) of the 
+- Maximize the [bus factor](https://en.wikipedia.org/wiki/Bus_factor) of the 
   project.
 
 The rules outlined below are inspired by the [lazy consensus system used in the Apache Foundation](https://www.apache.org/foundation/voting.html) 

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -1,5 +1,7 @@
 # Decision-making rules
+
 ## Introduction
+
 The Brain Imaging Data Structure (BIDS) community set out the following 
 decision-making rules with the intention to:
 
@@ -15,13 +17,16 @@ The rules outlined below are inspired by the [lazy consensus system used in the 
 and heavily depends on [GitHub Pull Request Review system](https://help.github.com/articles/about-pull-requests/).
 
 ## Definitions
+
 **Repository** - [https://github.com/bids-standard/bids-specification](https://github.com/bids-standard/bids-specification)
+
 **Contributor** - a person listed in the Appendix I: Contributors. The 
 community decides on the content of this file using the same process as any 
 other change to the Repository (see below) allowing the meaning of "Contributor"
 to evolve independently of the Decision-making rules.
 
 ## Rules
+
 1. Every modification of the specification (including a correction of a typo, 
    adding a new Contributor, an extension adding support for a new data type, or
    others) or proposal to release a new version needs to be done via a Pull 

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -72,8 +72,8 @@ to evolve independently of the Decision-making rules.
    add your Github name next to the file you want to subscribe to in the 
    [CODEOWNERS](CODEOWNERS). This way you will be ask to review each relevant
    PR. Please mind that lack of your review will not prevent the PR from being
-   merged so if you think the PR needs you attention review it promptly or
-   request more time via Request changes.
+   merged so if you think the PR needs your attention, please review it 
+   promptly or request more time via Request changes.
 1. Releases are triggered the same way as any other change - via a PR.
 
 

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -37,9 +37,9 @@ to evolve independently of the Decision-making rules.
 1. A PR is eligible to be merged if and only if these conditions are met:
    1. The last commit is at least 5 working days old to allow the community to 
       evaluate it.
-   1. The PR features at least one [Review that Approves](https://help.github.com/articles/about-pull-request-reviews/#about-pull-request-reviews) 
-      the PR from a Contributor that is not an author of the PR. The review 
-      needs to be made after the last commit in the PR (equivalent to 
+   1. The PR features at least two [Reviews that Approve](https://help.github.com/articles/about-pull-request-reviews/#about-pull-request-reviews) 
+      the PR from Contributors of which neither is the author of the PR. The reviews 
+      need to be made after the last commit in the PR (equivalent to 
       [Stale review dismissal](https://help.github.com/articles/enabling-required-reviews-for-pull-requests/)
       option on GitHub).
    1. Does not feature any [Reviews that Request changes](https://help.github.com/articles/about-required-reviews-for-pull-requests/).

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -32,6 +32,8 @@ to evolve independently of the Decision-making rules.
    others) or proposal to release a new version needs to be done via a Pull 
    Request (PR) to the Repository.
 1. Anyone can open a PR (this action is not limited to Contributors).
+1. PRs adding new Contributors must also add their GitHub names to the 
+   [CODEOWNERS](CODEOWNERS) file.
 1. A PR is eligible to be merged if and only if these conditions are met:
    1. The last commit is at least 5 working days old to allow the community to 
       evaluate it.

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -41,7 +41,7 @@ to evolve independently of the Decision-making rules.
 1. Any Contributor can Review a PR and Request changes. If a Contributor 
    Request changes they need to provide an explanation what changes 
    should be added and justification of their importance. Reviews requesting 
-   changes can also we used to request more time to review a PR.
+   changes can also be used to request more time to review a PR.
 1. A Contributor that Requested changes can Dismiss their own review or Approve 
    changes added by the Contributor who opened the PR.
 1. If the author of a PR and Contributor who provided Review that Requests 


### PR DESCRIPTION
Dear all,
After months of consultations and deliberations, I have put together a proposal for how we can make decisions. I really wanted the decision rules to be simple, inclusive, and promote consensus. The rules follow the 'doacracy' philosophy - if you want to do something and no one is against it it is going to happen. I think such an approach is very important considering this is a community project in which everyone volunteers their own time. 

The rules fit very well with existing GitHub mechanisms (used by many other repositories) which will make them easy to implement. Hopefully the administrative burden of following them will be minimal.

There are special roles in the decision making process. Anyone can submit a PR and any Contributor can review it. This removes bottlenecks while giving everyone the chance to contribute and express their opinion.

I hope that these decision-making rules will create a solid scaffolding that will let the BIDS community grow an thrive for many years to come.

Chris
(hopefully soon not the BDFL) 