### PR TITLE
[INFRA] Add conditional for link-checking releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,15 @@ jobs:
           at: ~/build
       - run:
           command: |
+            if (! git log -1 --pretty=%b | grep REL:) ; then
             chmod a+rX -R ~
             linkchecker -t 1 ~/build/site/
             # check external separately by pointing to all *html so no
             # failures for local file:/// -- yoh found no better way,
             linkchecker -t 1 --check-extern --ignore-url 'file:///.*' --ignore-url https://fonts.gstatic.com ~/build/site/*html ~/build/site/*/*.html
+            else
+            echo "Release PR - do nothing"
+            fi
 
   build_docs_pdf:
     working_directory: ~/bids-specification/pdf_build_src


### PR DESCRIPTION
This PR adds an if statement for running our linkchecker. The linkchecker will fail on release PRs due to our changelog pointing to the future specification version (it does not get generated until after the PR has been merged). We want the linkchecker to complete on release branches so we may grab the pdf artifact and upload onto Zenodo

