### PR TITLE
[INFRA] add # before heading in CHANGES

### DIFF
--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -1,4 +1,4 @@
-Changelog
+# Changelog
 
 ## [v1.2.2](https://bids-specification.readthedocs.io/en/v1.2.2/) (2020-02-12)
 


### PR DESCRIPTION
follow up to #417. This will turn the changelog heading in CHANGES.md into a proper first level heading.

The benefit is (among consistency), that the changelog becomes searchable on [bids-specification.readthedocs.io/](https://bids-specification.readthedocs.io/), which it currently isn't.

#417 made sure that also in future releases this behavior will be preserved.