### PR TITLE
[ENH] Clarify phenotypic and assessment data in new section

### DIFF
--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -98,20 +98,34 @@ sub-control02 12  F control
 sub-patient01 33  F patient
 ```
 
+## Phenotype files (questionnaires, etc.)
+
 If the dataset includes multiple sets of participant level measurements (for
 example responses from multiple questionnaires) they can be split into
-individual files separate from `participants.tsv`. Those measurements should be
-kept in phenotype/ folder and end with the `.tsv` extension. They can include
-arbitrary set of columns, but one of them has to be participant_id with matching
-`sub-<label>`. As with all other tabular data, those additional
-phenotypic information files can be accompanied by a JSON file describing the
-columns in detail (see [here](02-common-principles.md#tabular-files)).
-In addition to the column description, a
-section describing the measurement tool (as a whole) can be added under the name
-`MeasurementToolMetadata`. This section consists of two keys: `Description` - a
-free text description of the tool, and `TermURL` a link to an entity in an
-ontology corresponding to this tool. For example (content of
-phenotype/acds_adult.json):
+individual files separate from `participants.tsv`.
+
+Each of the measurement files MUST be kept in a `/phenotype` directory placed
+at the root of the BIDS dataset. Furthermore each of the measurement files
+MUST end with the `.tsv` extension. The file name of the measurement files can
+be chosen to reflect the contents of the files. For example, the "Adult ADHD
+Clinical Diagnostic Scale" could be saved in a file called: `acds_adult.tsv`.
+
+The files can include an arbitrary set of columns, but one of them MUST be
+`participant_id` and the entries of that column MUST be matches to the subjects
+in the BIDS dataset and `participants.tsv` file.
+
+As with all other tabular data, the additional phenotypic information files
+MUST be accompanied by a JSON file describing the columns in detail
+(see [here](02-common-principles.md#tabular-files)).
+In addition to the column description, a section describing the measurement tool
+(as a whole) can be added under the name `MeasurementToolMetadata`.
+This section consists of two keys:
+
+  - `Description`: A free text description of the measurement tool
+  - `TermURL`: A link to an entity in an ontology corresponding to this tool.
+
+As an example, consider the contents of a file called
+`phenotype/acds_adult.json`:
 
 ```JSON
 {
@@ -143,7 +157,7 @@ columns.
 In addition to the keys available to describe columns in all tabular files
 (`LongName`, `Description`, `Levels`, `Units`, and `TermURL`) the
 `participants.json` file as well as phenotypic files can also include column
-descriptions with `Derivative` field that, when set to true, indicates that
+descriptions with a `Derivative` field that, when set to true, indicates that
 values in the corresponding column is a transformation of values from other
 columns (for example a summary score based on a subset of items in a
 questionnaire).

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -98,7 +98,7 @@ sub-control02 12  F control
 sub-patient01 33  F patient
 ```
 
-## Phenotype files (questionnaires, etc.)
+## Phenotypic and assessment data
 
 If the dataset includes multiple sets of participant level measurements (for
 example responses from multiple questionnaires) they can be split into

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -105,20 +105,20 @@ example responses from multiple questionnaires) they can be split into
 individual files separate from `participants.tsv`.
 
 Each of the measurement files MUST be kept in a `/phenotype` directory placed
-at the root of the BIDS dataset. Furthermore each of the measurement files
-MUST end with the `.tsv` extension. The file name of the measurement files can
-be chosen to reflect the contents of the files. For example, the "Adult ADHD
-Clinical Diagnostic Scale" could be saved in a file called: `acds_adult.tsv`.
+at the root of the BIDS dataset and MUST end with the `.tsv` extension.
+File names SHOULD be chosen to reflect the contents of the file.
+For example, the "Adult ADHD Clinical Diagnostic Scale" could be saved in a file
+called `/phenotype/acds_adult.tsv`.
 
 The files can include an arbitrary set of columns, but one of them MUST be
-`participant_id` and the entries of that column MUST be matches to the subjects
+`participant_id` and the entries of that column MUST correspond to the subjects
 in the BIDS dataset and `participants.tsv` file.
 
 As with all other tabular data, the additional phenotypic information files
-MUST be accompanied by a JSON file describing the columns in detail
-(see [here](02-common-principles.md#tabular-files)).
+MAY be accompanied by a JSON file describing the columns in detail
+(see [Tabular files](02-common-principles.md#tabular-files)).
 In addition to the column description, a section describing the measurement tool
-(as a whole) can be added under the name `MeasurementToolMetadata`.
+(as a whole) MAY be added under the name `MeasurementToolMetadata`.
 This section consists of two keys:
 
   - `Description`: A free text description of the measurement tool


### PR DESCRIPTION
closes #280 

- make "phenotype" data its own section instead of a subsection of "participants"
- clarify WHERE to place the file, and how to name them
- be more consistent with using MUST, SHOULD, ...