### PR TITLE
REL: v.1.1.2

### DIFF
--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -1,6 +1,6 @@
 Changelog
 
-## [Unreleased](https://github.com/bids-standard/bids-specification/tree/HEAD)
+## [1.1.2](https://github.com/bids-standard/bids-specification/tree/1.1.2)
 
 -   Update 01-contributors.md [#120](https://github.com/bids-standard/bids-specification/pull/120) ([oesteban](https://github.com/oesteban))
 -   Global fields in data dictionaries [#117](https://github.com/bids-standard/bids-specification/pull/117) ([chrisfilo](https://github.com/chrisfilo))


### PR DESCRIPTION
There are no major changes in this release. It serves two purposes:
- testing the release mechanism (especially RTD component contributed by @choldgraf)
- creating a minor release prior to EEG and iEEG merges