### PR TITLE
[ENH] adding release guidelines

### DIFF
--- a/Release_Guideline.md
+++ b/Release_Guideline.md
@@ -8,20 +8,20 @@ In both cases, edition numbers are specified as MAJOR.MINOR.PATCH, and the diffe
 
 In BIDS, we have considered a major release version (the next being 2.0.0) to indicate backwards incompatible changes, and minor and patch releases must be backwards compatible.
 
-Once a decision for a release has been established, the rules of [decision-making](DECISION-MAKING) govern the mechanism of doing the release (i.e. waiting 5 business days to merge).
+Once a decision for a release has been established, the rules of [decision-making](DECISION-MAKING) govern the mechanism of doing the release (i.e., waiting 5 business days to merge).
 
 **When it is time for a minor (1.X) release?**
 
 This release should be reserved for when a modality (BEP) has been merged into the specification.
-Special cases can override this.
+Special cases can override this and it is up to the BIDS Maintainers Group to decide this given approval by the BIDS Steering Group.
 
 **When it is time for a patch (1.X.X) release?**
 
-This release can occur more frequently and in a number of cases:
+This release can occur more frequently and in a number of cases, not limited to the following examples:
 
-- A modality field has changed with the validator reflected in this change.
-- Additions or updates to the resources around BIDS (i.e. BEP update)
-- Specification rendering has been enhanced
+- A modality field has changed and the [bids-validator](https://github.com/bids-standard/bids-validator) has been updated to reflect this change.
+- Resources around BIDS have been added or updated (e.g., BEP updates)
+- The rendering of the [specification](https://bids-specification.readthedocs.io/en/stable/) has been enhanced
 - Use case motivated changes
 
 The decision for a patch release will fall onto the judgement call of the maintainer working group. 

--- a/Release_Guideline.md
+++ b/Release_Guideline.md
@@ -1,27 +1,38 @@
+# Release Guidelines
+
 This document captures guidelines to follow when considering a new release of the BIDS specification.
 
+## Background
 BIDS has generally followed a semantic versioning (semver) approach.
 The canonical semver text can be found at [https://semver.org/](https://semver.org/), and an adaptation to documents can be found at [https://semverdoc.org/](https://semver.org/).
-A specification falls somewhere between these two, so we should consider carefully the rules.
+A specification falls somewhere between these two, as documentation does not require
+backwards compatibility, while software has notions of bugs and features which do not
+map to the reasons for updating a specification.
 
 In both cases, edition numbers are specified as MAJOR.MINOR.PATCH, and the difference is in the rules for incrementing each edition number.
 
-In BIDS, we have considered a major release version (the next being 2.0.0) to indicate backwards incompatible changes, and minor and patch releases must be backwards compatible.
+In BIDS, we have considered a major release version (the next being 2.0.0) to indicate
+backwards-incompatible changes, while minor and patch releases must be backwards compatible.
+## Guidelines
 
-Once a decision for a release has been established, the rules of [decision-making](DECISION-MAKING) govern the mechanism of doing the release (i.e., waiting 5 business days to merge).
+Once a decision for a release has been established, the rules of [decision-making](DECISION-MAKING.md)
+govern the mechanism of doing the release, *i.e.*, waiting 5 business days to merge.
 
-**When it is time for a minor (1.X) release?**
+### Minor (1.X.0) releases
 
-This release should be reserved for when a modality (BEP) has been merged into the specification.
-Special cases can override this and it is up to the BIDS Maintainers Group to decide this given approval by the BIDS Steering Group.
+A minor release should be made when a BEP (BIDS Extension Proposal) has been merged into the
+specification.
+The BIDS Maintainers have discretion to identify other cases justifying a minor release.
 
-**When it is time for a patch (1.X.X) release?**
+### Patch (1.X.Y) releases
 
-This release can occur more frequently and in a number of cases, not limited to the following examples:
+Patch releases will generally be more frequent, and indicate less significant changes to the specification.
+The following is a non-exhaustive set of justifications for a patch release:
 
 - A modality field has changed and the [bids-validator](https://github.com/bids-standard/bids-validator) has been updated to reflect this change.
-- Resources around BIDS have been added or updated (e.g., BEP updates)
-- The rendering of the [specification](https://bids-specification.readthedocs.io/en/stable/) has been enhanced
-- Use case motivated changes
+- Links or information in the specification are no longer accurate, *e.g.* if a BEP document is added or moved
+- The rendering of the [specification](https://bids-specification.readthedocs.io/en/stable/) has changed
+- A metadata field or file type is added at the request of a curator attempting to release BIDS-compliant data
 
-The decision for a patch release will fall onto the judgement call of the maintainer working group. 
+Ultimately, all releases are a matter of maintainer discretion, but patch release frequency should
+balance community needs for stability and responsiveness.

--- a/Release_Guideline.md
+++ b/Release_Guideline.md
@@ -13,10 +13,12 @@ In both cases, edition numbers are specified as MAJOR.MINOR.PATCH, and the diffe
 
 In BIDS, we have considered a major release version (the next being 2.0.0) to indicate
 backwards-incompatible changes, while minor and patch releases must be backwards compatible.
+
 ## Guidelines
 
 Once a decision for a release has been established, the rules of [decision-making](DECISION-MAKING.md)
-govern the mechanism of doing the release, *i.e.*, waiting 5 business days to merge.
+govern the mechanism of doing the release, *i.e.*, waiting 5 business days and obtaining
+the approval of at least one maintainer before merging.
 
 ### Minor (1.X.0) releases
 

--- a/Release_Guideline.md
+++ b/Release_Guideline.md
@@ -4,7 +4,7 @@ This document captures guidelines to follow when considering a new release of th
 
 ## Background
 BIDS has generally followed a semantic versioning (semver) approach.
-The canonical semver text can be found at [https://semver.org/](https://semver.org/), and an adaptation to documents can be found at [https://semverdoc.org/](https://semver.org/).
+The canonical semver text can be found at https://semver.org/, and an adaptation to documents can be found at https://semverdoc.org/.
 A specification falls somewhere between these two, as documentation does not require
 backwards compatibility, while software has notions of bugs and features which do not
 map to the reasons for updating a specification.

--- a/Release_Guideline.md
+++ b/Release_Guideline.md
@@ -1,0 +1,27 @@
+This document captures guidelines to follow when considering a new release of the BIDS specification.
+
+BIDS has generally followed a semantic versioning (semver) approach.
+The canonical semver text can be found at [https://semver.org/](https://semver.org/), and an adaptation to documents can be found at [https://semverdoc.org/](https://semver.org/).
+A specification falls somewhere between these two, so we should consider carefully the rules.
+
+In both cases, edition numbers are specified as MAJOR.MINOR.PATCH, and the difference is in the rules for incrementing each edition number.
+
+In BIDS, we have considered a major release version (the next being 2.0.0) to indicate backwards incompatible changes, and minor and patch releases must be backwards compatible.
+
+Once a decision for a release has been established, the rules of [decision-making](DECISION-MAKING) govern the mechanism of doing the release (i.e. waiting 5 business days to merge).
+
+**When it is time for a minor (1.X) release?**
+
+This release should be reserved for when a modality (BEP) has been merged into the specification.
+Special cases can override this.
+
+**When it is time for a patch (1.X.X) release?**
+
+This release can occur more frequently and in a number of cases:
+
+- A modality field has changed with the validator reflected in this change.
+- Additions or updates to the resources around BIDS (i.e. BEP update)
+- Specification rendering has been enhanced
+- Use case motivated changes
+
+The decision for a patch release will fall onto the judgement call of the maintainer working group. 


### PR DESCRIPTION
addresses https://github.com/bids-standard/bids-specification/issues/257 and converted from [this google doc](https://docs.google.com/document/d/144Dorxn1e_22iRAvWIfmw-Q9KW7Ce7OZ-KyMHKAk_Qg/edit)

This is in the review phase and comment phase. I thought it could perhaps be easier to work and wrap up in this PR. 