### PR TITLE
[INFRA] use new bids-maintenance GitHub account to take over automatic work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,8 @@ jobs:
              merge_messsge=$(git log -1 | grep Merge | grep "pull")
              PR_number=$(echo $merge_messsge | cut -d ' ' -f 4)
              git config credential.helper 'cache --timeout=120'
-             git config user.email "franklin.feingold@gmail.com"
-             git config user.name "Changelog-bot"
+             git config user.email "bids.maintenance@gmail.com"
+             git config user.name "bids-maintenance"
              git add ~/build/src/CHANGES.md
              git commit -m "[DOC] Auto-generate changelog entry for PR ${PR_number}"
              git push https://${CHANGE_TOKEN}@github.com/bids-standard/bids-specification.git master


### PR DESCRIPTION
closes #332 

Letting our new @bids-maintenance bot user do the bot work. Relieving Franklin's account from the duty :wink: 

Hopefully the correct account will be attributed and linked in the GitHub user interface.