### PR TITLE
[FIX] Add reference to PDF on front page of specification

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,6 @@
 # The Brain Imaging Data Structure
 
-This resource defines the Brain Imaging Data Structure (BIDS) specification, including the core specification as well as many modality-specific extensions. 
+This resource defines the Brain Imaging Data Structure (BIDS) specification, including the core specification as well as many modality-specific extensions.
 
 To get started, [check out the introduction](01-introduction.md). If you'd like
 more information on how to adapt your own datasets to match the BIDS

--- a/src/index.md
+++ b/src/index.md
@@ -1,9 +1,9 @@
 # The Brain Imaging Data Structure
 
-This resource defines the Brain Imaging Data Structure (BIDS) specification, including the core specification as well as many modality-specific extensions.
+This resource defines the Brain Imaging Data Structure (BIDS) specification, including the core specification as well as many modality-specific extensions. 
 
 To get started, [check out the introduction](01-introduction.md). If you'd like
 more information on how to adapt your own datasets to match the BIDS
 specification, we recommend exploring the [bids-specification starter kit](https://github.com/bids-standard/bids-starter-kit).
 
-For an overview of the BIDS ecosystem, visit the [BIDS homepage](https://bids.neuroimaging.io).
+For an overview of the BIDS ecosystem, visit the [BIDS homepage](https://bids.neuroimaging.io).  The entire specification can also be [downloaded as PDF](https://doi.org/10.5281/zenodo.3686061).


### PR DESCRIPTION
The new PDF rendering isn't presently referenced within the specification.  The place to reference the PDF version is clearly the 'front matter' page `src/index.md`, but I'm not entirely pleased with my addition, tacking on the sentence...

> The entire specification can also be [downloaded as PDF](https://doi.org/10.5281/zenodo.3686061).

... but I couldn't see a more elegant edit.

This addresses #135.