### PR TITLE
Add "part" keyword for mag/phase BOLD images (based on BEP001).

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -187,14 +187,15 @@ Currently supported image contrasts include:
 | :----------------- | :------------- | :-----------------------------------------------------------------------------------------------------------------------|
 | BOLD               | bold           | Blood-Oxygen-Level Dependent contrast (specialized T2\* weighting)                                                      |
 | CBV                | cbv            | Cerebral Blood Volume contrast (specialized T2\* weighting or difference between T1 weighted images)                    |
+| Phase              | phase          | Phase information associated with magnitude information stored in BOLD contrast                                         |
 
 Template:
 
 ```Text
 sub-<label>/[ses-<label>/]
     func/
-        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_part-<mag|phase>][_run-<index>][_echo-<index>]_<contrast_label>.nii[.gz]
-        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_part-<mag|phase>][_run-<index>][_echo-<index>]_sbref.nii[.gz]
+        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_run-<index>][_echo-<index>]_<contrast_label>.nii[.gz]
+        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_run-<index>][_echo-<index>]_sbref.nii[.gz]
 ```
 
 Imaging data acquired during functional imaging (i.e. imaging which supports
@@ -237,9 +238,6 @@ can be used to distinguish different phase-encoding directions and
 reconstruction algorithms (for example ones using motion correction).
 See [`fmap` Case 4](01-magnetic-resonance-imaging-data.md#case-4-multiple-phase-encoded-directions-pepolar)
 for more information on `dir` field specification.
-
-The OPTIONAL `part-<mag|phase>` key/value allows for storing
-magnitude and phase images. In its absence the image is assumed to be magnitude.
 
 Multi-echo data MUST be split into one file per echo. Each file shares the same
 name with the exception of the `_echo-<index>` key/value. For example:

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -193,8 +193,8 @@ Template:
 ```Text
 sub-<label>/[ses-<label>/]
     func/
-        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_run-<index>][_echo-<index>]_<contrast_label>.nii[.gz]
-        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_run-<index>][_echo-<index>]_sbref.nii[.gz]
+        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_part-<mag|phase>][_run-<index>][_echo-<index>]_<contrast_label>.nii[.gz]
+        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_ce-<label>][_dir-<label>][_rec-<label>][_part-<mag|phase>][_run-<index>][_echo-<index>]_sbref.nii[.gz]
 ```
 
 Imaging data acquired during functional imaging (i.e. imaging which supports
@@ -238,7 +238,10 @@ reconstruction algorithms (for example ones using motion correction).
 See [`fmap` Case 4](01-magnetic-resonance-imaging-data.md#case-4-multiple-phase-encoded-directions-pepolar)
 for more information on `dir` field specification.
 
-Multi echo data MUST  be split into one file per echo. Each file shares the same
+The OPTIONAL `part-<mag|phase>` key/value allows for storing
+magnitude and phase images. In its absence the image is assumed to be magnitude.
+
+Multi-echo data MUST be split into one file per echo. Each file shares the same
 name with the exception of the `_echo-<index>` key/value. For example:
 
 ```Text


### PR DESCRIPTION
When users choose to reconstruct both magnitude and phase images from their EPI sequences, they end up with full 4D phase time series. The "part" keyword is [used in BEP001](https://github.com/bids-standard/bep001/blob/1be21287ec2926f239b241e470cbb4c7ecb3f8aa/main.md#8101-filenames) for situations where there is both a magnitude and a phase image.

An alternative to this might be to place the phase time series in `fmap/` and to label them the same way one would label single-volume phase images (i.e., for Case 2 for field maps in the specification).