### PR TITLE
[FIX] make section headings and ToC consistent between meg and eeg specs

### DIFF
--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -289,7 +289,7 @@ The free text field for the channel description can for example be specified as
 intracranial, stimulus, response, vertical EOG, horizontal EOG, skin
 conductance, eyetracker, etc.
 
-## Electrode description (`*[_space-<label>]_electrodes.tsv`)
+## Electrode description (`*_electrodes.tsv`)
 
 Template:
 
@@ -366,7 +366,7 @@ LT02  23  -40  -19  2.3    Integra
 H01   27  -42  -21  5      AdTech
 ```
 
-## Coordinate System JSON (`*[_space-<label>]_coordsystem.json`)
+## Coordinate System JSON (`*_coordsystem.json`)
 
 Template:
 


### PR DESCRIPTION
I removed the `space-<xxx>` from the filename in the section headings, it is still part of the actual specification. 

This should make the following headings and table of contents more similar
- https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/02-magnetoencephalography.html
- https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/03-electroencephalography.html
- https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/04-intracranial-electroencephalography.html

