### PR TITLE
[FIX] Fix typos and formatting

### DIFF
--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -199,16 +199,16 @@ below, that contains common tissue classes and can be used to map segmentations
 | Integer value | Description             | Abbreviation (label) |
 | ------------- | ----------------------- | -------------------- |
 | 0             | Background              | BG                   |
-| 1             | Grey Matter             | GM                   |
+| 1             | Gray Matter             | GM                   |
 | 2             | White Matter            | WM                   |
 | 3             | Cerebrospinal Fluid     | CSF                  |
-| 4             | Grey and White Matter   | GWM                  |
+| 4             | Gray and White Matter   | GWM                  |
 | 5             | Bone                    | B                    |
 | 6             | Soft Tissue             | ST                   |
 | 7             | Non-brain               | NB                   |
 | 8             | Lesion                  | L                    |
-| 9             | Cortical Grey Matter    | CGM                  |
-| 10            | Subcortical Grey Matter | SCGM                 |
+| 9             | Cortical Gray Matter    | CGM                  |
+| 10            | Subcortical Gray Matter | SCGM                 |
 | 11            | Brainstem               | BS                   |
 | 12            | Cerebellum              | CBM                  |
 
@@ -253,7 +253,7 @@ An example, custom dseg.tsv that defines three labels:
 
 ```Text
 index   name            abbr	color       mapping
-100     "Grey Matter"	GM      #ff53bb	    1
+100     "Gray Matter"	GM      #ff53bb	    1
 101     "White Matter"	WM      #2f8bbe	    2
 102     "Brainstem"     BS      #36de72	    11
 ```

--- a/src/05-derivatives/05-functional-derivatives.md
+++ b/src/05-derivatives/05-functional-derivatives.md
@@ -174,7 +174,7 @@ atlases or segmentation algorithms:
 | WhiteMatter    | Signal derived from white matter ROI.                                                  |
 | CSF            | Signal derived from cerebro-spinal fluid ROI.                                          |
 | Background     | Signal derived from background (out of brain) ROI.                                     |
-| GreyMatter     | Signal derived from grey matter ROI.                                                   |
+| GrayMatter     | Signal derived from gray matter ROI.                                                   |
 | Ventricles     | Signal derived from ventricles ROI.                                                    |
 | CircleOfWillis | Signal derived from circle of Willis ROI.                                              |
 | GlobalSignal   | Vector of mean values within the brain mask. Can be used for Global Signal Regression. |

--- a/src/05-derivatives/06-diffusion-derivatives.md
+++ b/src/05-derivatives/06-diffusion-derivatives.md
@@ -228,7 +228,7 @@ Contents of JSON file (using "`_tissue-WM`" as example):
         "ResponseFunctionZSH": [ [ 15335 0 0 0 0 0 ],
                                  [ 7688 -2766 597 -82 10 -5 ],
                                  [ 5258 -2592 1024 -270 48 -11 ],
-                                 [ 4226 -2193 1124 -436 119 -19 ] ]
+                                 [ 4226 -2193 1124 -436 119 -19 ] ],
         "SphericalHarmonicBasis": "MRtrix3",
         "NonNegativityConstraint": "hard"
     }
@@ -459,7 +459,7 @@ Example:
 {
     "TractographyClass": "global",
     "TractographyMethod": "UKF",
-    "Description": "UKF tracking where only short fibers were kept."
+    "Description": "UKF tracking where only short fibers were kept.",
     "Parameters": {
         "MaximumLength": 50.0
     }

--- a/src/05-derivatives/06-diffusion-derivatives.md
+++ b/src/05-derivatives/06-diffusion-derivatives.md
@@ -12,8 +12,8 @@ should be included in the pipeline documentation.
     sub-<participant_label>/
         dwi/
             <source_keywords>[_space-<space>][_desc-<label>]_dwi.nii[.gz]
-            <source_keywords>[_space-<space>][_desc-<label>]_dwi.bvals
-            <source_keywords>[_space-<space>][_desc-<label>]_dwi.bvecs
+            <source_keywords>[_space-<space>][_desc-<label>]_dwi.bval
+            <source_keywords>[_space-<space>][_desc-<label>]_dwi.bvec
             <source_keywords>[_space-<space>][_desc-<label>]_dwi.json
 ```
 


### PR DESCRIPTION
Hello,

I found very small typos/formatting issues. Also, Gray/Grey names were both present. I used US convention to harmonize this.

Best,
Alexandre