### PR TITLE
[INFRA] Enable permalink urls to appear at (sub)section headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Brain Imaging Data Structure v1.2.0-dev
 theme: material
 markdown_extensions:
     - toc:
-        permalink: "#"
+        anchorlink: true
 plugins:
     - search
 docs_dir: 'src'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: Brain Imaging Data Structure v1.2.0-dev
 theme: material
+markdown_extensions:
+    - toc:
+        permalink: "#"
 plugins:
     - search
 docs_dir: 'src'


### PR DESCRIPTION
There is no convenient way to obtain a permalink to reference a specific (sub)section
in the page ATM.  Only top level section urls available in the TOC. With this permalink
those IDs, which are already in HTML anyways, become exposed so it is easy to get
permalink for any section.  I chose # symbol since that is what is used in the URL to
separate out the fragment to point to that ID in the page, e.g.
![image](https://user-images.githubusercontent.com/39889/56850029-9ab8de00-68ca-11e9-8112-128408239132.png)
