### PR TITLE
[FIX] Clarify name of "BrainVision" format

### DIFF
--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -36,7 +36,7 @@ stored in one of the following formats:
 
 -   [European data format](https://www.edfplus.info/) (`.edf`)
 
--   [BrainVision Core file data format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
+-   [BrainVision Core Data Format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
     (`.vhdr`, `.vmrk`, `.eeg`) by Brain Products GmbH
 
 -   The format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab)

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -36,7 +36,7 @@ stored in one of the following formats:
 
 -   [European data format](https://www.edfplus.info/) (`.edf`)
 
--   [BrainVision data format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
+-   [BrainVision Core file data format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
     (`.vhdr`, `.vmrk`, `.eeg`) by Brain Products GmbH
 
 -   The format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab)

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -33,7 +33,7 @@ stored in one of the following formats:
 
 -   [European Data Format](https://www.edfplus.info/) (`.edf`)
 
--   [BrainVision data format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
+-   [BrainVision Core file data format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
     (`.vhdr`, `.eeg`, `.vmrk`) by Brain Products GmbH
 
 -   The format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab)

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -33,7 +33,7 @@ stored in one of the following formats:
 
 -   [European Data Format](https://www.edfplus.info/) (`.edf`)
 
--   [BrainVision Core file data format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
+-   [BrainVision Core Data Format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
     (`.vhdr`, `.eeg`, `.vmrk`) by Brain Products GmbH
 
 -   The format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab)


### PR DESCRIPTION
As discussed in the issue #172, I suggest changing the name BrainVision data format in BrainVision Core file data format in iEEG and EEG specifications.

closes #172 