### PR TITLE
[FIX] unordered list formatting in BEP018

### DIFF
--- a/src/04-modality-specific-files/08-genetic-descriptor.md
+++ b/src/04-modality-specific-files/08-genetic-descriptor.md
@@ -89,14 +89,15 @@ fields:
 | TissueOrigin                                                | OPTIONAL. String. Describes the type of tissue analyzed for SampleOrigin `brain`. Values MUST be one of `gray matter`, `white matter`, `csf`, `meninges`, `macrovascular` or `microvascular`.                                                                                            |
 | BrainLocation                                               | OPTIONAL. String. Refers to the location in space of the `TissueOrigin`. Values may be an MNI coordinate, a label taken from the [Allen Brain Atlas][allen], or layer to refer to layer-specific gene expression, which can also tie up with laminar fMRI.                               |
 | CellType                                                    | OPTIONAL. String. Describes the type of cell analyzed. Values SHOULD come from the [cell ontology][ontology].                                                                                                                                                                            |
-  
-To ensure dataset description consistency, we recommend following [Multi-omics approaches to disease](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1215-1) by Hasin et al. 2017 to determine the `GeneticLevel:`   
-  - `Genetic`: data report on a single genetic location (typically directly in the `participants.tsv` file) 
-  - `Genomic`:  data link to participants' genome (multiple genetic locations)
-  - `Epigenomic`: data link to participants' characterization of reversible modifications of DNA
-  - `Transcriptomic`: data link to participants RNA levels
-  - `Metabolomic`: data link to participants' products of cellular metabolic functions
-  - `Proteomic`: data link to participants peptides and proteins quantification 
+
+To ensure dataset description consistency, we recommend following [Multi-omics approaches to disease](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1215-1) by Hasin et al. 2017 to determine the `GeneticLevel:`
+
+-   `Genetic`: data report on a single genetic location (typically directly in the `participants.tsv` file)
+-   `Genomic`:  data link to participants' genome (multiple genetic locations)
+-   `Epigenomic`: data link to participants' characterization of reversible modifications of DNA
+-   `Transcriptomic`: data link to participants RNA levels
+-   `Metabolomic`: data link to participants' products of cellular metabolic functions
+-   `Proteomic`: data link to participants peptides and proteins quantification
 
 `genetic_info.json` example:
 


### PR DESCRIPTION
it currently looks like this:

![image](https://user-images.githubusercontent.com/9084751/79363472-39a97080-7f48-11ea-921e-edacd2425c54.png)


see: https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/08-genetic-descriptor.html

I wonder why the linter did not catch this :shrug: 