### PR TITLE
[FIX] Clarify use of acq and task parameters in EEG, MEG, and iEEG

### DIFF
--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -18,8 +18,8 @@ Template:
 sub-<label>/
     [ses-<label>]/
       meg/
-        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>][_proc-<label>]_meg.<manufacturer_specific_extension>
-        [sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>][_proc-<label>]_meg.json]
+        sub-<label>[_ses-<label>]_task-<label>[_run-<index>][_proc-<label>]_meg.<manufacturer_specific_extension>
+        [sub-<label>[_ses-<label>]_task-<label>[_run-<index>][_proc-<label>]_meg.json]
 ```
 
 Unprocessed MEG data MUST be stored in the native file format of the MEG
@@ -178,7 +178,7 @@ Template:
 sub-<label>/
     [ses-<label>]/
       meg/
-        [sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>][_proc-<label>]_channels.tsv]
+        [sub-<label>[_ses-<label>]_task-<label>[_run-<index>][_proc-<label>]_channels.tsv]
 ```
 
 This file is RECOMMENDED as it provides easily searchable information across
@@ -372,6 +372,10 @@ actual anatomical landmarks, these latter may be marked with a piece of felt-tip
 taped to the skin. Please note that the photos may need to be cropped or blurred
 to conceal identifying features prior to sharing, depending on the terms of the
 consent form signed by the participant.
+
+The `acq` parameter can be used to indicate acquisition of different photos of
+the same face (or other body part in different angles to show, for example, the
+location of the nasion (NAS) as opposed to the right periauricular point (RPA).
 
 Example of the NAS fiducial placed between the eyebrows, rather than at the
 actual anatomical nasion: `sub-0001_ses-001_acq-NAS_photo.jpg`

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -371,7 +371,7 @@ subject’s head are RECOMMENDED. If the coils are not placed at the location of
 actual anatomical landmarks, these latter may be marked with a piece of felt-tip
 taped to the skin. Please note that the photos may need to be cropped or blurred
 to conceal identifying features prior to sharing, depending on the terms of the
-consent form signed by the participant.
+consent given by the participant.
 
 The `acq` parameter can be used to indicate acquisition of different photos of
 the same face (or other body part in different angles to show, for example, the

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -375,7 +375,7 @@ consent form signed by the participant.
 
 The `acq` parameter can be used to indicate acquisition of different photos of
 the same face (or other body part in different angles to show, for example, the
-location of the nasion (NAS) as opposed to the right periauricular point (RPA).
+location of the nasion (NAS) as opposed to the right periauricular point (RPA)).
 
 Example of the NAS fiducial placed between the eyebrows, rather than at the
 actual anatomical nasion: `sub-0001_ses-001_acq-NAS_photo.jpg`

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -26,8 +26,8 @@ Template:
 sub-<label>/
     [ses-<label>]/
       eeg/
-        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>]_eeg.<manufacturer_specific_extension>
-        sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>]_eeg.json
+        sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_eeg.<manufacturer_specific_extension>
+        sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_eeg.json
 ```
 
 The EEG community uses a variety of formats for storing raw data, and there is
@@ -188,7 +188,7 @@ Template:
 sub-<label>/
     [ses-<label>]/
       eeg/
-        [sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>]_channels.tsv]
+        [sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_channels.tsv]
 ```
 
 Although this information can often be extracted from the EEG recording,
@@ -303,6 +303,10 @@ Fz    0.0000    0.0714   0.0699    cup       Ag/AgCl
 REF   -0.0742   -0.0200  -0.0100   cup       Ag/AgCl
 GND   0.0742    -0.0200  -0.0100   cup       Ag/AgCl
 ```
+
+The `acq` parameter can be used to indicate acquisition of the same data (i.e.,
+the electrode positions) with, for example, a different electrode position
+recording device.
 
 ## Coordinate System JSON (`*_coordsystem.json`)
 
@@ -419,9 +423,13 @@ sub-<label>/
 ```
 
 Photos of the anatomical landmarks and/or fiducials are OPTIONAL.
-Please note that the photos may need to be cropped or
-blurred to conceal identifying features prior to sharing, depending on the
-terms of the consent form signed by the participant.
+Please note that the photos may need to be cropped or blurred to conceal
+identifying features prior to sharing, depending on the terms of the consent
+form signed by the participant.
+
+The `acq` parameter can be used to indicate acquisition of different photos of
+the same face (or other body part in different angles to show, for example, the
+location of the nasion (NAS) as opposed to the right periauricular point (RPA).
 
 Example:
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -304,9 +304,10 @@ REF   -0.0742   -0.0200  -0.0100   cup       Ag/AgCl
 GND   0.0742    -0.0200  -0.0100   cup       Ag/AgCl
 ```
 
-The `acq` parameter can be used to indicate acquisition of the same data (i.e.,
-the electrode positions) with, for example, a different electrode position
-recording device.
+The `acq` parameter can be used to indicate acquisition of the same data. For
+example, this could be the recording of electrode positions with a different
+electrode position recording device, or repeated digitization before and after
+the recording.
 
 ## Coordinate System JSON (`*_coordsystem.json`)
 
@@ -425,7 +426,7 @@ sub-<label>/
 Photos of the anatomical landmarks and/or fiducials are OPTIONAL.
 Please note that the photos may need to be cropped or blurred to conceal
 identifying features prior to sharing, depending on the terms of the consent
-form signed by the participant.
+given by the participant.
 
 The `acq` parameter can be used to indicate acquisition of different photos of
 the same face (or other body part in different angles to show, for example, the

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -266,7 +266,7 @@ Template:
 sub-<label>/
     [ses-<label>]/
       eeg/
-        [sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>]_electrodes.tsv]
+        [sub-<label>[_ses-<label>][_acq-<label>][_run-<index>]_electrodes.tsv]
 ```
 
 File that gives the location of EEG electrodes. Note that coordinates are

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -23,8 +23,8 @@ Template:
 sub-<label>/
   [ses-<label>]/
     ieeg/
-      sub-<label>[_ses-<label>]_task-<task_label>[_acq-<label>][_run-<index>]_ieeg.<manufacturer_specific_extension>
-      sub-<label>[_ses-<label>]_task-<task_label>[_acq-<label>][_run-<index>]_ieeg.json
+      sub-<label>[_ses-<label>]_task-<task_label>[_run-<index>]_ieeg.<manufacturer_specific_extension>
+      sub-<label>[_ses-<label>]_task-<task_label>[_run-<index>]_ieeg.json
 ```
 
 The iEEG community uses a variety of formats for storing raw data, and there is
@@ -211,7 +211,7 @@ Template:
 sub-<label>/
     [ses-<label>]/
       ieeg/
-        [sub-<label>[_ses-<label>]_task-<label>[_acq-<label>][_run-<index>]_channels.tsv]
+        [sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_channels.tsv]
 ```
 
 A channel represents one time series recorded with the recording system (for


### PR DESCRIPTION
While @robertoostenveld and I went over #173, we noticed several minor inaccuracies with the entities that recording modalities can have.

This PR mainly targets a consistent and sensible use of the acq parameter, as also discussed in https://github.com/bids-standard/bids-specification/issues/194#issuecomment-480480719

Furthermore, one superfluous task label is deleted from EEG electrodes.

In Robert's words:

> My confusion is only with task for headshape/photo/electrodes. Those are measurements which are task-independent. See https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/03-electroencephalography.html#electrodes-description-_electrodestsv which includes task as required. I think that is incorrect. Electrode data is not recorded while the subject performs a task (except for "sit still!")
