### PR TITLE
[FIX] 404 error link for fsl dtifit

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -385,7 +385,7 @@ dwi.nii file) and not the magnet’s coordinate system, which means that any
 rotations applied to dwi.nii also need to be applied to the corresponding bvec
 file.
 
-<sup>4</sup>[https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide?highlight=(dtifit)#DTIFIT](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide?highlight=(dtifit)#DTIFIT)
+<sup>4</sup>[https://web.archive.org/web/20181012012715/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#DTIFIT](https://web.archive.org/web/20181012012715/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#DTIFIT)
 
 bvec example:
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -385,7 +385,7 @@ dwi.nii file) and not the magnet’s coordinate system, which means that any
 rotations applied to dwi.nii also need to be applied to the corresponding bvec
 file.
 
-<sup>4</sup>[http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/fdt/fdt_dtifit.html](http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/fdt/fdt_dtifit.html)
+<sup>4</sup>[https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide?highlight=(dtifit)#DTIFIT](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide?highlight=(dtifit)#DTIFIT)
 
 bvec example:
 


### PR DESCRIPTION
In the Diffusion Imaging Data section of 04-modality-specific-files/01-magnetic-resonance-imaging-data.md

When refering to FSL for the bval/bvec file format, http://fsl.fmrib.ox.ac.uk/fsl/fsl4.0/fdt/fdt_dtifit.html return a 404 not found error

This section should probably now link to https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide?highlight=(dtifit)#DTIFIT