### PR TITLE
[INFRA] Get latest PDF build from CircleCI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ jobs:
     steps:
       - checkout:
           path: ~/bids-specification
-      - run: 
-          name: generate pdf version docs 
+      - run:
+          name: generate pdf version docs
           command: sh build_pdf.sh
       - store_artifacts:
           path: bids-spec.pdf
@@ -160,7 +160,6 @@ workflows:
   search_build:
     jobs:
       - build_docs
-      - build_docs_pdf
       - linkchecker:
           requires:
             - build_docs
@@ -180,3 +179,4 @@ workflows:
           filters:
                branches:
                    only: master
+      - build_docs_pdf


### PR DESCRIPTION
With #431 we gained a PDF version of the spec that CircleCI builds upon each merged PR/commit.

With this PR I want to allow us to use a CircleCI API link that will always resolve to the latest generated PDF version.

It'll look somewhat like this:

[`https://circleci.com/api/v1.1/project/github/bids-standard/bids-specification/1957/artifacts/0/bids-spec.pdf?branch=master`](https://circleci.com/api/v1.1/project/github/bids-standard/bids-specification/1957/artifacts/0/bids-spec.pdf?branch=master)

This link is constructed according to the CircleCI [API](https://circleci.com/docs/api/#download-an-artifact-file) and should work.

Current issues:

- See the `1957` in the link --> I had to find this number manually. With the changes in this PR, the `build_docs_pdf` job will always be executed last, and I can replace `1957` with a `latest` --> making the URL "automatic"


Notes:

- CircleCI artifacts are probably not there "forever", but according to my experience, they persist reasonably long to make use of the "latest" version. (Note, there is no official statement as to the actual amount of time that artifacts persist, see [here](https://support.circleci.com/hc/en-us/articles/115014004948-Uses-for-artifacts-and-limitations-))

- The actual use of this CircleCI URL can be discussed:
    - put it into the spec as a link to the "latest" PDF build as opposed to our "stable" PDF builds hosted on [zenodo](https://zenodo.org/record/3688707)?
    - put it just into the README of this repo?
    - don't do anything with it and look for another option to host "latest" PDF builds.
