### PR TITLE
[ENH] Explicitly mention bids-validator and update link

### DIFF
--- a/src/01-introduction.md
+++ b/src/01-introduction.md
@@ -29,7 +29,8 @@ standard you will benefit in the following ways:
     and speed up the curation process by using BIDS to structure and describe
     your data right after acquisition.
 
--   There are [validation tools](https://github.com/Squishymedia/BIDS-Validator)
+-   There are validation tools such as the
+    [bids-validator](https://github.com/bids-standard/bids-validator)
     that can check your dataset integrity and let you easily spot missing
     values.
 

--- a/src/01-introduction.md
+++ b/src/01-introduction.md
@@ -29,10 +29,8 @@ standard you will benefit in the following ways:
     and speed up the curation process by using BIDS to structure and describe
     your data right after acquisition.
 
--   There are validation tools such as the
-    [bids-validator](https://github.com/bids-standard/bids-validator)
-    that can check your dataset integrity and let you easily spot missing
-    values.
+-   Validation tools such as the [BIDS Validator](https://github.com/bids-standard/bids-validator)
+    can check your dataset integrity and help you easily spot missing values.
 
 BIDS is heavily inspired by the format used internally by OpenfMRI.org and has
 been supported by the International Neuroinformatics Coordinating Facility and


### PR DESCRIPTION
I was searching the spec for `bids-validator` and noticed, that no results were shown.

This minor PR allows people to search for bids-validator and also find a link.

