### PR TITLE
[ENH] Clarify requirements in Release Protocol

### DIFF
--- a/Release_Guideline.md
+++ b/Release_Guideline.md
@@ -4,7 +4,7 @@ This document captures guidelines to follow when considering a new release of th
 
 ## Background
 BIDS has generally followed a semantic versioning (semver) approach.
-The canonical semver text can be found at [https://semver.org/](https://semver.org/), and an adaptation to documents can be found at [https://semverdoc.org/](https://semver.org/).
+The canonical semver text can be found at https://semver.org/, and an adaptation to documents can be found at https://semverdoc.org/.
 A specification falls somewhere between these two, as documentation does not require
 backwards compatibility, while software has notions of bugs and features which do not
 map to the reasons for updating a specification.

--- a/Release_Protocol.md
+++ b/Release_Protocol.md
@@ -14,9 +14,11 @@ $ git remote get-url upstream
 git@github.com:bids-standard/bids-specification.git
 ```
 
-If you do not, add it with:
+If you do not, clone the Master branch of the BIDS-specification and add it to `upstream` with:
 
 ```Shell
+$ git clone https://github.com/bids-standard/bids-specification.git
+$ cd bids-specification
 $ git remote add upstream git@github.com:bids-standard/bids-specification.git
 ```
 


### PR DESCRIPTION
Added a git clone command. This was found when opening https://github.com/bids-standard/bids-specification/pull/291 . This command was needed to complete the rest of the procedure when starting from a clean directory