### PR TITLE
[INFRA] fix heading of auto changelog to be a markdown header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
            working_directory: ~/build
            command: |
              if (git log -1 --pretty=%s | grep Merge*) && (! git log -1 --pretty=%b | grep REL:) ; then
-             github_changelog_generator --user bids-standard --project bids-specification --token ${CHANGE_TOKEN} --output ~/build/CHANGES.md --base ~/build/src/pregh-changes.md --header-label Changelog --no-issues --no-issues-wo-labels --no-filter-by-milestone --no-compare-link --pr-label ""
+             github_changelog_generator --user bids-standard --project bids-specification --token ${CHANGE_TOKEN} --output ~/build/CHANGES.md --base ~/build/src/pregh-changes.md --header-label "# Changelog" --no-issues --no-issues-wo-labels --no-filter-by-milestone --no-compare-link --pr-label ""
              cat ~/build/CHANGES.md
              mv ~/build/CHANGES.md ~/build/src/CHANGES.md
              else


### PR DESCRIPTION
I am changing the `header-label [LABEL]` parameter to include a `#` sign, so that hopefully the header of our changelog file will be rendered as an actual header.

see: https://github.com/bids-standard/bids-specification/pull/400#discussion_r372834937

- [list of parameters for the changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator/wiki/Advanced-change-log-generation-examples)