### PR TITLE
[FIX] Recommend SI units formatting to adhere to CMIXF-12

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -524,7 +524,7 @@ units, these non-standard prefixed units MUST be specified in the JSON file.
 See [Appendix V](99-appendices/05-units.md) for a list of standard units and
 prefixes. Note also that for the *formatting* of SI units, the
 [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention for
-encoding units is RECOMMENDED.
+encoding units is REQUIRED.
 
 For additional rules, see below:
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -529,7 +529,6 @@ More information about CMIXF can be found in [Appendix V](99-appendices/05-units
 but to provide some examples, CMIXF formatting of "micro volts" would be `uV`,
 and of "kilobecquerel per ml" would be `kBq/ml`.
 
-
 For additional rules, see below:
 
 -   Elapsed time SHOULD be expressed in seconds. Please note that some DICOM

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -553,7 +553,7 @@ Describing dates and timestamps:
 
 -   Dates can be shifted by a random number of days for privacy protection
     reasons.
-    To distinguish real dates from shifted dates always use year 1925
+    To distinguish real dates from shifted dates, always use year 1925
     or earlier when including shifted years.
     For longitudinal studies dates MUST be shifted by the same number of days
     within each subject to maintain the interval information.

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -447,7 +447,7 @@ Example:
   },
   "bmi": {
     "LongName": "Body mass index",
-    "Units": "kilograms per squared meters",
+    "Units": "kg/m^2",
     "TermURL": "http://purl.bioontology.org/ontology/SNOMEDCT/60621009"
   }
 }

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -525,9 +525,10 @@ See [Appendix V](99-appendices/05-units.md) for a list of standard units and
 prefixes.
 Note also that for the *formatting* of SI units, the [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12)
 convention for encoding units is REQUIRED.
-More information about CMIXF can be found in [Appendix V](99-appendices/05-units.md)
-but to provide some examples, CMIXF formatting of "micro volts" would be `uV`,
-and of "kilobecquerel per milliliter" would be `kBq/mL`.
+CMIXF provides a consistent system for all units and prefix symbols with only basic
+characters, avoiding symbols that can cause text encoding problems; for example the
+CMIXF formatting for "micro volts" is `uV`, "degrees Celsius" is `oC` and "Ohm" is `Ohm`. 
+See [Appendix V](99-appendices/05-units.md) for more information.
 
 For additional rules, see below:
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -290,7 +290,7 @@ within that specific series directory specifying the TR for that specific run.
 There is no notion of "unsetting" a key/value pair.
 Once a key/value pair is set in a given level in the dataset, lower down in
 the hierarchy that key/value pair will always have some assigned value.
-Files for a particular 
+Files for a particular
 participant can exist only at participant level directory, i.e
 `/dataset/sub-*[/ses-*]/sub-*_T1w.json`. Similarly, any file that is not
 specific to a participant is to be declared only at top level of dataset for eg:
@@ -423,13 +423,13 @@ dictionary matches a column name in the TSV file, then that field MUST contain a
 description of the corresponding column, using an object containing the following
 fields:
 
