### PR TITLE
[MISC] add information about continuous integration checks to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,18 +1,23 @@
 --- PLEASE READ AND DELETE THE TEXT BELOW BEFORE OPENING THE PULL REQUEST ---
 
-- Please keep the title of your pull request short but informative - it will 
+- Please keep the title of your pull request (PR) short but informative - it will
   appear in the changelog
-- Please ensure your name is credited on our [Contributors appendix](https://github.com/bids-standard/bids-specification/blob/master/src/99-appendices/01-contributors.md). To add your name, please edit our [Contributors wiki](https://github.com/bids-standard/bids-specification/wiki/Contributors) and add your name with the type of contribution. For assistance, please contact @franklin-feingold or @sappelhoff.
-- Use one of the following prefixes in the title of your pull request:
-  - `[ENH]` - enhancement of the specification that adds a new feature or 
+- Please ensure your name is credited on our [Contributors appendix](https://github.com/bids-standard/bids-specification/blob/master/src/99-appendices/01-contributors.md).
+  To add your name, please edit our [Contributors wiki](https://github.com/bids-standard/bids-specification/wiki/Contributors) and add your name with the type of contribution.
+  For assistance, please contact @franklin-feingold or @sappelhoff.
+- Use one of the following prefixes in the title of your PR:
+  - `[ENH]` - enhancement of the specification that adds a new feature or
     support for a new data type
   - `[FIX]` - fix of a typo or language clarification
-  - `[INFRA]` - changes to the infrastructure automating the specification 
+  - `[INFRA]` - changes to the infrastructure automating the specification
     release (for example building HTML docs etc.)
-  - `[MISC]` - everything else including changes to the file listing 
+  - `[MISC]` - everything else including changes to the file listing
     contributors
-- If you are opening a pull request to obtain early feedback, but the changes 
-  are not ready to be merged (a.k.a. Work in Progress pull request) please 
-  use a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+- If you are opening a PR to obtain early feedback, but the changes
+  are not ready to be merged (a.k.a. Work in Progress PR) please
+  use a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+- After opening the PR, our continuous integration services will automatically check your contribution  for formatting errors and render a preview of the BIDS specification with your changes.
+  To see the checks and preview, scroll down and click on the "show all checks" link.
+  From the list, select the "Details" link of the `ci/circleci: build_docs artifact` check to see the preview of the BIDS specification.
 
 --- PLEASE READ AND DELETE THE TEXT ABOVE BEFORE OPENING THE PULL REQUEST ---


### PR DESCRIPTION
- each sentence on a new line
- use abbreviation "PR" instead of pull request, after first mention
- add new bullet point at the end with some details on how to check out previews etc.

closes #326 