### PR TITLE
[INFRA] ensure build_docs_pdf CircleCI job runs last

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,8 @@ workflows:
           filters:
                branches:
                    only: master
+      # Ensure that build_docs_pdf always runs last, so that we can use the CircleCI API link for the "latest" artifact
+      # https://circleci.com/api/v1.1/project/github/bids-standard/bids-specification/latest/artifacts/0/bids-spec.pdf?branch=master
       - build_docs_pdf:
           requires:
                - build_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,3 @@ workflows:
                - github-changelog-generator
                - remark
                - Changelog-bot
-          filters:
-               branches:
-                   only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,4 +179,13 @@ workflows:
           filters:
                branches:
                    only: master
-      - build_docs_pdf
+      - build_docs_pdf:
+          requires:
+               - build_docs
+               - linkchecker
+               - github-changelog-generator
+               - remark
+               - Changelog-bot
+          filters:
+               branches:
+                   only: master


### PR DESCRIPTION
follow up #433, which was apparently not sufficient. :disappointed: 

With this PR we ensure that `build_docs_pdf` runs only when all other jobs have successfully finished AND the current branch is `master`.

@franklin-feingold can we get this in despite your opening of #435 ?