-| Field name  | Definition                                                                                                                        |
-| :---------- | :-------------------------------------------------------------------------------------------------------------------------------- |
-| LongName    | Long (unabbreviated) name of the column.                                                                                          |
-| Description | Description of the column.                                                                                                        |
-| Levels      | For categorical variables: a dictionary of possible values (keys) and their descriptions (values).                                |
-| Units       | Measurement units. SI units in CMIXF formatting are REQUIRED when possible (see [units section](./02-common-principles.md#units). |
-| TermURL     | URL pointing to a formal definition of this type of data in an ontology available on the web.                                     |
+| Field name  | Definition                                                                                                             |
+| :---------- | :--------------------------------------------------------------------------------------------------------------------- |
+| LongName    | Long (unabbreviated) name of the column.                                                                               |
+| Description | Description of the column.                                                                                             |
+| Levels      | For categorical variables: a dictionary of possible values (keys) and their descriptions (values).                     |
+| Units       | Measurement units. SI units in CMIXF formatting are RECOMMENDED (see [units section](./02-common-principles.md#units). |
+| TermURL     | URL pointing to a formal definition of this type of data in an ontology available on the web.                          |
 
 Example:
 
@@ -524,10 +524,10 @@ non-standard prefixed units MUST be specified in the JSON file.
 See [Appendix V](99-appendices/05-units.md) for a list of standard units and
 prefixes.
 Note also that for the *formatting* of SI units, the [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12)
-convention for encoding units is REQUIRED.
+convention for encoding units is RECOMMENDED.
 CMIXF provides a consistent system for all units and prefix symbols with only basic
 characters, avoiding symbols that can cause text encoding problems; for example the
-CMIXF formatting for "micro volts" is `uV`, "degrees Celsius" is `oC` and "Ohm" is `Ohm`. 
+CMIXF formatting for "micro volts" is `uV`, "degrees Celsius" is `oC` and "Ohm" is `Ohm`.
 See [Appendix V](99-appendices/05-units.md) for more information.
 
 For additional rules, see below:

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -513,18 +513,22 @@ label, but must be included in file names (similarly to other key names).
 ## Units
 
 All units SHOULD be specified as per [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units)
-(abbreviated
-as SI, from the French Système international (d'unités)) and can be SI units or
-[SI derived units](https://en.wikipedia.org/wiki/SI_derived_unit).
-In case there are valid reasons to deviate from SI units or SI
-derived units, the units MUST be specified in the sidecar JSON file. In case
-data is expressed in SI units or SI derived units, the units MAY be specified in
-the sidecar JSON file. In case non-standard prefixes are added to SI or non-SI
-units, these non-standard prefixed units MUST be specified in the JSON file.
+(abbreviated as SI, from the French Système international (d'unités)) and can
+be SI units or [SI derived units](https://en.wikipedia.org/wiki/SI_derived_unit).
+In case there are valid reasons to deviate from SI units or SI derived units,
+the units MUST be specified in the sidecar JSON file.
+In case data is expressed in SI units or SI derived units, the units MAY be
+specified in the sidecar JSON file.
+In case non-standard prefixes are added to SI or non-SI units, these
+non-standard prefixed units MUST be specified in the JSON file.
 See [Appendix V](99-appendices/05-units.md) for a list of standard units and
-prefixes. Note also that for the *formatting* of SI units, the
-[CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention for
-encoding units is REQUIRED.
+prefixes.
+Note also that for the *formatting* of SI units, the [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12)
+convention for encoding units is REQUIRED.
+More information about CMIXF can be found in [Appendix V](99-appendices/05-units.md)
+but to provide some examples, CMIXF formatting of "micro volts" would be `uV`,
+and of "kilobecquerel per ml" would be `kBq/ml`.
+
 
 For additional rules, see below:
 
@@ -537,17 +541,24 @@ For additional rules, see below:
 Describing dates and timestamps:
 
 -   Date time information MUST be expressed in the following format
-    `YYYY-MM-DDThh:mm:ss` (one of the
-    [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date-time formats). For
-    example: `2009-06-15T13:45:30`
+    `YYYY-MM-DDThh:mm:ss[.000000]` (year, month, day, hour (24h), minute,
+    second, and optionally fractional second).
+    This is equivalent to the RFC3339 "date-time" format, time zone is always
+    assumed as local time).
+    No specific precision is required for fractional seconds, but the precision
+    SHOULD be consistent across the dataset.
+    For example `2009-06-15T13:45:30`
 
--   Time stamp information MUST be expressed in the following format: `13:45:30`
+-   Time stamp information MUST be expressed in the following format:
+    `13:45:30[.000000]`
 
 -   Dates can be shifted by a random number of days for privacy protection
-    reasons. To distinguish real dates from shifted dates always use year 1925
-    or earlier when including shifted years. For longitudinal studies please
-    remember to shift dates within one subject by the same number of days to
-    maintain the interval information. Example: `1867-06-15T13:45:30`
+    reasons.
+    To distinguish real dates from shifted dates always use year 1925
+    or earlier when including shifted years.
+    For longitudinal studies dates MUST be shifted by the same number of days
+    within each subject to maintain the interval information.
+    For example: `1867-06-15T13:45:30`
 
 -   Age SHOULD be given as the number of years since birth at the time of
     scanning (or first scan in case of multi session datasets). Using higher

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -423,13 +423,13 @@ dictionary matches a column name in the TSV file, then that field MUST contain a
 description of the corresponding column, using an object containing the following
 fields:
 
-| Field name  | Definition                                                                                                                                                  |
-| :---------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| LongName    | Long (unabbreviated) name of the column.                                                                                                                    |
-| Description | Description of the column.                                                                                                                                  |
-| Levels      | For categorical variables: a dictionary of possible values (keys) and their descriptions (values).                                                          |
-| Units       | Measurement units. `[<prefix symbol>] <unit symbol>` format following the SI standard is RECOMMENDED (see [units section](./02-common-principles.md#units). |
-| TermURL     | URL pointing to a formal definition of this type of data in an ontology available on the web.                                                               |
+| Field name  | Definition                                                                                                                        |
+| :---------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| LongName    | Long (unabbreviated) name of the column.                                                                                          |
+| Description | Description of the column.                                                                                                        |
+| Levels      | For categorical variables: a dictionary of possible values (keys) and their descriptions (values).                                |
+| Units       | Measurement units. SI units in CMIXF formatting are REQUIRED when possible (see [units section](./02-common-principles.md#units). |
+| TermURL     | URL pointing to a formal definition of this type of data in an ontology available on the web.                                     |
 
 Example:
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -290,8 +290,7 @@ within that specific series directory specifying the TR for that specific run.
 There is no notion of "unsetting" a key/value pair.
 Once a key/value pair is set in a given level in the dataset, lower down in
 the hierarchy that key/value pair will always have some assigned value.
-Files for a particular
-participant can exist only at participant level directory, i.e
+Files for a particular participant can exist only at participant level directory, i.e
 `/dataset/sub-*[/ses-*]/sub-*_T1w.json`. Similarly, any file that is not
 specific to a participant is to be declared only at top level of dataset for eg:
 `task-sist_bold.json` must be placed under `/dataset/task-sist_bold.json`
@@ -423,13 +422,13 @@ dictionary matches a column name in the TSV file, then that field MUST contain a
 description of the corresponding column, using an object containing the following
 fields:
 
-| Field name  | Definition                                                                                                             |
-| :---------- | :--------------------------------------------------------------------------------------------------------------------- |
-| LongName    | Long (unabbreviated) name of the column.                                                                               |
-| Description | Description of the column.                                                                                             |
-| Levels      | For categorical variables: a dictionary of possible values (keys) and their descriptions (values).                     |
-| Units       | Measurement units. SI units in CMIXF formatting are RECOMMENDED (see [units section](./02-common-principles.md#units). |
-| TermURL     | URL pointing to a formal definition of this type of data in an ontology available on the web.                          |
+| Field name  | Definition                                                                                                      |
+| :---------- | :-------------------------------------------------------------------------------------------------------------- |
+| LongName    | Long (unabbreviated) name of the column.                                                                        |
+| Description | Description of the column.                                                                                      |
+| Levels      | For categorical variables: a dictionary of possible values (keys) and their descriptions (values).              |
+| Units       | Measurement units. SI units in CMIXF formatting are RECOMMENDED (see [Units](./02-common-principles.md#units)). |
+| TermURL     | URL pointing to a formal definition of this type of data in an ontology available on the web.                   |
 
 Example:
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -522,7 +522,9 @@ data is expressed in SI units or SI derived units, the units MAY be specified in
 the sidecar JSON file. In case non-standard prefixes are added to SI or non-SI
 units, these non-standard prefixed units MUST be specified in the JSON file.
 See [Appendix V](99-appendices/05-units.md) for a list of standard units and
-prefixes.
+prefixes. Note also that for the *formatting* of SI units, the
+[CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention for
+encoding units is RECOMMENDED.
 
 For additional rules, see below:
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -527,7 +527,7 @@ Note also that for the *formatting* of SI units, the [CMIXF-12](https://people.c
 convention for encoding units is REQUIRED.
 More information about CMIXF can be found in [Appendix V](99-appendices/05-units.md)
 but to provide some examples, CMIXF formatting of "micro volts" would be `uV`,
-and of "kilobecquerel per ml" would be `kBq/ml`.
+and of "kilobecquerel per milliliter" would be `kBq/mL`.
 
 For additional rules, see below:
 

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -336,8 +336,7 @@ imaging acquisition sequence (each run `.nii[.gz]` file) within one session.
 Each `.nii[.gz]` file should be described by at most one row.
 Relative paths to files should be used under a compulsory `filename` header.
 If acquisition time is included it should be under `acq_time` header.
-Datetime should be expressed as described in the
-[Units section](./02-common-principles.md#units).
+Datetime should be expressed as described in [Units](./02-common-principles.md#units).
 For anonymization purposes all dates within one subject should be shifted by a
 randomly chosen (but consistent across all runs etc.) number of days.
 This way relative timing would be preserved, but chances of identifying a

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -336,12 +336,8 @@ imaging acquisition sequence (each run `.nii[.gz]` file) within one session.
 Each `.nii[.gz]` file should be described by at most one row.
 Relative paths to files should be used under a compulsory `filename` header.
 If acquisition time is included it should be under `acq_time` header.
-Datetime should be expressed in the following format
-`2009-06-15T13:45:30[.000000]` (year, month, day, hour (24h), minute, second,
-and optionally fractional second; this is equivalent to the RFC3339 "date-time"
-format, time zone is always assumed as local time).
-No specific precision is required for fractional seconds, but the precision
-SHOULD be consistent across the dataset
+Datetime should be expressed as described in the
+[Units section](../02-common-principles.md#units).
 For anonymization purposes all dates within one subject should be shifted by a
 randomly chosen (but consistent across all runs etc.) number of days.
 This way relative timing would be preserved, but chances of identifying a

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -337,7 +337,7 @@ Each `.nii[.gz]` file should be described by at most one row.
 Relative paths to files should be used under a compulsory `filename` header.
 If acquisition time is included it should be under `acq_time` header.
 Datetime should be expressed as described in the
-[Units section](../02-common-principles.md#units).
+[Units section](./02-common-principles.md#units).
 For anonymization purposes all dates within one subject should be shifted by a
 randomly chosen (but consistent across all runs etc.) number of days.
 This way relative timing would be preserved, but chances of identifying a

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -537,8 +537,11 @@ sub-<label>/[ses-<label>/]
 
 In some cases (for example GE) the scanner software will output a precomputed
 fieldmap denoting the B0 inhomogeneities along with a magnitude image used for
-coregistration. In this case the sidecar JSON file needs to include the units of
-the fieldmap. The possible options are: `Hz`, `rad/s`, or `Tesla`. For example:
+coregistration.
+In this case the sidecar JSON file needs to include the units of the fieldmap.
+The possible options are: Hertz (`Hz`), Radians per second (`rad/s`), or Tesla
+(`T`).
+For example:
 
 ```JSON
 {

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -199,11 +199,11 @@ The columns of the Channels description table stored in `*_channels.tsv` are:
 
 MUST be present:
 
-| Column name | Definition                                                                                                                                                                              |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name        | REQUIRED. Channel name (e.g., MRT012, MEG023)                                                                                                                                           |
-| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                                     |
-| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [units section](../02-common-principles.md#units). |
+| Column name | Definition                                                                                                                                                                       |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name        | REQUIRED. Channel name (e.g., MRT012, MEG023)                                                                                                                                    |
+| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                              |
+| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [Units](../02-common-principles.md#units)). |
 
 SHOULD be present:
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -199,11 +199,11 @@ The columns of the Channels description table stored in `*_channels.tsv` are:
 
 MUST be present:
 
-| Column name | Definition                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name        | REQUIRED. Channel name (e.g., MRT012, MEG023)                                                                                                                                                                                                                                                                                                                                                                                    |
-| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                                                                                                                                                                                                                                                                              |
-| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., V for Volt, specified according to the [SI unit symbol](https://en.wikipedia.org/wiki/International_System_of_Units#Base_units) and possibly prefix symbol (e.g., mV, μV), or as a [derived SI unit](https://en.wikipedia.org/wiki/SI_derived_unit) (e.g., fT/cm). For guidelines for Units and Prefixes see [Appendix V](../99-appendices/05-units.md). |
+| Column name | Definition                                                                                                                                                                              |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name        | REQUIRED. Channel name (e.g., MRT012, MEG023)                                                                                                                                           |
+| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                                     |
+| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [units section](../02-common-principles.md#units). |
 
 SHOULD be present:
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -214,11 +214,11 @@ The columns of the Channels description table stored in `*_channels.tsv` are:
 
 MUST be present:
 
-| Column name | Definition                                                                                                                                                                              |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name        | REQUIRED. Channel name (e.g., FC1, Cz)                                                                                                                                                  |
-| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                                     |
-| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [units section](../02-common-principles.md#units). |
+| Column name | Definition                                                                                                                                                                       |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name        | REQUIRED. Channel name (e.g., FC1, Cz)                                                                                                                                           |
+| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                              |
+| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [Units](../02-common-principles.md#units)). |
 
 SHOULD be present:
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -214,11 +214,11 @@ The columns of the Channels description table stored in `*_channels.tsv` are:
 
 MUST be present:
 
-| Column name | Definition                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name        | REQUIRED. Channel name (e.g., FC1, Cz)                                                                                                                                                                                                                                                                                                                                                                                           |
-| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                                                                                                                                                                                                                                                                              |
-| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., V for Volt, specified according to the [SI unit symbol](https://en.wikipedia.org/wiki/International_System_of_Units#Base_units) and possibly prefix symbol (e.g., mV, μV), or as a [derived SI unit](https://en.wikipedia.org/wiki/SI_derived_unit) (e.g., fT/cm). For guidelines for Units and Prefixes see [Appendix V](../99-appendices/05-units.md). |
+| Column name | Definition                                                                                                                                                                              |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name        | REQUIRED. Channel name (e.g., FC1, Cz)                                                                                                                                                  |
+| type        | REQUIRED. Type of channel; MUST use the channel types listed below.                                                                                                                     |
+| units       | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [units section](../02-common-principles.md#units). |
 
 SHOULD be present:
 
@@ -263,10 +263,10 @@ Example:
 
 ```Text
 name     type   units   description                     status  status_description
-VEOG     VEOG   microV  n/a                             good    n/a
-FDI      EMG    microV  left first dorsal interosseous  good    n/a
-Cz       EEG    microV  n/a                             bad     high frequency noise
-UADC001  MISC   n/a     enevelope of audio signal       good    n/a
+VEOG     VEOG   uV      n/a                             good    n/a
+FDI      EMG    uV      left first dorsal interosseous  good    n/a
+Cz       EEG    uV      n/a                             bad     high frequency noise
+UADC001  MISC   n/a     envelope of audio signal        good    n/a
 ```
 
 ## Electrodes description (`*_electrodes.tsv`)
@@ -301,8 +301,8 @@ SHOULD be present:
 | Column name | Definition                                                                  |
 | ------------------------------| ------------------------------------------------------------------------------- |
 | type        | RECOMMENDED. Type of the electrode (e.g., cup, ring, clip-on, wire, needle) |
-| material    | RECOMMENDED. Material of the electrode, e.g., Tin, Ag/AgCl, Gold            |
-| impedance   | RECOMMENDED. Impedance of the electrode in kOhm                             |
+| material    | RECOMMENDED. Material of the electrode  (e.g., Tin, Ag/AgCl, Gold)          |
+| impedance   | RECOMMENDED. Impedance of the electrode, units MUST be in `kOhm`.           |
 
 Example:
 
@@ -376,7 +376,7 @@ Fields relating to the EEG electrode positions:
 | Keyword                        | Description                                                                                                                                                            |
 | --------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | EEGCoordinateSystem            | REQUIRED. Refers to the coordinate system in which the EEG electrode positions are to be interpreted (see [Appendix VIII](../99-appendices/08-coordinate-systems.md)). |
-| EEGCoordinateUnits             | REQUIRED. Units in which the coordinates that are listed in the field `EEGCoordinateSystem` are represented (e.g., "mm", "cm").                                        |
+| EEGCoordinateUnits             | REQUIRED. Units in which the coordinates that are listed in the field `EEGCoordinateSystem` are represented. MUST be `m`, `cm`, or `mm`.                               |
 | EEGCoordinateSystemDescription | RECOMMENDED. Free-form text description of the coordinate system. May also include a link to a documentation page or paper describing the system in greater detail.    |
 
 Fields relating to the position of fiducials measured during an EEG session/run:
@@ -386,7 +386,7 @@ Fields relating to the position of fiducials measured during an EEG session/run:
 | FiducialsDescription                          | OPTIONAL. Free-form text description of how the fiducials such as vitamin-E capsules were placed relative to anatomical landmarks, and how the position of the fiducials were measured (e.g., both with Polhemus and with T1w MRI).      |
 | FiducialsCoordinates                          | RECOMMENDED. Key:value pairs of the labels and 3-D digitized position of anatomical landmarks, interpreted following the `FiducialsCoordinateSystem` (e.g., `{"NAS": [12.7,21.3,13.9], "LPA": [5.2,11.3,9.6], "RPA": [20.2,11.3,9.1]}`). |
 | FiducialsCoordinateSystem                     | RECOMMENDED. Refers to the coordinate space to which the landmarks positions are to be interpreted - preferably the same as the `EEGCoordinateSystem`.                                                                                   |
-| FiducialsCoordinateUnits                      | RECOMMENDED. Units in which the coordinates that are  listed in the field `AnatomicalLandmarkCoordinateSystem` are represented (e.g.,  "mm", "cm").                                                                                      |
+| FiducialsCoordinateUnits                      | RECOMMENDED. Units in which the coordinates that are  listed in the field `AnatomicalLandmarkCoordinateSystem` are represented. MUST be `m`, `cm`, or `mm`.                                                                              |
 | FiducialsCoordinateSystemDescription          | RECOMMENDED. Free-form text description of the coordinate system. May also include a link to a documentation page or paper describing the system in greater detail.                                                                      |
 
 Fields relating to the position of anatomical landmark measured during an EEG session/run:
@@ -395,7 +395,7 @@ Fields relating to the position of anatomical landmark measured during an EEG se
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | AnatomicalLandmarkCoordinates                 | RECOMMENDED. Key:value pairs of the labels and 3-D digitized position of anatomical landmarks, interpreted following the `AnatomicalLandmarkCoordinateSystem` (e.g., `{"NAS": [12.7,21.3,13.9], "LPA": [5.2,11.3,9.6], "RPA": [20.2,11.3,9.1]}`). |
 | AnatomicalLandmarkCoordinateSystem            | RECOMMENDED. Refers to the coordinate space to which the landmarks positions are to be interpreted - preferably the same as the `EEGCoordinateSystem`.                                                                                            |
-| AnatomicalLandmarkCoordinateUnits             | RECOMMENDED. Units in which the coordinates that are  listed in the field `AnatomicalLandmarkCoordinateSystem` are represented (e.g.,  "mm", "cm").                                                                                               |
+| AnatomicalLandmarkCoordinateUnits             | RECOMMENDED. Units in which the coordinates that are  listed in the field `AnatomicalLandmarkCoordinateSystem` are represented. MUST be `m`, `cm`, or `mm`.                                                                                       |
 | AnatomicalLandmarkCoordinateSystemDescription | RECOMMENDED. Free-form text description of the coordinate system. May also include a link to a documentation page or paper describing the system in greater detail.                                                                               |
 
 If the position of anatomical landmarks is measured using the same system or

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -342,7 +342,7 @@ MUST be present:
 | Column name  | Definition                                                                                                                                 |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | name         | REQUIRED. Name of the electrode contact point.                                                                                             |
-| x            | REQUIRED. X position. The positions of the center of each electrode in xyz space. Units are specified in `*_space-<label>_electrode.json`. |
+| x            | REQUIRED. X position. The positions of the center of each electrode in xyz space. Units are specified in `space-<label>_coordsystem.json`. |
 | y            | REQUIRED. Y position.                                                                                                                      |
 | z            | REQUIRED. Z position. If electrodes are in 2D space this should be a column of `n/a` values.                                               |
 | size         | REQUIRED. Surface area of the electrode, units MUST be in `mm^2`.                                                                          |

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -239,7 +239,7 @@ MUST be present:
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name         | REQUIRED. Label of the channel. The label must correspond to \_electrodes.tsv name and all ieeg type channels are required to have a position. The reference channel name MAY be provided in the reference column.    |
 | type         | REQUIRED. Type of channel, see below for adequate keywords in this field.                                                                                                                                             |
-| units        | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [units section](../02-common-principles.md#units).                               |
+| units        | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [Units](../02-common-principles.md#units)).                                      |
 | low_cutoff   | REQUIRED. Frequencies used for the low pass filter applied to the channel in Hz. If no low pass filter was applied, use `n/a`. Note that anti-alias is a low pass filter, specify its frequencies here if applicable. |
 | high_cutoff  | REQUIRED. Frequencies used for the high pass filter applied to the channel in Hz. If no high pass filter applied, use `n/a`.                                                                                          |
 

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -235,13 +235,13 @@ The columns of the Channels description table stored in \*\_channels.tsv are:
 
 MUST be present:
 
-| Column name  | Definition                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name         | REQUIRED. Label of the channel. The label must correspond to \_electrodes.tsv name and all ieeg type channels are required to have a position. The reference channel name MAY be provided in the reference column.                                                                                                                                                                                                               |
-| type         | REQUIRED. Type of channel, see below for adequate keywords in this field.                                                                                                                                                                                                                                                                                                                                                        |
-| units        | REQUIRED. Physical unit of the value represented in this channel, e.g., V for Volt, specified according to the [SI unit symbol](https://en.wikipedia.org/wiki/International_System_of_Units#Base_units) and possibly prefix symbol (e.g., mV, μV), or as a [derived SI unit](https://en.wikipedia.org/wiki/SI_derived_unit) (e.g., fT/cm). For guidelines for Units and Prefixes see [Appendix V](../99-appendices/05-units.md). |
-| low_cutoff   | REQUIRED. Frequencies used for the low pass filter applied to the channel in Hz. If no low pass filter was applied, use `n/a`. Note that anti-alias is a low pass filter, specify its frequencies here if applicable.                                                                                                                                                                                                            |
-| high_cutoff  | REQUIRED. Frequencies used for the high pass filter applied to the channel in Hz. If no high pass filter applied, use `n/a`.                                                                                                                                                                                                                                                                                                     |
+| Column name  | Definition                                                                                                                                                                                                            |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name         | REQUIRED. Label of the channel. The label must correspond to \_electrodes.tsv name and all ieeg type channels are required to have a position. The reference channel name MAY be provided in the reference column.    |
+| type         | REQUIRED. Type of channel, see below for adequate keywords in this field.                                                                                                                                             |
+| units        | REQUIRED. Physical unit of the value represented in this channel, e.g., `V` for Volt, or `fT/cm` for femto Tesla per centimeter (see [units section](../02-common-principles.md#units).                               |
+| low_cutoff   | REQUIRED. Frequencies used for the low pass filter applied to the channel in Hz. If no low pass filter was applied, use `n/a`. Note that anti-alias is a low pass filter, specify its frequencies here if applicable. |
+| high_cutoff  | REQUIRED. Frequencies used for the high pass filter applied to the channel in Hz. If no high pass filter applied, use `n/a`.                                                                                          |
 
 SHOULD be present:
 
@@ -259,10 +259,10 @@ SHOULD be present:
 
 ```Text
 name  type  units low_cutoff  high_cutoff status  status_description
-LT01  ECOG  μV    300         0.11        good    n/a
-LT02  ECOG  μV    300         0.11        bad     broken
-H01   SEEG  μV    300         0.11        bad     line_noise
-ECG1  ECG   μV    n/a         0.11        good    n/a
+LT01  ECOG  uV    300         0.11        good    n/a
+LT02  ECOG  uV    300         0.11        bad     broken
+H01   SEEG  uV    300         0.11        bad     line_noise
+ECG1  ECG   uV    n/a         0.11        good    n/a
 TR1   TRIG  n/a   n/a         n/a         good    n/a
 ```
 Restricted keyword list for field type in alphabetic order (shared with the MEG
@@ -339,13 +339,13 @@ listed below.
 
 MUST be present:                                                   
 
-| Column name  | Definition                                                                                                                                                                   |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name         | REQUIRED. Name of the electrode contact point.                                                                                                                               |
-| x            | REQUIRED. X position. The positions of the center of each electrode in xyz space. Units are in millimeters or pixels and are specified in \_\*space-<label>\_electrode.json. |
-| y            | REQUIRED. Y position.                                                                                                                                                        |
-| z            | REQUIRED. Z position. If electrodes are in 2D space this should be a column of n/a values.                                                                                   |
-| size         | REQUIRED. Surface area of the electrode, in mm^2.                                                                                                                            |
+| Column name  | Definition                                                                                                                                 |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| name         | REQUIRED. Name of the electrode contact point.                                                                                             |
+| x            | REQUIRED. X position. The positions of the center of each electrode in xyz space. Units are specified in `*_space-<label>_electrode.json`. |
+| y            | REQUIRED. Y position.                                                                                                                      |
+| z            | REQUIRED. Z position. If electrodes are in 2D space this should be a column of `n/a` values.                                               |
+| size         | REQUIRED. Surface area of the electrode, units MUST be in `mm^2`.                                                                          |
 
 SHOULD be present:
 
@@ -361,7 +361,7 @@ MAY be present:
 | Column name | Definition                                                                                                                                                |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | type        | OPTIONAL. Optional type of the electrode, e.g., cup, ring, clip-on, wire, needle, ...                                                                     |
-| impedance   | OPTIONAL. Impedance of the electrode in kOhm.                                                                                                             |
+| impedance   | OPTIONAL. Impedance of the electrode, units MUST be in `kOhm`.                                                                                            |
 | dimension   | OPTIONAL. Size of the group (grid/strip/probe) that this electrode belongs to. Must be of form `[AxB]` with the smallest dimension first (e.g., `[1x8]`). |
 
 Example:

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -39,6 +39,7 @@ Examples for CMIXF-12 (including the five unicode symbols mentioned above):
 1.  Different formatting of "micro Volts":
     1.  RECOMMENDED: `uV` or `µV`
     1.  NOT RECOMMENDED: `microV`, `µvolt`, `1e-6V`, etc.
+
 1.  Combinations of units:
     1.  RECOMMENDED: `V/us` for the [Slew rate](https://en.wikipedia.org/wiki/Slew_rate)
     1.  NOT RECOMMENDED: `volts per microsecond`

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -1,12 +1,22 @@
 # Appendix V: Units
 
 Following the International System of Units (SI, abbreviated from the French
-Système international (d'unités)). The ASCII representation is taken from
-[here](http://people.csail.mit.edu/jaffer/MIXF/CMIXF-12), where additional units
-may be found. The primary reason for choosing an ASCII representation, is that
-certain characters can have multiple unicode representations that look very
-similar. The BIDS specification will allow only the following unicode symbols for
-backwards compatibility: U+00B5 (µ) and U+00B0 (°) and U+2126 (Ω).
+Système international (d'unités)).
+
+The [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
+for encoding units is RECOMMENDED to achieve maximum portability and limited
+variability of representation.
+Earlier versions of the BIDS standard listed the following Unicode symbols, and
+these are still included for backwards compatibility:
+
+1. `U+00B5` (µ)
+
+1. `U+00B0` (°)
+
+1. `U+2126` (Ω).
+
+It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
+characters.
 
 | Unit name      | Unit symbol       | Quantity name                              |
 | -------------- | ----------------- | ------------------------------------------ |

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -6,8 +6,11 @@ the specification of units MUST follow the
 (SI, abbreviated from the French Système international (d'unités)).
 
 The [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
-for encoding units is RECOMMENDED to achieve maximum portability and limited
+for encoding units is REQUIRED to achieve maximum portability and limited
 variability of representation.
+In case that a CMIXF representation of SI units is not possible, you will have
+to declare your units as custom units and define them in accompanying JSON
+files, as described in the [units section](../02-common-principles.md#units).
 Earlier versions of the BIDS standard listed the following Unicode symbols, and
 these are still included for backwards compatibility:
 

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -9,11 +9,9 @@ variability of representation.
 Earlier versions of the BIDS standard listed the following Unicode symbols, and
 these are still included for backwards compatibility:
 
-1. `U+00B5` (µ)
-
-1. `U+00B0` (°)
-
-1. `U+2126` (Ω).
+1.  `U+00B5` (µ)
+1.  `U+00B0` (°)
+1.  `U+2126` (Ω).
 
 It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
 characters.

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -21,6 +21,10 @@ these are still included for backwards compatibility:
 It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
 characters.
 
+Please take care to not confuse the accepted unicode `U+00B5` (µ) with the
+unicode NOT accepted `U+03BC` (μ):
+They look equal in appearance but are different to the computer.
+
 Units MUST consist of the `unit symbol` with an optionally accompanying
 `prefix symbol` (see table below). Appropriate upper- or lower- casing MUST
 be applied as declared by CMIXF-12.

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -1,8 +1,8 @@
 # Appendix V: Units
 
-Following the International System of Units (SI, abbreviated from the French
-Système international (d'unités)).
-
+The specification of units MUST follow the
+[International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units)
+(SI, abbreviated from the French Système international (d'unités)).
 The [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
 for encoding units is RECOMMENDED to achieve maximum portability and limited
 variability of representation.

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -14,16 +14,17 @@ as custom units and defined in an accompanying JSON file, as described in the
 Earlier versions of the BIDS standard listed the following Unicode symbols, and
 these are still included for backwards compatibility:
 
-1.  [`U+00B5` (µ)](https://codepoints.net/U+00B5)
+1.  [`U+03BC` (μ)](https://codepoints.net/U+03BC) or [`U+00B5` (µ)](https://codepoints.net/U+00B5)
+1.  [`U+03A9` (Ω)](https://codepoints.net/U+03A9) or [`U+2126` (Ω)](https://codepoints.net/U+2126)
 1.  [`U+00B0` (°)](https://codepoints.net/U+00B0)
-1.  [`U+2126` (Ω)](https://codepoints.net/U+2126)
 
-It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
+Note that for the first two Unicode symbols in the list above, two characters
+are permissible for each, but the first character mentioned respectively is
+preferred as per Unicode rules (see the section on "Duplicated Characters"
+on page 11 in the [unicode report](https://www.unicode.org/reports/tr25/)).
+
+It is REQUIRED that units be CMIXF-12 compliant or among these five Unicode
 characters.
-Please take care not to confuse the accepted Unicode character
-[`U+00B5`](https://codepoints.net/U+00B5) (µ) with the disallowed Unicode
-character [`U+03BC`](https://codepoints.net/U+03BC) (μ):
-They look equal in appearance but are different to the computer.
 
 Units MUST consist of the `unit symbol` with an optionally accompanying
 `prefix symbol` (see table below). Appropriate upper- or lower- casing MUST
@@ -41,38 +42,38 @@ Examples:
 1.  `uV` or `µV` are permissible, but NOT: `microV`, `µvolt`, `1e-6V`, etc.
 1.  Combinations of units are allowed, e.g., `V/us` for the [Slew rate](https://en.wikipedia.org/wiki/Slew_rate)
 
-| Unit name      | Unit symbol       | Quantity name                              |
-| -------------- | ----------------- | ------------------------------------------ |
-| metre          | m                 | length                                     |
-| kilogram       | kg                | mass                                       |
-| litre (liter)  | L                 | volume                                     |
-| second         | s                 | time                                       |
-| ampere         | A                 | electric current                           |
-| kelvin         | K                 | thermodynamic temperature                  |
-| mole           | mol               | amount of substance                        |
-| candela        | cd                | luminous intensity                         |
-| radian         | rad               | angle                                      |
-| steradian      | sr                | solid angle                                |
-| hertz          | Hz                | frequency                                  |
-| newton         | N                 | force, weight                              |
-| pascal         | Pa                | pressure, stress                           |
-| joule          | J                 | energy, work, heat                         |
-| watt           | W                 | power, radiant flux                        |
-| coulomb        | C                 | electric charge or quantity of electricity |
-| volt           | V                 | voltage (electrical potential), emf        |
-| farad          | F                 | capacitance                                |
-| ohm            | Ohm or Ω (U+2126) | resistance, impedance, reactance           |
-| siemens        | S                 | electrical conductance                     |
-| weber          | Wb                | magnetic flux                              |
-| tesla          | T                 | magnetic flux density                      |
-| henry          | H                 | inductance                                 |
-| degree Celsius | oC or °C (U+00B0) | temperature relative to 273.15 K           |
-| lumen          | lm                | luminous flux                              |
-| lux            | lx                | illuminance                                |
-| becquerel      | Bq                | radioactivity (decays per unit time)       |
-| gray           | Gy                | absorbed dose (of ionizing radiation)      |
-| sievert        | Sv                | equivalent dose (of ionizing radiation)    |
-| katal          | kat               | catalytic activity                         |
+| Unit name      | Unit symbol | Quantity name                              |
+| -------------- | ----------- | ------------------------------------------ |
+| metre          | m           | length                                     |
+| kilogram       | kg          | mass                                       |
+| litre (liter)  | L           | volume                                     |
+| second         | s           | time                                       |
+| ampere         | A           | electric current                           |
+| kelvin         | K           | thermodynamic temperature                  |
+| mole           | mol         | amount of substance                        |
+| candela        | cd          | luminous intensity                         |
+| radian         | rad         | angle                                      |
+| steradian      | sr          | solid angle                                |
+| hertz          | Hz          | frequency                                  |
+| newton         | N           | force, weight                              |
+| pascal         | Pa          | pressure, stress                           |
+| joule          | J           | energy, work, heat                         |
+| watt           | W           | power, radiant flux                        |
+| coulomb        | C           | electric charge or quantity of electricity |
+| volt           | V           | voltage (electrical potential), emf        |
+| farad          | F           | capacitance                                |
+| ohm            | Ohm         | resistance, impedance, reactance           |
+| siemens        | S           | electrical conductance                     |
+| weber          | Wb          | magnetic flux                              |
+| tesla          | T           | magnetic flux density                      |
+| henry          | H           | inductance                                 |
+| degree Celsius | oC          | temperature relative to 273.15 K           |
+| lumen          | lm          | luminous flux                              |
+| lux            | lx          | illuminance                                |
+| becquerel      | Bq          | radioactivity (decays per unit time)       |
+| gray           | Gy          | absorbed dose (of ionizing radiation)      |
+| sievert        | Sv          | equivalent dose (of ionizing radiation)    |
+| katal          | kat         | catalytic activity                         |
 
 ## Prefixes
 
@@ -93,15 +94,15 @@ Examples:
 
 ### Submultiples
 
-| Prefix name                                 | Prefix symbol   | Factor           |
-| ------------------------------------------- | --------------- | ---------------- |
-| [deci](https://www.wikiwand.com/en/Deci-)   | d               | 10<sup>-1</sup>  |
-| [centi](https://www.wikiwand.com/en/Centi-) | c               | 10<sup>-2</sup>  |
-| [milli](https://www.wikiwand.com/en/Milli-) | m               | 10<sup>-3</sup>  |
-| [micro](https://www.wikiwand.com/en/Micro-) | u or µ (U+00B5) | 10<sup>-6</sup>  |
-| [nano](https://www.wikiwand.com/en/Nano-)   | n               | 10<sup>-9</sup>  |
-| [pico](https://www.wikiwand.com/en/Pico-)   | p               | 10<sup>-12</sup> |
-| [femto](https://www.wikiwand.com/en/Femto-) | f               | 10<sup>-15</sup> |
-| [atto](https://www.wikiwand.com/en/Atto-)   | a               | 10<sup>-18</sup> |
-| [zepto](https://www.wikiwand.com/en/Zepto-) | z               | 10<sup>-21</sup> |
-| [yocto](https://www.wikiwand.com/en/Yocto-) | y               | 10<sup>-24</sup> |
+| Prefix name                                 | Prefix symbol | Factor           |
+| ------------------------------------------- | ------------- | ---------------- |
+| [deci](https://www.wikiwand.com/en/Deci-)   | d             | 10<sup>-1</sup>  |
+| [centi](https://www.wikiwand.com/en/Centi-) | c             | 10<sup>-2</sup>  |
+| [milli](https://www.wikiwand.com/en/Milli-) | m             | 10<sup>-3</sup>  |
+| [micro](https://www.wikiwand.com/en/Micro-) | u             | 10<sup>-6</sup>  |
+| [nano](https://www.wikiwand.com/en/Nano-)   | n             | 10<sup>-9</sup>  |
+| [pico](https://www.wikiwand.com/en/Pico-)   | p             | 10<sup>-12</sup> |
+| [femto](https://www.wikiwand.com/en/Femto-) | f             | 10<sup>-15</sup> |
+| [atto](https://www.wikiwand.com/en/Atto-)   | a             | 10<sup>-18</sup> |
+| [zepto](https://www.wikiwand.com/en/Zepto-) | z             | 10<sup>-21</sup> |
+| [yocto](https://www.wikiwand.com/en/Yocto-) | y             | 10<sup>-24</sup> |

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -1,8 +1,10 @@
 # Appendix V: Units
 
-The specification of units MUST follow the
+As described in the [units section](../../02-common-principles.md#units),
+the specification of units MUST follow the
 [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units)
 (SI, abbreviated from the French Système international (d'unités)).
+
 The [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
 for encoding units is RECOMMENDED to achieve maximum portability and limited
 variability of representation.
@@ -15,6 +17,21 @@ these are still included for backwards compatibility:
 
 It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
 characters.
+
+Units MUST consist of the `unit symbol` with an optionally accompanying
+`prefix symbol` (see table below). Appropriate upper- or lower- casing MUST
+be applied as declared by CMIXF-12.
+
+For cases that are unspecified by this appendix, or the
+[units section](../../02-common-principles.md#units), the
+[CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
+applies.
+
+Examples:
+
+1.   `uV` or `µV` are permissible, but NOT: `microV`, `µvolt`, `1e-6V`, etc.
+1.   Combinations of units are allowed, e.g., `V/us` for the [Slew rate](https://en.wikipedia.org/wiki/Slew_rate)
+
 
 | Unit name      | Unit symbol       | Quantity name                              |
 | -------------- | ----------------- | ------------------------------------------ |

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -1,6 +1,6 @@
 # Appendix V: Units
 
-As described in the [units section](../../02-common-principles.md#units),
+As described in the [units section](../02-common-principles.md#units),
 the specification of units MUST follow the
 [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units)
 (SI, abbreviated from the French Système international (d'unités)).
@@ -23,15 +23,14 @@ Units MUST consist of the `unit symbol` with an optionally accompanying
 be applied as declared by CMIXF-12.
 
 For cases that are unspecified by this appendix, or the
-[units section](../../02-common-principles.md#units), the
+[units section](../02-common-principles.md#units), the
 [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
 applies.
 
 Examples:
 
-1.   `uV` or `µV` are permissible, but NOT: `microV`, `µvolt`, `1e-6V`, etc.
-1.   Combinations of units are allowed, e.g., `V/us` for the [Slew rate](https://en.wikipedia.org/wiki/Slew_rate)
-
+1.  `uV` or `µV` are permissible, but NOT: `microV`, `µvolt`, `1e-6V`, etc.
+1.  Combinations of units are allowed, e.g., `V/us` for the [Slew rate](https://en.wikipedia.org/wiki/Slew_rate)
 
 | Unit name      | Unit symbol       | Quantity name                              |
 | -------------- | ----------------- | ------------------------------------------ |

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -20,7 +20,6 @@ these are still included for backwards compatibility:
 
 It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
 characters.
-
 Please take care to not confuse the accepted unicode `U+00B5` (µ) with the
 unicode NOT accepted `U+03BC` (μ):
 They look equal in appearance but are different to the computer.
@@ -33,6 +32,8 @@ For cases that are unspecified by this appendix, or the
 [units section](../02-common-principles.md#units), the
 [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
 applies.
+You can use the [cmixf Python package](https://github.com/sensein/cmixf) to
+check whether your formatting is compliant.
 
 Examples:
 

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -1,14 +1,14 @@
 # Appendix V: Units
 
 As described in the [units section](../02-common-principles.md#units),
-the specification of units MUST follow the
+the specification of units SHOULD follow the
 [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units)
 (SI, abbreviated from the French Système international (d'unités)).
 
 The [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
-for encoding units is REQUIRED to achieve maximum portability and limited
+for encoding units is RECOMMENDED to achieve maximum portability and limited
 variability of representation.
-If a CMIXF-12 representation of a unit is not possible, the unit MUST be declared
+If a CMIXF-12 representation of a unit is not possible, the unit can be declared
 as custom units and defined in an accompanying JSON file, as described in the
 [units section](../02-common-principles.md#units).
 Earlier versions of the BIDS standard listed the following Unicode symbols, and
@@ -23,24 +23,27 @@ are permissible for each, but the first character mentioned respectively is
 preferred as per Unicode rules (see the section on "Duplicated Characters"
 on page 11 in the [unicode report](https://www.unicode.org/reports/tr25/)).
 
-It is REQUIRED that units be CMIXF-12 compliant or among these five Unicode
+It is RECOMMENDED that units be CMIXF-12 compliant or among these five Unicode
 characters.
+Please note the appropriate upper- or lower- casing when using CMIXF-12.
 
-Units MUST consist of the `unit symbol` with an optionally accompanying
-`prefix symbol` (see table below). Appropriate upper- or lower- casing MUST
-be applied as declared by CMIXF-12.
-
-For cases that are unspecified by this appendix, or the
-[units section](../02-common-principles.md#units), the
-[CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
+For cases that are unspecified by this appendix or the[units section](../02-common-principles.md#units),
+the [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
 applies.
+
 You can use the [cmixf Python package](https://github.com/sensein/cmixf) to
 check whether your formatting is compliant.
 
-Examples:
+Examples for CMIXF-12 (including the five unicode symbols mentioned above):
 
-1.  `uV` or `µV` are permissible, but NOT: `microV`, `µvolt`, `1e-6V`, etc.
-1.  Combinations of units are allowed, e.g., `V/us` for the [Slew rate](https://en.wikipedia.org/wiki/Slew_rate)
+1.  Different formatting of "micro Volts":
+    1.  RECOMMENDED: `uV` or `µV`
+    1.  NOT RECOMMENDED: `microV`, `µvolt`, `1e-6V`, etc.
+1.  Combinations of units:
+    1.  RECOMMENDED: `V/us` for the [Slew rate](https://en.wikipedia.org/wiki/Slew_rate)
+    1.  NOT RECOMMENDED: `volts per microsecond`
+
+## Unit table
 
 | Unit name      | Unit symbol | Quantity name                              |
 | -------------- | ----------- | ------------------------------------------ |

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -1,6 +1,6 @@
 # Appendix V: Units
 
-As described in the [units section](../02-common-principles.md#units),
+As described in the [Units](../02-common-principles.md#units),
 the specification of units SHOULD follow the
 [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units)
 (SI, abbreviated from the French Système international (d'unités)).
@@ -18,10 +18,10 @@ these are still included for backwards compatibility:
 1.  [`U+03A9` (Ω)](https://codepoints.net/U+03A9) or [`U+2126` (Ω)](https://codepoints.net/U+2126)
 1.  [`U+00B0` (°)](https://codepoints.net/U+00B0)
 
-Note that for the first two Unicode symbols in the list above, two characters
-are permissible for each, but the first character mentioned respectively is
-preferred as per Unicode rules (see the section on "Duplicated Characters"
-on page 11 in the [unicode report](https://www.unicode.org/reports/tr25/)).
+Note that for the first two entries in this list, two characters are permissible
+for each, but the first character in each entry is preferred, per Unicode rules
+(see the section on "Duplicated Characters" on page 11 in the
+[unicode report](https://www.unicode.org/reports/tr25/)).
 
 It is RECOMMENDED that units be CMIXF-12 compliant or among these five Unicode
 characters.

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -1,39 +1,44 @@
 # Appendix V: Units
 
-Following the [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units)
-(SI, abbreviated from the French Système international (d'unités))
+Following the International System of Units (SI, abbreviated from the French
+Système international (d'unités)). The ASCII representation is taken from
+[here](http://people.csail.mit.edu/jaffer/MIXF/CMIXF-12), where additional units
+may be found. The primary reason for choosing an ASCII representation, is that
+certain characters can have multiple unicode representations that look very
+similar. The BIDS specification will allow only the following unicode symbols for
+backwards compatibility: U+00B5 (µ) and U+00B0 (°) and U+2126 (Ω).
 
-| Unit name      | Unit symbol | Quantity name                              |
-| ------------------------- | ------------------------------ | ------------------------------------------------------------------ |
-| metre          | m           | length                                     |
-| kilogram       | kg          | mass                                       |
-| second         | s           | time                                       |
-| ampere         | A           | electric current                           |
-| kelvin         | K           | thermodynamic temperature                  |
-| mole           | mol         | amount of substance                        |
-| candela        | cd          | luminous intensity                         |
-| radian         | rad         | angle                                      |
-| steradian      | sr          | solid angle                                |
-| hertz          | Hz          | frequency                                  |
-| newton         | N           | force, weight                              |
-| pascal         | Pa          | pressure, stress                           |
-| joule          | J           | energy, work, heat                         |
-| watt           | W           | power, radiant flux                        |
-| coulomb        | C           | electric charge or quantity of electricity |
-| volt           | V           | voltage (electrical potential), emf        |
-| farad          | F           | capacitance                                |
-| ohm            | Ω           | resistance, impedance, reactance           |
-| siemens        | S           | electrical conductance                     |
-| weber          | Wb          | magnetic flux                              |
-| tesla          | T           | magnetic flux density                      |
-| henry          | H           | inductance                                 |
-| degree Celsius | °C          | temperature relative to 273.15 K           |
-| lumen          | lm          | luminous flux                              |
-| lux            | lx          | illuminance                                |
-| becquerel      | Bq          | radioactivity (decays per unit time)       |
-| gray           | Gy          | absorbed dose (of ionizing radiation)      |
-| sievert        | Sv          | equivalent dose (of ionizing radiation)    |
-| katal          | kat         | catalytic activity                         |
+| Unit name      | Unit symbol       | Quantity name                              |
+| -------------- | ----------------- | ------------------------------------------ |
+| metre          | m                 | length                                     |
+| kilogram       | kg                | mass                                       |
+| second         | s                 | time                                       |
+| ampere         | A                 | electric current                           |
+| kelvin         | K                 | thermodynamic temperature                  |
+| mole           | mol               | amount of substance                        |
+| candela        | cd                | luminous intensity                         |
+| radian         | rad               | angle                                      |
+| steradian      | sr                | solid angle                                |
+| hertz          | Hz                | frequency                                  |
+| newton         | N                 | force, weight                              |
+| pascal         | Pa                | pressure, stress                           |
+| joule          | J                 | energy, work, heat                         |
+| watt           | W                 | power, radiant flux                        |
+| coulomb        | C                 | electric charge or quantity of electricity |
+| volt           | V                 | voltage (electrical potential), emf        |
+| farad          | F                 | capacitance                                |
+| ohm            | Ohm or Ω (U+2126) | resistance, impedance, reactance           |
+| siemens        | S                 | electrical conductance                     |
+| weber          | Wb                | magnetic flux                              |
+| tesla          | T                 | magnetic flux density                      |
+| henry          | H                 | inductance                                 |
+| degree Celsius | oC or °C (U+00B0) | temperature relative to 273.15 K           |
+| lumen          | lm                | luminous flux                              |
+| lux            | lx                | illuminance                                |
+| becquerel      | Bq                | radioactivity (decays per unit time)       |
+| gray           | Gy                | absorbed dose (of ionizing radiation)      |
+| sievert        | Sv                | equivalent dose (of ionizing radiation)    |
+| katal          | kat               | catalytic activity                         |
 
 ## Prefixes
 
@@ -54,15 +59,15 @@ Following the [International System of Units](https://en.wikipedia.org/wiki/Inte
 
 ### Submultiples
 
-| Prefix name                                 | Prefix symbol | Factor           |
-| ------------------------------------------------------------------ | ---------------------- | ------------------------------ |
-| [deci](https://www.wikiwand.com/en/Deci-)   | d             | 10<sup>-1</sup>  |
-| [centi](https://www.wikiwand.com/en/Centi-) | c             | 10<sup>-2</sup>  |
-| [milli](https://www.wikiwand.com/en/Milli-) | m             | 10<sup>-3</sup>  |
-| [micro](https://www.wikiwand.com/en/Micro-) | µ             | 10<sup>-6</sup>  |
-| [nano](https://www.wikiwand.com/en/Nano-)   | n             | 10<sup>-9</sup>  |
-| [pico](https://www.wikiwand.com/en/Pico-)   | p             | 10<sup>-12</sup> |
-| [femto](https://www.wikiwand.com/en/Femto-) | f             | 10<sup>-15</sup> |
-| [atto](https://www.wikiwand.com/en/Atto-)   | a             | 10<sup>-18</sup> |
-| [zepto](https://www.wikiwand.com/en/Zepto-) | z             | 10<sup>-21</sup> |
-| [yocto](https://www.wikiwand.com/en/Yocto-) | y             | 10<sup>-24</sup> |
+| Prefix name                                 | Prefix symbol   | Factor           |
+| ------------------------------------------- | --------------- | ---------------- |
+| [deci](https://www.wikiwand.com/en/Deci-)   | d               | 10<sup>-1</sup>  |
+| [centi](https://www.wikiwand.com/en/Centi-) | c               | 10<sup>-2</sup>  |
+| [milli](https://www.wikiwand.com/en/Milli-) | m               | 10<sup>-3</sup>  |
+| [micro](https://www.wikiwand.com/en/Micro-) | u or µ (U+00B5) | 10<sup>-6</sup>  |
+| [nano](https://www.wikiwand.com/en/Nano-)   | n               | 10<sup>-9</sup>  |
+| [pico](https://www.wikiwand.com/en/Pico-)   | p               | 10<sup>-12</sup> |
+| [femto](https://www.wikiwand.com/en/Femto-) | f               | 10<sup>-15</sup> |
+| [atto](https://www.wikiwand.com/en/Atto-)   | a               | 10<sup>-18</sup> |
+| [zepto](https://www.wikiwand.com/en/Zepto-) | z               | 10<sup>-21</sup> |
+| [yocto](https://www.wikiwand.com/en/Yocto-) | y               | 10<sup>-24</sup> |

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -14,9 +14,9 @@ as custom units and defined in an accompanying JSON file, as described in the
 Earlier versions of the BIDS standard listed the following Unicode symbols, and
 these are still included for backwards compatibility:
 
-1.  `U+00B5` (µ)
-1.  `U+00B0` (°)
-1.  `U+2126` (Ω).
+1.  [`U+00B5` (µ)](https://codepoints.net/U+00B5)
+1.  [`U+00B0` (°)](https://codepoints.net/U+00B0)
+1.  [`U+2126` (Ω)](https://codepoints.net/U+2126)
 
 It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
 characters.

--- a/src/99-appendices/05-units.md
+++ b/src/99-appendices/05-units.md
@@ -8,9 +8,9 @@ the specification of units MUST follow the
 The [CMIXF-12](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) convention
 for encoding units is REQUIRED to achieve maximum portability and limited
 variability of representation.
-In case that a CMIXF representation of SI units is not possible, you will have
-to declare your units as custom units and define them in accompanying JSON
-files, as described in the [units section](../02-common-principles.md#units).
+If a CMIXF-12 representation of a unit is not possible, the unit MUST be declared
+as custom units and defined in an accompanying JSON file, as described in the
+[units section](../02-common-principles.md#units).
 Earlier versions of the BIDS standard listed the following Unicode symbols, and
 these are still included for backwards compatibility:
 
@@ -20,8 +20,9 @@ these are still included for backwards compatibility:
 
 It is REQUIRED that units be CMIXF-12 compliant or among these three Unicode
 characters.
-Please take care to not confuse the accepted unicode `U+00B5` (µ) with the
-unicode NOT accepted `U+03BC` (μ):
+Please take care not to confuse the accepted Unicode character
+[`U+00B5`](https://codepoints.net/U+00B5) (µ) with the disallowed Unicode
+character [`U+03BC`](https://codepoints.net/U+03BC) (μ):
 They look equal in appearance but are different to the computer.
 
 Units MUST consist of the `unit symbol` with an optionally accompanying
@@ -44,6 +45,7 @@ Examples:
 | -------------- | ----------------- | ------------------------------------------ |
 | metre          | m                 | length                                     |
 | kilogram       | kg                | mass                                       |
+| litre (liter)  | L                 | volume                                     |
 | second         | s                 | time                                       |
 | ampere         | A                 | electric current                           |
 | kelvin         | K                 | thermodynamic temperature                  |


### PR DESCRIPTION
replaces #151 as proposed by @satra , please see discussion therein!

Here is a summary:

- In BIDS we accept SI units only (...and in very special circumstances, custom units - but they'd need to be documented in JSON files)
- Currently, we have nowhere in the spec clarified how the FORMATTING of the SI units should be done (although some users and developers have **assumed** that the [units appendix](https://bids-specification.readthedocs.io/en/stable/99-appendices/05-units.html) shows the required formatting)
- Thus in practice, users have applied either ASCII formatting (e.g., "u" instead of  "µ") or unicode formatting (µ) ... with the problem being that some unicodes **look** the same, while being different (e.g., µ and μ ... micro vs. mu)

This PR is intended to explicitly state how we want the FORMATTING of SI units to be. Namely, we prefer ASCII formatting according to MIXF (metric interchange format), see --> http://people.csail.mit.edu/jaffer/MIXF/CMIXF-12.

For backward compatibility, we will allow unicode characters, but further clarify the exact unicode we expect (e.g, U+00B5 for the micro sign µ).

Please see the proposed changes in this PR and approve or discuss!


more recent summary: https://github.com/bids-standard/bids-specification/pull/411#issuecomment-617036529

# To do

- [x] add paragraphs to spec that teach users how we expect the formatting to be 
- [x] discuss with community and reach consensus on whether CMIXF is a good idea
- [x] get some kind of a mixf validator (we got https://github.com/sensein/cmixf by Satra)
- [ ] stop bids-validator from units validation how it is currently implemented (https://github.com/bids-standard/bids-validator/issues/969)
- [ ] make bids-validator check MIXF units (https://github.com/bids-standard/bids-validator/issues/969) ... and warn if the units are not compliant (but no error, we only RECOMMEND)