### PR TITLE
[ENH] Storing basic provenance on JSON sidecars of derivatives

### DIFF
--- a/src/05-derivatives/02-common-data-types.md
+++ b/src/05-derivatives/02-common-data-types.md
@@ -62,9 +62,19 @@ makes them invalid (e.g., if a source 4D image is averaged to create a single
 static volume, a SamplingFrequency property would no longer be relevant). In
 addition, all processed files include the following metadata JSON fields:
 
-| **Key name**  | **Description**                                                                                 |
-| ------------- | ----------------------------------------------------------------------------------------------- |
-| SkullStripped | REQUIRED. Boolean. Whether the volume was skull stripped (non-brain voxels set to zero) or not. |
+| **Key name**                           | **Description**                                                                                                                                   |
+| ---------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SkullStripped                          | REQUIRED. Boolean. Whether the volume was skull stripped (non-brain voxels set to zero) or not.                                                   |
+| Denoising                              | OPTIONAL. String. Denoising method                                                                                                                |
+| GibbsRingingCorrection                 | OPTIONAL. Boolean. Removal of Gibbs ringing artifacts                                                                                             |
+| MotionCorrection                       | OPTIONAL. String. Motion correction; allowed values: `none`, `volume`, `slice`                                                                    |
+| EddyCurrentCorrection                  | OPTIONAL. String. Eddy current distortion correction; reserved values: `none`, `linear`, `quadratic`, `cubic`                                     |
+| IntensityNormalizationMethod           | OPTIONAL. String. Method (if any) used for intensity normalization                                                                                |
+| SusceptibilityDistortionEstimation     | OPTIONAL. String. Method (if any) used for estimation of the B0 inhomogeneity field; reserved values: `multiecho`, `phaseencode`, `registration`  |
+| SusceptibilityDistortionCorrection     | OPTIONAL. String. Correction for geometric distortions arising from B0 magnetic field inhomogeneity; reserved values: `none`, `static`, `dynamic` |
+| GradientNonLinearityGeometryCorrection | OPTIONAL. Boolean. Correction for geometric distortions arising from non-linearity of gradients                                                   |
+| BiasFieldCorrectionMethod              | OPTIONAL. String. Method (if any) used for correction of B1 RF field inhomogeneity                                                                |
+
 
 ## Masks
 

--- a/src/05-derivatives/02-common-data-types.md
+++ b/src/05-derivatives/02-common-data-types.md
@@ -75,7 +75,6 @@ addition, all processed files include the following metadata JSON fields:
 | GradientNonLinearityGeometryCorrection | OPTIONAL. Boolean. Correction for geometric distortions arising from non-linearity of gradients                                                   |
 | BiasFieldCorrectionMethod              | OPTIONAL. String. Method (if any) used for correction of B1 RF field inhomogeneity                                                                |
 
-
 ## Masks
 
 Template:


### PR DESCRIPTION
## Summary

In the context of BEP 016 we found ourselves prescribing what metadata fields should/could be included within derivatives. We then realized that some of them would easily extend to other _Imaging derivatives_ (see #310), and also tapped on the quite controversial `SkullStripped` metadata field.

## Proposal

Since BIDS has always been reluctant to include much provenance information, this PR proposes to make all these metadata fields OPTIONAL, and provides some suggestions for naming.

## Original Content of this PR
Mapped from @Lestropie's bids-standard/bids-bep016#5
Closes bids-standard/bids-bep016#2

I have removed some keys that I believe should remain in BEP16 for being
applicable to dwi only.

I have also changed _FieldInhomogeneity*_ with
_SusceptibilityDistortion*_ since I think the latter will be more
familiar to a wider audience.

EDIT: fields that remained in BEP16 are - `EddyCurrentCorrection`, `GradientNonLinearityQSpaceCorrection`, `SliceDropoutDetection`, `SliceDropoutReplacement`