### PR TITLE
[MISC] Move the PR template to a separate folder and improve contents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
 --- PLEASE READ AND DELETE THE TEXT BELOW BEFORE OPENING THE PULL REQUEST ---
 
+See the [CONTRIBUTING](https://github.com/bids-standard/bids-specification/blob/master/CONTRIBUTING.md) guide. Specifically:
+
 - Please keep the title of your pull request (PR) short but informative - it will
-  appear in the changelog
+  appear in the changelog.
 - Please ensure your name is credited on our [Contributors appendix](https://github.com/bids-standard/bids-specification/blob/master/src/99-appendices/01-contributors.md).
   To add your name, please edit our [Contributors wiki](https://github.com/bids-standard/bids-specification/wiki/Contributors) and add your name with the type of contribution.
   For assistance, please contact @franklin-feingold or @sappelhoff.
@@ -15,9 +17,9 @@
     contributors
 - If you are opening a PR to obtain early feedback, but the changes
   are not ready to be merged (a.k.a. Work in Progress PR) please
-  use a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+  use a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
 - After opening the PR, our continuous integration services will automatically check your contribution  for formatting errors and render a preview of the BIDS specification with your changes.
-  To see the checks and preview, scroll down and click on the "show all checks" link.
-  From the list, select the "Details" link of the `ci/circleci: build_docs artifact` check to see the preview of the BIDS specification.
+  To see the checks and preview, scroll down and click on the `show all checks` link.
+  From the list, select the `Details` link of the `ci/circleci: build_docs artifact` check to see the preview of the BIDS specification.
 
 --- PLEASE READ AND DELETE THE TEXT ABOVE BEFORE OPENING THE PULL REQUEST ---


### PR DESCRIPTION
Move the PR template to a separate folder and use HTML syntax.

The first action helps in reducing clutter in the root folder, and helps
identifying more clearly the GitHub-related files.

The HMTL syntax transition using HTML comments allows the PR template
text not to be part of PR message, and saves the user the task of
deleting it while being still clearly visible when opening a PR.

Minor syntax enhancements.