### PR TITLE
[FIX] change file for definition of electrical stimulation labels from _electrodes.json to _events.json

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,5 @@
 # Individual sections
 /src/01-common-principles.md @chrisfilo @DimitriPapadopoulos
 /src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md @chrisfilo
-/src/04-modality-specific-files/03-electroencephalography.md @sappelhoff
+/src/04-modality-specific-files/03-electroencephalography.md @sappelhoff @ezemikulan
+/src/04-modality-specific-files/04-intracranial-electroencephalography.md @ezemikulan

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -496,7 +496,7 @@ onset, duration), the `_events.tsv` file can contain the electrical stimulation
 parameters in addition to other events. Note that these can be intermixed with
 other task events. Electrical stimulation parameters can be described in columns
 called `electrical_stimulation_<label>`, with labels chosen by the researcher and
-optionally defined in more detail in an accompanying `_electrodes.json` file (as
+optionally defined in more detail in an accompanying `_events.json` file (as
 per the main BIDS spec). Functions for complex stimulation patterns can, similar
 as when a video is presented, be stored in a folder in the `/stimuli/` folder.
 For example: `/stimuli/electrical_stimulation_functions/biphasic.tsv`

--- a/src/99-appendices/01-contributors.md
+++ b/src/99-appendices/01-contributors.md
@@ -81,6 +81,7 @@ your name is not listed, please add it.
 -   Christopher J. Markiewicz 💬📖💻
 -   Jeremy Moreau 📖💡
 -   Zachary Michael 📖
+-   Ezequiel Mikulan 📖💻
 -   Michael P. Milham 💡🔍
 -   Henk Mutsaerts 📖
 -   National Institute of Mental Health 💵


### PR DESCRIPTION
closes #184 

The text mentioned that the description of the electrical\_stimulation\_\<label> columns had to be placed on \_electrodes.json, but it should be placed on \_events.json. 

This PR fixes the issue.
