### PR TITLE
[WIP] [ENH] Add section numbers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ theme:
     logo: images/logo.png
 extra_javascript:
     - js/jquery-3.4.1.min.js
+extra_css:
+    - css/section_numbering.css
 markdown_extensions:
     - toc:
         anchorlink: true

--- a/src/css/section_numbering.css
+++ b/src/css/section_numbering.css
@@ -1,0 +1,49 @@
+body {
+counter-reset : h2;
+    }
+
+h2 {
+counter-reset : h3;
+    }
+
+h3 {
+counter-reset : h4;
+    }
+
+h4 {
+counter-reset : h5;
+    }
+
+h5 {
+counter-reset : h6;
+    }
+
+article h2:before {
+content : counter(h2,decimal) ". ";
+counter-increment : h2;
+    }
+
+article h3:before {
+content : counter(h2,decimal) "." counter(h3,decimal) ". ";
+counter-increment : h3;
+    }
+
+article h4:before {
+content : counter(h2,decimal) "." counter(h3,decimal) "." counter(h4,decimal) ". ";
+counter-increment : h4;
+    }
+
+article h5:before {
+content : counter(h2,decimal) "." counter(h3,decimal) "." counter(h4,decimal) "." counter(h5,decimal) ". ";
+counter-increment : h5;
+    }
+
+article h6:before {
+content : counter(h2,decimal) "." counter(h3,decimal) "." counter(h4,decimal) "." counter(h5,decimal) "." counter(h6,decimal) ". ";
+counter-increment : h6;
+    }
+
+h2.nocount:before, h3.nocount:before, h4.nocount:before, h5.nocount:before, h6.nocount:before {
+content : "";
+counter-increment : none;
+    }


### PR DESCRIPTION
This is a WIP to address issue #421, adding section and subsection numbers throughout the document.

Will require extensive checking of a RTD and PDF rendered version to ensure it is doing what it should and doesn't have any bad side effects.

RTD rendering:  https://bids-specification.readthedocs.io/en/addsectionnums
PDF rendering: (Find via the ci/circleci "build_docs_pdf" job below, expanded under "show all checks", "artifacts" tab; requires Circle CI login)

Note 1. This takes over from PR #453, which came from a personal branch instead of the main repo.
Note 2. The the content for CSS directly copied and pasted from here: https://stackoverflow.com/questions/48029165/is-there-a-way-to-make-the-headings-sections-and-subsections-numbering-in-markd