### PR TITLE
[FIX] divide readme into 3 parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ organisation of neuroimaging data.
 In this repository, we develop the
 [BIDS specification](https://bids-specification.readthedocs.io/en/latest/).
 
-# Using BIDS
+# Formatting your data with BIDS
 
 To organize your data in BIDS, all you need is neuro data, a computer, and the
 [BIDS specification](https://bids-specification.readthedocs.io/en/stable/).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ In this repository, we develop the
 To organize your data in BIDS, all you need is neuro data, a computer, and the
 [BIDS specification](https://bids-specification.readthedocs.io/en/stable/).
 
+BIDS currently supports MRI, MEG, EEG, iEEG, behavioral, and phsyiological data
+and more modalities are being added continuously (see here for
+[work in progress modalities](https://bids-specification.readthedocs.io/en/stable/06-extensions.html#bids-extension-proposals)).
+
 As a dataset curator, the GitHub repository and all files therein can be safely ignored
 to focus on the rendered content instead (see link above).
 The specification is provided in the form of a webpage, built using

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ organisation of neuroimaging data.
 In this repository, we develop the
 [BIDS specification](https://bids-specification.readthedocs.io/en/latest/).
 
-# Formatting your data with BIDS
+# When to use BIDS
 
 To organize your data in BIDS, all you need is neuro data, a computer, and the
 [BIDS specification](https://bids-specification.readthedocs.io/en/stable/).
@@ -20,12 +20,12 @@ BIDS currently supports MRI, MEG, EEG, iEEG, behavioral, and physiological data
 and more modalities are being added continuously (see here for
 [work in progress modalities](https://bids-specification.readthedocs.io/en/stable/06-extensions.html#bids-extension-proposals)).
 
-As a dataset curator, the GitHub repository and all files therein can be safely ignored
-to focus on [the rendered content](https://bids-specification.readthedocs.io/en/stable/).
+# Formatting your data with BIDS
+
+As a dataset curator, the GitHub repository and all files therein can be safely ignored.
+Users should focus on [the rendered content](https://bids-specification.readthedocs.io/en/stable/).
 The specification is provided in the form of a webpage, built using
 [MkDocs](https://www.mkdocs.org/) and [Read the Docs](https://readthedocs.org/).
-
-# Getting started
 
 *Want to learn more about working with BIDS? Have a question, comment, or suggestion?*
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ In this repository, we develop the
 
 # Using BIDS
 
-To use BIDS, all you need is neuro data, a computer, and the
+To organize your data in BIDS, all you need is neuro data, a computer, and the
 [BIDS specification](https://bids-specification.readthedocs.io/en/stable/).
 
-As a user, the GitHub repository and all files therein can be safely ignored
+As a dataset curator, the GitHub repository and all files therein can be safely ignored
 to focus on the rendered content instead (see link above).
 The specification is provided in the form of a webpage, built using
 [MkDocs](https://www.mkdocs.org/) and [Read the Docs](https://readthedocs.org/).
 
 # Asking Questions
 
-If you have a question about BIDS, you have several options:
+*Want to learn more about working with BIDS? Have a question, comment, or suggestion?*
 
 1. Read some introductory material, most likely the very basic problems have already been addressed!
   - [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit) for tutorials, wikis, templates, ...

--- a/README.md
+++ b/README.md
@@ -11,8 +11,26 @@ organisation of neuroimaging data.
 In this repository, we develop the
 [BIDS specification](https://bids-specification.readthedocs.io/en/latest/).
 
-**Want to learn more about working with BIDS? Have a question, comment, or suggestion?**
-Open or comment on one of our [NeuroStars issues](https://neurostars.org/tags/bids) or check out the [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit)!
+# Using BIDS
+
+To use BIDS, all you need is neuro data, a computer, and the
+[BIDS specification](https://bids-specification.readthedocs.io/en/stable/).
+
+As a user, the GitHub repository and all files therein can be safely ignored
+to focus on the rendered content instead (see link above).
+The specification is provided in the form of a webpage, built using
+[MkDocs](https://www.mkdocs.org/) and [Read the Docs](https://readthedocs.org/).
+
+# Asking Questions
+
+If you have a question about BIDS, you have several options:
+
+1. Read some introductory material, most likely the very basic problems have already been addressed!
+  - [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit) for tutorials, wikis, templates, ...
+2. Post your question in one of several channels where BIDS members are active
+  - the [NeuroStars](https://neurostars.org/tags/bids) discourse forum, for technical questions
+  - the [Google group](https://groups.google.com/forum/#!forum/bids-discussion), for broader discussions surrounding BIDS
+  - the [specification repository issue page](https://github.com/bids-standard/bids-specification/issues), if you found inconsistencies, typos, or other issues with the BIDS specification itself
 
 # Contributing to BIDS
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ In this repository, we develop the
 To organize your data in BIDS, all you need is neuro data, a computer, and the
 [BIDS specification](https://bids-specification.readthedocs.io/en/stable/).
 
-BIDS currently supports MRI, MEG, EEG, iEEG, behavioral, and phsyiological data
+BIDS currently supports MRI, MEG, EEG, iEEG, behavioral, and physiological data
 and more modalities are being added continuously (see here for
 [work in progress modalities](https://bids-specification.readthedocs.io/en/stable/06-extensions.html#bids-extension-proposals)).
 
 As a dataset curator, the GitHub repository and all files therein can be safely ignored
-to focus on the rendered content instead (see link above).
+to focus on [the rendered content](https://bids-specification.readthedocs.io/en/stable/).
 The specification is provided in the form of a webpage, built using
 [MkDocs](https://www.mkdocs.org/) and [Read the Docs](https://readthedocs.org/).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The specification is provided in the form of a webpage, built using
 1. Read some introductory material, most likely the very basic problems have already been addressed!
   - [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit) for tutorials, wikis, templates, ...
 2. Post your question in one of several channels where BIDS members are active
-  - the [NeuroStars](https://neurostars.org/tags/bids) discourse forum, for technical questions
+  - the [NeuroStars](https://neurostars.org/tags/bids) discourse forum
   - the [Google group](https://groups.google.com/forum/#!forum/bids-discussion), for broader discussions surrounding BIDS
   - the [specification repository issue page](https://github.com/bids-standard/bids-specification/issues), if you found inconsistencies, typos, or other issues with the BIDS specification itself
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ to focus on the rendered content instead (see link above).
 The specification is provided in the form of a webpage, built using
 [MkDocs](https://www.mkdocs.org/) and [Read the Docs](https://readthedocs.org/).
 
-# Asking Questions
+# Getting started
 
 *Want to learn more about working with BIDS? Have a question, comment, or suggestion?*
 


### PR DESCRIPTION
This is an attempt to make the README of the specification repository a bit cleaner.

- structured according to what a potential visitor might want:
    - **using** bids
    - **asking questions**
    - **contributing** to BIDS

What do you think? What else should be addressed? 