### PR TITLE
FIX: Clarify channels.tsv is RECOMMENDED consistently across ephys

### DIFF
--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -181,9 +181,11 @@ sub-<label>/
 ```
 
 This file is RECOMMENDED as it provides easily searchable information across
-MEG-BIDS datasets for e.g., general curation, response to queries or batch
-analysis. To avoid confusion, the channels SHOULD be listed in the order they
-appear in the MEG data file. Missing values MUST be indicated with `n/a`.
+BIDS datasets for e.g., general curation, response to queries or batch
+analysis.
+To avoid confusion, the channels SHOULD be listed in the order they
+appear in the MEG data file.
+Missing values MUST be indicated with `n/a`.
 
 The columns of the Channels description table stored in `*_channels.tsv` are:
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -199,13 +199,16 @@ sub-<label>/
         [sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_channels.tsv]
 ```
 
-Although this information can often be extracted from the EEG recording,
-listing it in a simple `.tsv` document makes it easy to browse or search. The
-required columns are channel `name`, `type` and `units` in this specific order.
-Channel names should furthermore appear in the table in the same order they do
-in the EEG data file. Any number of additional columns may be provided to
-provide additional information about the channels. Note that electrode
-positions should not be added to this file, but to [`*_electrodes.tsv`](./03-electroencephalography.md#electrodes-description-_electrodestsv).
+This file is RECOMMENDED as it provides easily searchable information across
+BIDS datasets for e.g., general curation, response to queries or batch
+analysis.
+The required columns are channel `name`, `type` and `units` in this specific
+order.
+To avoid confusion, the channels SHOULD be listed in the order they
+appear in the EEG data file.
+Any number of additional columns may be added to provide additional information
+about the channels.
+Note that electrode positions SHOULD NOT be added to this file, but to [`*_electrodes.tsv`](./03-electroencephalography.md#electrodes-description-_electrodestsv).
 
 The columns of the Channels description table stored in `*_channels.tsv` are:
 

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -222,7 +222,7 @@ points on the tissue).
 Although this information can often be extracted from the iEEG recording,
 listing it in a simple `.tsv` document makes it easy to browse or search (e.g.,
 searching for recordings with a sampling frequency of >=1000 Hz).
-Hence, the Channels file is RECOMMENDED.
+Hence, the channels.tsv is RECOMMENDED.
 The two required columns are channel `name` and `type`.
 Channels SHOULD appear in the table in the same order they do in the iEEG data
 file.

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -66,7 +66,7 @@ in the sidecar JSON file. Other relevant files MAY be included alongside the
 original iEEG data in the [`/sourcedata` directory](../02-common-principles.md#source-vs-raw-vs-derived-data).
 
 Note the RecordingType, which depends on whether the data stream on disk is interrupted or not. Continuous data is by definition 1 segment without interruption. Epoched data consists of multiple segments that all have the same length (e.g., corresponding to trials) and that have gaps in between. Discontinuous data consists of multiple segments of different length, for example due to a pause in the acquisition.
- 
+
 ### Terminology: Electrodes vs. Channels
 
 For proper documentation of iEEG recording metadata it is important to
@@ -218,13 +218,17 @@ sub-<label>/
 
 A channel represents one time series recorded with the recording system (for
 example, there can be a bipolar channel, recorded from two electrodes or contact
-points on the tissue). Although this information can often be extracted from the
-iEEG recording, listing it in a simple `.tsv` document makes it easy to browse
-or search (e.g., searching for recordings with a sampling frequency of >=1000
-Hz). The two required columns are channel name and type. Channels should appear
-in the table in the same order they do in the iEEG data file. Any number of
-additional columns may be provided to provide additional information about the
-channels. Note that electrode positions should not be added to this file but to
+points on the tissue).
+Although this information can often be extracted from the iEEG recording,
+listing it in a simple `.tsv` document makes it easy to browse or search (e.g.,
+searching for recordings with a sampling frequency of >=1000 Hz).
+Hence, the Channels file is RECOMMENDED.
+The two required columns are channel `name` and `type`.
+Channels SHOULD appear in the table in the same order they do in the iEEG data
+file.
+Any number of additional columns may be provided to provide additional
+information about the channels.
+Note that electrode positions SHOULD NOT be added to this file but to
 `*_electrodes.tsv`.
 
 The columns of the Channels description table stored in \*\_channels.tsv are:


### PR DESCRIPTION
closes #344 

following the discussion in #344 this is a proposal to:

- clarify the language (make it RECOMMENDED/SHOULD be present) in EEG and iEEG specs
- make this consistently the same across EEG, MEG, iEEG

I think most of us agree that a more strict "MUST" would be more adequate ... but it would break several existing datasets.

This PR can be merged as a backward-compatible, initial improvement, until we finished discussion on whether we should elevate the SHOULD to a MUST.

