### PR TITLE
Documenting the contrast suffix and disambiguating it from the catch-all modality categorization

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -303,6 +303,30 @@ sub- prefix is not part of the subject label, but must be included in file names
 MUST be integers. Those labels MAY include zero padding, but this is NOT
 RECOMMENDED to maintain their uniqueness.
 
+## The contrast suffix
+
+In addition to the `*<label_identifier>-<custom_label>*` pairs (e.g. `sub-001`),
+it is RECOMMENDED that file names contain a suffix of the form `*_<suffix>.`,
+which directly precedes the file format delimiter. The string values of this
+suffix indicate  the contrast of the file in question.
+
+This specification is often needed, as the NIfTI header does not allow us to
+specify what unit or contrast the voxel values correspond to. The decision of
+BIDS to track this information in the file name rather than in the JSON sidecar
+file, is based on (a) the high relevance of this field for rapid file selection
+(b) the low number but large scope of brain imaging contrasts. For non-NIfTI
+files, this suffix provides more user-friendly recognition of the feature
+documented by the file. A file ending in `_events.tsv` is more unambiguously
+understood as documenting the events than if this information had to be inferred
+purely from the `.tsv` format.
+
+It is particularly noteworthy that there can only be one contrast suffix per file,
+as the voxel values can only correspond to one contrast. This field is not
+designed to track historical information, and the suffix `_cbv_tstat.*` is
+nonsensical. If multiple contrasts (e.g. `_cbv.*` and `_bold.*`) are acquired in
+one session, the corresponding files MUST be differentiated by other labels
+(e.g. `*run-<label>`).
+
 ## Units
 
 All units SHOULD be specified as per International System of Units (abbreviated

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -112,14 +112,14 @@ Template:
 ```Text
 sub-<label>/[ses-<label>/]
     anat/
-        sub-<label>[_ses-<label>][_acq-<label>][_ce-<label>][_rec-<label>][_run-<index>]_<modality_label>.nii[.gz]
+        sub-<label>[_ses-<label>][_acq-<label>][_ce-<label>][_rec-<label>][_run-<index>]_<contrast_label>.nii[.gz]
         sub-<label>[_ses-<label>][_acq-<label>][_ce-<label>][_rec-<label>][_run-<index>][_mod-<label>]_defacemask.nii[.gz]
 ```
 
 Anatomical (structural) data acquired for that participant. Currently supported
-modalities include:
+contrast include:
 
-| Name               | modality_label | Description                                                                                                                                                                                                                             |
+| Name               | contrast_label | Description                                                                                                                                                                                                                             |
 | :----------------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | T1 weighted        | T1w            |                                                                                                                                                                                                                                         |
 | T2 weighted        | T2w            |                                                                                                                                                                                                                                         |
@@ -136,7 +136,7 @@ modalities include:
 | Inplane T2         | inplaneT2      | T2-weighted anatomical image matched to functional acquisition                                                                                                                                                                          |
 | Angiography        | angio          |                                                                                                                                                                                                                                         |
 
-If several scans of the same modality are acquired they MUST be indexed with a
+If several scans of the same contrast are acquired they MUST be indexed with a
 key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only integers are allowed as
 run labels). When there is only one scan of a given type the run key MAY be
 omitted. Please note that diffusion imaging data is stored elsewhere (see
@@ -144,13 +144,13 @@ below).
 
 The OPTIONAL `acq-<label>` key/value pair corresponds to a custom label the user
 MAY use to distinguish a different set of parameters used for acquiring the same
-modality. For example this should be used when a study includes two T1w images -
+contrast. For example this should be used when a study includes two T1w images -
 one full brain low resolution and and one restricted field of view but high
 resolution. In such case two files could have the following names:
 `sub-01_acq-highres_T1w.nii.gz` and `sub-01_acq-lowres_T1w.nii.gz`, however the
 user is free to choose any other label than `highres` and `lowres` as long as
 they are consistent across subjects and sessions. In case different sequences
-are used to record the same modality (e.g. RARE and FLASH for T1w) this field
+are used to record the same contrast (e.g. RARE and FLASH for T1w) this field
 can also be used to make that distinction. At what level of detail to make the
 distinction (e.g. just between RARE and FLASH, or between RARE, FLASH, and
 FLASHsubsampled) remains at the discretion of the researcher.
@@ -166,7 +166,7 @@ different reconstruction algorithms (for example ones using motion correction).
 If the structural images included in the dataset were defaced (to protect
 identity of participants) one CAN provide the binary mask that was used to
 remove facial features in the form of `_defacemask` files. In such cases the
-OPTIONAL `mod-<label>` key/value pair corresponds to modality label for eg: T1w,
+OPTIONAL `mod-<label>` key/value pair corresponds to contrast label for eg: T1w,
 inplaneT1, referenced by a defacemask image. E.g.,
 `sub-01_mod-T1w_defacemask.nii.gz`.
 


### PR DESCRIPTION
Renaming and clarifying the scope, utility, and usage of the suffix field hitherto ambiguously named “modality” — as [discussed previously](https://github.com/bids-standard/bids-specification/issues/63#issuecomment-435168888).