### PR TITLE
[FIX] Add SoftwareFilters to EEG sidecar example

### DIFF
--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -163,6 +163,12 @@ Example:
   "EEGPlacementScheme":"10 percent system",
   "EEGReference":"single electrode placed on FCz",
   "EEGGround":"placed on AFz",
+  "SoftwareFilters":{
+    "Anti-aliasing filter":{
+      "half-amplitude cutoff (Hz)": 500,
+      "Roll-off": "6dB/Octave"
+    }
+  },
   "HardwareFilters":{
     "ADC's decimation filter (hardware bandwidth limit)":{
       "-3dB cutoff point (Hz)":480,


### PR DESCRIPTION
Related to issue #321. Closes #321 

Just a small addition to make eeg json side car example a valid one according to the specs.