### PR TITLE
[MRG] clarify encoding of README, CHANGES, TSV, and JSON files

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -223,7 +223,8 @@ MUST NOT be a series of space characters. Each TSV file MUST start with a header
 line listing the names of all columns (with the exception of physiological and
 other continuous acquisition data - see below for details). Names MUST be
 separated with tabs. String values containing tabs MUST be escaped using double
-quotes. Missing and non-applicable values MUST be coded as `n/a`.
+quotes. Missing and non-applicable values MUST be coded as `n/a`. TSV files MUST
+be in UTF-8 encoding.
 
 Example:
 
@@ -234,12 +235,12 @@ onset duration  response_time correct stop_trial  go_trial
 
 Tabular files MAY be optionally accompanied by a simple data dictionary in a
 JSON format (see below). The data dictionaries MUST have the same name as their
-corresponding tabular files but with `.json` extensions. If a JSON file 
-is provided, it MAY contain one or more fields describing the columns found in 
-the TSV file (in addition to any other metadata one wishes to include that 
-describe the file as a whole). Note that if a field name included in the JSON 
-sidecar matches a column name in the TSV file, then that field MUST contain a 
-description of the corresponding column, using an object containing the following 
+corresponding tabular files but with `.json` extensions. If a JSON file
+is provided, it MAY contain one or more fields describing the columns found in
+the TSV file (in addition to any other metadata one wishes to include that
+describe the file as a whole). Note that if a field name included in the JSON
+sidecar matches a column name in the TSV file, then that field MUST contain a
+description of the corresponding column, using an object containing the following
 fields:
 
 | Field name  | Definition                                                                                                             |

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -49,7 +49,8 @@ Example:
 ### `README`
 
 In addition a free form text file (`README`) describing the dataset in more
-details SHOULD be provided.
+details SHOULD be provided. The `README` file MUST be either in ASCII or UTF-8
+encoding.
 
 ### `CHANGES`
 
@@ -57,7 +58,7 @@ Version history of the dataset (describing changes, updates and corrections) MAY
 be provided in the form of a `CHANGES` text file. This file MUST follow the CPAN
 Changelog convention:
 [http://search.cpan.org/~haarg/CPAN-Changes-0.400002/lib/CPAN/Changes/Spec.pod](https://metacpan.org/pod/release/HAARG/CPAN-Changes-0.400002/lib/CPAN/Changes/Spec.pod).
-`README` and `CHANGES` files MUST be either in ASCII or UTF-8 encoding.
+The `CHANGES` file MUST be either in ASCII or UTF-8 encoding.
 
 Example:
 


### PR DESCRIPTION
there was no indication about which encoding should be used for TSV files. It was probably meant to mention UTF-8, so I added this.