### PR TITLE
[MISC] Maintainers - `Scope` responsibility

### DIFF
--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -30,11 +30,13 @@ BIDS governance.
 | Chris Markiewicz ([@effigies](https://github.com/effigies))                    | 5h/week         |                       |
 | Franklin Feingold ([@franklin-feingold](https://github.com/franklin-feingold)) | 5h/week         | Community development | 
 
-In addition to the [BIDS Governance](https://bids.neuroimaging.io/governance.html#bids-maintainers-group) classification of a Maintainer, the Steering Group and Maintainers Group have enhanced this to include a `Purview` responsibility.
-A purview can range from maintaining a modality supported in the specification to nuturing a welcoming BIDS community. 
-The purview will be choosen by the Maintainer and agreed upon by the Maintainers Group.
-The Maintainer is primarily responsible for maintaining their choosen purview.
-Though, a Maintainer may contribute in a purview that is not their own.
+In addition to the [BIDS Governance](https://bids.neuroimaging.io/governance.html#bids-maintainers-group)
+classification of a maintainer, maintainers may declare a limited scope or purview of responsibility.
+Such a purview can range from maintaining a modality supported in the specification to nurturing a
+welcoming BIDS community. 
+One or more purviews can be chosen by the maintainer and agreed upon by the Maintainers Group.
+A maintainer is primarily responsible for issues within their chosen purview(s), although
+contributions elsewhere are welcome, as well.
 
 **BEP Leads Group**
 

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -24,11 +24,17 @@ BIDS governance.
 
 **Maintainers Group**
 
-| Name                                                                           | Time commitment |
-|--------------------------------------------------------------------------------|-----------------|
-| Stefan Appelhoff ([@sappelhoff](https://github.com/sappelhoff))                | 5h/week         |
-| Chris Markiewicz ([@effigies](https://github.com/effigies))                    | 5h/week         |
-| Franklin Feingold ([@franklin-feingold](https://github.com/franklin-feingold)) | 5h/week         |
+| Name                                                                           | Time commitment | Domain expert         |
+|--------------------------------------------------------------------------------|-----------------|-----------------------|
+| Stefan Appelhoff ([@sappelhoff](https://github.com/sappelhoff))                | 5h/week         |                       |
+| Chris Markiewicz ([@effigies](https://github.com/effigies))                    | 5h/week         |                       |
+| Franklin Feingold ([@franklin-feingold](https://github.com/franklin-feingold)) | 5h/week         | Community development | 
+
+In addition to the [BIDS Governance](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/edit#bookmark=id.y2yr6itn36kv) classification of a Maintainer, the Steering Group and Maintainers Group have enhanced this to include a `Domain Expert` responsibility.
+This domain can range from maintaining a modality supported in the specification to nuturing a welcoming BIDS community. 
+The domain will be choosen by the Maintainer and agreed upon by the Maintainers Group.
+The Maintainer is primarily responsible for maintaining their choosen domain.
+Though, a Maintainer may contribute in a domain that is not their own.
 
 **BEP Leads Group**
 

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -24,17 +24,17 @@ BIDS governance.
 
 **Maintainers Group**
 
-| Name                                                                           | Time commitment | Domain expert         |
+| Name                                                                           | Time commitment | Purview               |
 |--------------------------------------------------------------------------------|-----------------|-----------------------|
 | Stefan Appelhoff ([@sappelhoff](https://github.com/sappelhoff))                | 5h/week         |                       |
 | Chris Markiewicz ([@effigies](https://github.com/effigies))                    | 5h/week         |                       |
 | Franklin Feingold ([@franklin-feingold](https://github.com/franklin-feingold)) | 5h/week         | Community development | 
 
-In addition to the [BIDS Governance](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/edit#bookmark=id.y2yr6itn36kv) classification of a Maintainer, the Steering Group and Maintainers Group have enhanced this to include a `Domain Expert` responsibility.
-This domain can range from maintaining a modality supported in the specification to nuturing a welcoming BIDS community. 
-The domain will be choosen by the Maintainer and agreed upon by the Maintainers Group.
-The Maintainer is primarily responsible for maintaining their choosen domain.
-Though, a Maintainer may contribute in a domain that is not their own.
+In addition to the [BIDS Governance](https://bids.neuroimaging.io/governance.html#bids-maintainers-group) classification of a Maintainer, the Steering Group and Maintainers Group have enhanced this to include a `Purview` responsibility.
+A purview can range from maintaining a modality supported in the specification to nuturing a welcoming BIDS community. 
+The purview will be choosen by the Maintainer and agreed upon by the Maintainers Group.
+The Maintainer is primarily responsible for maintaining their choosen purview.
+Though, a Maintainer may contribute in a purview that is not their own.
 
 **BEP Leads Group**
 

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -24,18 +24,18 @@ BIDS governance.
 
 **Maintainers Group**
 
-| Name                                                                           | Time commitment | Purview               |
+| Name                                                                           | Time commitment | Scope                 |
 |--------------------------------------------------------------------------------|-----------------|-----------------------|
 | Stefan Appelhoff ([@sappelhoff](https://github.com/sappelhoff))                | 5h/week         |                       |
 | Chris Markiewicz ([@effigies](https://github.com/effigies))                    | 5h/week         |                       |
 | Franklin Feingold ([@franklin-feingold](https://github.com/franklin-feingold)) | 5h/week         | Community development | 
 
 In addition to the [BIDS Governance](https://bids.neuroimaging.io/governance.html#bids-maintainers-group)
-classification of a maintainer, maintainers may declare a limited scope or purview of responsibility.
-Such a purview can range from maintaining a modality supported in the specification to nurturing a
+classification of a maintainer, maintainers may declare a limited scope of responsibility.
+Such a scope can range from maintaining a modality supported in the specification to nurturing a
 welcoming BIDS community. 
-One or more purviews can be chosen by the maintainer and agreed upon by the Maintainers Group.
-A maintainer is primarily responsible for issues within their chosen purview(s), although
+One or more scopes can be chosen by the maintainer and agreed upon by the Maintainers Group.
+A maintainer is primarily responsible for issues within their chosen scope(s), although
 contributions elsewhere are welcome, as well.
 
 **BEP Leads Group**


### PR DESCRIPTION
This pull request is seeking to enhance our current definition of a Maintainer. Our current definition is derived from our [governance document](https://docs.google.com/document/d/1R-J2lL9V_wIkYhye4zH-feyl4P4J8NyO40rIYyY141o/edit#bookmark=id.y2yr6itn36kv) and implemented in our [decision-making document](https://github.com/bids-standard/bids-specification/blob/master/DECISION-MAKING.md). 

We intend to add a ~~`Domain expert`~~ ~~`Purview` (edit 5/12)~~ `Scope` (edit 5/14) identification to a Maintainer. This ~~`Domain expert`~~ ~~`Purview` (edit 5/12)~~ `Scope` (edit 5/14) enhancement enables a Maintainer to specify what part of BIDS they intend to be responsible for maintaining. This addition will provide more clarity on how potential maintainers can specifically contribute to the Maintainers team by slowly taking on responsibilities in their domain of expertise. This will provide a clearer pathway into the Maintainers Group.

The purpose of this is to build more resilience and sustainability into our community by reducing the barrier to entry through identifying more specific (and diverse) contribution opportunities 