### PR TITLE
FIX: Refer to BIDS consistently, instead of "<Modality>-BIDS"

### DIFF
--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -23,9 +23,10 @@ sub-<label>/
 ```
 
 Unprocessed MEG data MUST be stored in the native file format of the MEG
-instrument with which the data was collected. With MEG-BIDS, we wish to promote
-the adoption of good practices in the management of scientific data. Hence, the
-emphasis of MEG-BIDS is not to impose a new, generic data format for the
+instrument with which the data was collected.
+With the MEG specification of BIDS, we wish to promote the adoption of good
+practices in the management of scientific data.
+Hence, the emphasis is not to impose a new, generic data format for the
 modality, but rather to standardize the way data is stored in repositories.
 Further, there is currently no widely accepted standard file format for MEG, but
 major software applications, including free and open-source solutions for MEG

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -61,8 +61,8 @@ file.
 sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_meg.fif
 ```
 
-Note that we do not provide specific specifications for cross-talk and
-fine-calibration matrix files in the present MEG-BIDS version.
+Note that we do not provide specifications for cross-talk and
+fine-calibration matrix files in the current version of BIDS.
 
 Example:
 


### PR DESCRIPTION
closes #365 

As it seems, there were only few instances of <modality>-BIDS left.

I searched the entire repo for:

- EEG-BIDS, BIDS-EEG
- MEG-BIDS, BIDS-MEG
- iEEG-BIDS, BIDS-iEEG

and corrected those I found to just be BIDS.