### PR TITLE
[FIX] Unify section titles and table-of-contents entries

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,1 +1,1 @@
-0/home/circleci/project/site/01-introduction.html
+0/site/01-introduction.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,21 +27,21 @@ nav:
         - Magnetic Resonance Imaging: 04-modality-specific-files/01-magnetic-resonance-imaging-data.md
         - Magnetoencephalography: 04-modality-specific-files/02-magnetoencephalography.md
         - Electroencephalography: 04-modality-specific-files/03-electroencephalography.md
-        - intracranial Electroencephalography: 04-modality-specific-files/04-intracranial-electroencephalography.md
+        - Intracranial Electroencephalography: 04-modality-specific-files/04-intracranial-electroencephalography.md
         - Task events: 04-modality-specific-files/05-task-events.md
         - Physiological and other continuous recordings: 04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
         - Behavioral experiments (with no MRI): 04-modality-specific-files/07-behavioral-experiments.md
       - Longitudinal and multi-site studies: 05-longitudinal-and-multi-site-studies.md
-      - Extending the BIDS specification: 06-extensions.md
+      - BIDS Extension Proposals: 06-extensions.md
       - Appendix:
         - Contributors: 99-appendices/01-contributors.md
         - Licenses: 99-appendices/02-licenses.md
-        - HED: 99-appendices/03-hed.md
-        - Entity-table: 99-appendices/04-entity-table.md
+        - Hierarchical Event Descriptors: 99-appendices/03-hed.md
+        - Entity table: 99-appendices/04-entity-table.md
         - Units: 99-appendices/05-units.md
         - MEG file formats: 99-appendices/06-meg-file-formats.md
         - MEG systems: 99-appendices/07-meg-systems.md
-        - Coordinate-systems: 99-appendices/08-coordinate-systems.md
+        - Coordinate systems: 99-appendices/08-coordinate-systems.md
       - Changelog: CHANGES.md
     - The BIDS Starter Kit:
       - GitHub repository: https://github.com/bids-standard/bids-starter-kit

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -1,4 +1,4 @@
-# Modality-agnostic files
+# Modality agnostic files
 
 ## Dataset description
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -1,4 +1,4 @@
-# Magnetic Resonance Imaging data
+# Magnetic Resonance Imaging
 
 ## Common metadata fields
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -1,6 +1,6 @@
-# Magnetoencephalography (MEG)
+# Magnetoencephalography
 
-Support for MEG was developed as a [BIDS Extension Proposal](../06-extensions.md#bids-extension-proposals).
+Support for Magnetoencephalography (MEG) was developed as a [BIDS Extension Proposal](../06-extensions.md#bids-extension-proposals).
 Please cite the following paper when referring to this part of the standard in
 context of the academic literature:
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -1,6 +1,6 @@
-# Electroencephalography (EEG)
+# Electroencephalography
 
-Support for EEG was developed as a [BIDS Extension Proposal](../06-extensions.md#bids-extension-proposals).
+Support for Electroencephalography (EEG) was developed as a [BIDS Extension Proposal](../06-extensions.md#bids-extension-proposals).
 Please cite the following paper when referring to this part of the standard in
 context of the academic literature:
 

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -1,6 +1,6 @@
-# intracranial Electroencephalography (iEEG)
+# Intracranial Electroencephalography
 
-Support for iEEG was developed as a [BIDS Extension Proposal](../06-extensions.md#bids-extension-proposals).
+Support for Intracranial Electroencephalography (iEEG) was developed as a [BIDS Extension Proposal](../06-extensions.md#bids-extension-proposals).
 Please cite the following paper when referring to this part of the standard in
 context of the academic literature:
 

--- a/src/05-longitudinal-and-multi-site-studies.md
+++ b/src/05-longitudinal-and-multi-site-studies.md
@@ -1,4 +1,4 @@
-# Longitudinal studies with multiple sessions (visits)
+# Longitudinal and multi-site studies
 
 Multiple sessions (visits) are encoded by adding an extra layer of directories
 and file names in the form of `ses-<label>`. Session label can consist

--- a/src/99-appendices/03-hed.md
+++ b/src/99-appendices/03-hed.md
@@ -1,6 +1,6 @@
-# Appendix III: Hierarchical Event Descriptor (HED) Tags
+# Appendix III: Hierarchical Event Descriptor
 
-HED is a controlled vocabulary of terms describing events in a behavioral
+Hierarchical Event Descriptors (HED) are a controlled vocabulary of terms describing events in a behavioral
 paradigm. HED was originally developed with EEG in mind, but is applicable to
 all behavioral experiments. Each level of a hierarchical tag is delimited with
 a forward slash (`/`). An HED string contains one or more HED tags separated by

--- a/src/99-appendices/03-hed.md
+++ b/src/99-appendices/03-hed.md
@@ -1,4 +1,4 @@
-# Appendix III: Hierarchical Event Descriptor
+# Appendix III: Hierarchical Event Descriptors
 
 Hierarchical Event Descriptors (HED) are a controlled vocabulary of terms describing events in a behavioral
 paradigm. HED was originally developed with EEG in mind, but is applicable to

--- a/src/99-appendices/07-meg-systems.md
+++ b/src/99-appendices/07-meg-systems.md
@@ -1,6 +1,6 @@
-# Appendix VII: preferred names of MEG systems
+# Appendix VII: MEG systems
 
-Restricted keywords for Manufacturer field in the `*_meg.json` file:
+Perferred names of MEG systems comprise restricted keywords for Manufacturer field in the `*_meg.json` file:
 
 -   [`CTF`](06-meg-file-formats.md#ctf)
 -   [`Neuromag/Elekta/Megin`](06-meg-file-formats.md#neuromagelektamegin)

--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -1,4 +1,4 @@
-# Appendix VIII: Preferred Names of Coordinate Systems
+# Appendix VIII: Coordinate Systems
 
 To interpret a coordinate (x, y, z), it is required that you know relative to
 which origin the coordinates are expressed, you have to know the interpretation

--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -1,4 +1,4 @@
-# Appendix VIII: Coordinate Systems
+# Appendix VIII: Coordinate systems
 
 To interpret a coordinate (x, y, z), it is required that you know relative to
 which origin the coordinates are expressed, you have to know the interpretation


### PR DESCRIPTION
Work on #400 revealed that there were inconsistencies between the mkdocs navigation titles and the section titles in the markdown files, a difference that becomes more evident when only a rendered PDF is examined and compared to the HTML version.

These changes mainly comprise dropping some terms, removing unneeded hypens and removing abbreviations.  The abbreviations, so removed, then do need to be moved into the first line of the corresponding section.

See also #421 that discusses this issue.