### PR TITLE
[ENH] Update contributing guide and README to make discussion forums easy to find

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,15 +5,15 @@
 
 *We're so excited you're here and want to contribute.*
 
-We hope that these guidelines are designed to make it as easy as possible to get involved. If you have any questions that aren't discussed below, please let us know through one of the many ways to [get in touch](#get-in-touch).
+We hope that these guidelines are designed to make it as easy as possible to get involved. If you have any questions that aren't discussed below, please let us know by [opening an issue](#understanding-issues).
 
 ## Table of contents
 
 Been here before? Already know what you're looking for in this guide? Jump to the following sections:
 
 *   [Joining the BIDS community](#joining-the-community)
-*   [Get in touch](#get-in-touch)
 *   [Contributing through GitHub](#contributing-through-github)
+*   [Understanding issues](#understanding-issues)
 *   [Writing in markdown](#writing-in-markdown)
 *   [Make a change with a pull request](#making-a-change-with-a-pull-request)
 *   [Example pull request](#example-pull-request)
@@ -21,21 +21,57 @@ Been here before? Already know what you're looking for in this guide? Jump to th
 
 ## Joining the community
 
-BIDS - the [Brain Imaging Data Structure](http://bids.neuroimaging.io/) - is a growing community of neuroimaging enthusiasts, and we want to make our resources accessible to and engaging for as many researchers as possible.
-
-We therefore require that all contributions **adhere to our [Code of Conduct](CODE_OF_CONDUCT.md)**.
+BIDS - the [Brain Imaging Data Structure](https://bids.neuroimaging.io/) - is a growing community of neuroimaging enthusiasts, and we want to make our resources accessible to and engaging for as many researchers as possible.
 
 How do you know that you're a member of the BIDS community? You're here! You know that BIDS exists! You're officially a member of the community. It's THAT easy! Welcome!
 
-## Get in touch
+Most of our discussions take place here in [GitHub issues](#understanding-issues).
+We also have a [bids-discussion](https://groups.google.com/forum/#!forum/bids-discussion) Google Group, although this is largely now an archive of previous conversations.
+
+Moving forward, we encourage all members to contribute here on [GitHub](https://github.com/bids-standard/bids-specification) or on the [NeuroStars](https://neurostars.org/tags/bids) Discourse Forum, under the `bids` tag.
+
+To keep on top of new posts, please see this guide for setting your [topic notifications](https://meta.discourse.org/t/discourse-new-user-guide/96331#heading--topic-notifications).
+
+As a reminder, we expect that all contributions adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Contributing through GitHub
 
-[Git](https://git-scm.com/) is a really useful tool for version control. [GitHub](https://github.com/) sits on top of git and supports collaborative and distributed working.
+[git](https://git-scm.com/) is a really useful tool for version control. [GitHub](https://github.com/) sits on top of git and supports collaborative and distributed working.
 
 We know that it can be daunting to start using git and GitHub if you haven't worked with them in the past, but the BIDS Specification maintainers are here to help you figure out any of the jargon or confusing instructions you encounter!
 
 In order to contribute via GitHub you'll need to set up a free account and sign in. Here are some [instructions](https://help.github.com/articles/signing-up-for-a-new-github-account/) to help you get going. Remember that you can ask us any questions you need to along the way.
+
+## Understanding issues
+
+Every project on GitHub uses [issues](https://github.com/bids-standard/bids-specification/issues) slightly differently.
+
+The following outlines how BIDS developers think about communicating through issues.
+
+**Issues** are individual pieces of work that need to be completed or decisions that need to be made to move the project forwards.
+A general guideline: if you find yourself tempted to write a great big issue that
+is difficult to describe as one unit of work, please consider splitting it into two or more issues.
+
+Issues are assigned [labels](#issue-labels) which explain how they relate to the overall project's goals and immediate next steps.
+
+### Issue labels
+
+The current list of labels are [here](https://github.com/bids-standard/bids-specification/labels) and include:
+
+* [![Help wanted](https://img.shields.io/badge/-help%20wanted-159818.svg)](https://github.com/bids-standard/bids-specification/labels/community) *These issues contain a task that a member of the team has determined we need additional help with.*
+
+    If you feel that you can contribute to one of these issues, we especially encourage you to do so!
+
+* [![Opinions wanted](https://img.shields.io/badge/-opinions%20wanted-84b6eb.svg)](https://github.com/bids-standard/bids-specification/labels/opinions%20wanted) *These issues hold discussions where we're especially eager for feedback.*
+
+    Ongoing discussions benefit from broad feedback.
+    This label is used to highlight issues where decisions are being considered, so please join the conversation!
+
+* [![Community](https://img.shields.io/badge/-community-%23ddcc5f.svg)](https://github.com/bids-standard/bids-specification/labels/community) *These issues are related to building and supporting the BIDS community.*
+
+    In addition to the specification itself, we are dedicated to creating a healthy community.
+    These issues highlight pieces of work or discussions around how we can support our members and make it easier to contribute.
+
 
 ## Writing in markdown
 
@@ -95,20 +131,20 @@ Try to keep the changes focused. If you submit a large amount of work in all in 
 
 #### 4. Submit a [pull request](https://help.github.com/articles/about-pull-requests/)
 
-Please keep the title of your pull request short but informative - it will 
+Please keep the title of your pull request short but informative - it will
 appear in the [changelog](src/CHANGES.md).
 
 Use one of the following prefixes in the title of your pull request:
-  - `[ENH]` - enhancement of the specification that adds a new feature or 
+  - `[ENH]` - enhancement of the specification that adds a new feature or
     support for a new data type
   - `[FIX]` - fix of a typo or language clarification
-  - `[INFRA]` - changes to the infrastructure automating the specification 
+  - `[INFRA]` - changes to the infrastructure automating the specification
     release (for example building HTML docs etc.)
-  - `[MISC]` - everything else including changes to the file listing 
+  - `[MISC]` - everything else including changes to the file listing
     contributors
 
-If you are opening a pull request to obtain early feedback, but the changes 
-are not ready to be merged (a.k.a. Work in Progress pull request) please 
+If you are opening a pull request to obtain early feedback, but the changes
+are not ready to be merged (a.k.a. Work in Progress pull request) please
 use a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
 
 A member of the BIDS Specification team will review your changes to confirm that they can be merged into the main codebase.
@@ -120,15 +156,16 @@ You can update your [fork](https://help.github.com/articles/about-forks/) of the
 GitHub has a [nice introduction](https://help.github.com/articles/github-flow/) to the pull request workflow, but please [get in touch](#get-in-touch) if you have any questions.
 
 ## Example pull request
-<img align="right" src="https://i.imgur.com/s8yELfK.png" alt="Example-Contribution"/>
+<img align="right" src="https://i.imgur.com/s8yELfK.png" alt="Example-Contribution" width="800"/>
 
-<br>
+<br />
+<br />
 
-<br>
 
 ## How the decision to merge a pull request is made?
 
 The decision-making rules are outlined in [DECISION-MAKING.md](DECISION-MAKING.md).
+
 
 ## Recognizing contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ As a reminder, we expect that all contributions adhere to our [Code of Conduct](
 
 ## Contributing through GitHub
 
-[git](https://git-scm.com/) is a really useful tool for version control. [GitHub](https://github.com/) sits on top of git and supports collaborative and distributed working.
+[Git](https://git-scm.com/) is a really useful tool for version control. [GitHub](https://github.com/) sits on top of git and supports collaborative and distributed working.
 
 We know that it can be daunting to start using git and GitHub if you haven't worked with them in the past, but the BIDS Specification maintainers are here to help you figure out any of the jargon or confusing instructions you encounter!
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
 [![Build Status](https://travis-ci.com/bids-standard/bids-specification.svg?branch=master)](https://travis-ci.com/bids-standard/bids-specification)
 [![CircleCI](https://circleci.com/gh/bids-standard/bids-specification.svg?style=svg)](https://circleci.com/gh/bids-standard/bids-specification)
 
-![BIDS logo](BIDS_logo/BIDS_logo_black_transparent_background_crop.png)
 
-The Brain Imaging Data Structure (BIDS) is an emerging standard for the
+<img src="./BIDS_logo/BIDS_logo_black_transparent_background_crop.png" alt="bids-logo" width="600"/>
+
+The [Brain Imaging Data Structure (BIDS)](https://bids.neuroimaging.io) is an emerging standard for the
 organisation of neuroimaging data.
 
 In this repository, we develop the
 [BIDS specification](https://bids-specification.readthedocs.io/en/latest/).
 
-If you want to become a part of the BIDS community and contribute to the specification, please see our
-[contributing guidelines](./CONTRIBUTING.md).
+# Contributing to BIDS
+
+BIDS is a community-driven standard, and it depends on contributions from its members.
+We welcome new contributors, and we appreciate all contributions to the project!
+
+For a current list of our contributors, please see our [Contributors appendix](https://github.com/bids-standard/bids-specification/blob/master/src/99-appendices/01-contributors.md).
+
+When you're ready to get started, check out [our contributing guidelines](https://github.com/bids-standard/bids-specification/blob/master/CONTRIBUTING.md).
+
+Want to learn more about working with BIDS? Have a question, comment, or suggestion?
+Open or comment on one of our [NeuroStars issues](https://neurostars.org/tags/bids)!
+
+We ask that all contributions to BIDS across all project-related spaces (including but not limited to:
+[GitHub](https://github.com/bids-standard),
+the [Google group](https://groups.google.com/forum/#!forum/bids-discussion), and newsletter emails),
+adhere to our [code of conduct](https://github.com/bids-standard/bids-specification/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ organisation of neuroimaging data.
 In this repository, we develop the
 [BIDS specification](https://bids-specification.readthedocs.io/en/latest/).
 
-Want to learn more about working with BIDS? Have a question, comment, or suggestion?
+**Want to learn more about working with BIDS? Have a question, comment, or suggestion?**
 Open or comment on one of our [NeuroStars issues](https://neurostars.org/tags/bids) or check out the [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit)!
 
 # Contributing to BIDS

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ organisation of neuroimaging data.
 In this repository, we develop the
 [BIDS specification](https://bids-specification.readthedocs.io/en/latest/).
 
+Want to learn more about working with BIDS? Have a question, comment, or suggestion?
+Open or comment on one of our [NeuroStars issues](https://neurostars.org/tags/bids) or check out the [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit)!
+
 # Contributing to BIDS
 
 BIDS is a community-driven standard, and it depends on contributions from its members.
@@ -18,9 +21,6 @@ We welcome new contributors, and we appreciate all contributions to the project!
 For a current list of our contributors, please see our [Contributors appendix](https://github.com/bids-standard/bids-specification/blob/master/src/99-appendices/01-contributors.md).
 
 When you're ready to get started, check out [our contributing guidelines](https://github.com/bids-standard/bids-specification/blob/master/CONTRIBUTING.md).
-
-Want to learn more about working with BIDS? Have a question, comment, or suggestion?
-Open or comment on one of our [NeuroStars issues](https://neurostars.org/tags/bids)!
 
 We ask that all contributions to BIDS across all project-related spaces (including but not limited to:
 [GitHub](https://github.com/bids-standard),


### PR DESCRIPTION
For consideration to update text in the README and CONTRIBUTING documents.

Related to #273, #275.

Pinging @franklin-feingold @sappelhoff @effigies based on previous conversations, but all feedback is welcome !

[Rendered README](https://github.com/bids-standard/bids-specification/blob/enh/contrib-pathways/README.md).
[Rendered CONTRIBUTING](https://github.com/bids-standard/bids-specification/blob/enh/contrib-pathways/CONTRIBUTING.md).