### PR TITLE
[INFRA] Link to doc builds in CI checks

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/home/circleci/project/site/01-introduction.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build_docs:
     docker:
       - image: circleci/python:3.6.6
     steps:
@@ -143,10 +143,10 @@ workflows:
   version: 2
   search_build:
     jobs:
-      - build
+      - build_docs
       - linkchecker:
           requires:
-            - build
+            - build_docs
       - github-changelog-generator:
           filters:
                branches:


### PR DESCRIPTION
This PR introduces a quick link to the specification when a PR is made. To enable this, we would have to install this app: https://github.com/larsoner/circleci-artifacts-redirector. It was developed by @larsoner from the MNE team. If people agree, I think it can really help in reviewing PRs here.