### PR TITLE
[INFRA] linkchecker - ignore github pull and tree URLs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
               --ignore-url 'file:///.*' \
               --ignore-url https://fonts.gstatic.com \
               --ignore-url "https://github.com/bids-standard/bids-specification/(pull|tree)/.*" \
+              --ignore-url "https://github.com/[^/]*" \
               ~/build/site/*html ~/build/site/*/*.html
             else
             echo "Release PR - do nothing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             linkchecker -t 1 --check-extern \
               --ignore-url 'file:///.*' \
               --ignore-url https://fonts.gstatic.com \
-              --ignore-url https://github.com/bids-standard/bids-specification/(pull|tree)/.* \
+              --ignore-url "https://github.com/bids-standard/bids-specification/(pull|tree)/.*" \
               ~/build/site/*html ~/build/site/*/*.html
             else
             echo "Release PR - do nothing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,11 @@ jobs:
             linkchecker -t 1 ~/build/site/
             # check external separately by pointing to all *html so no
             # failures for local file:/// -- yoh found no better way,
-            linkchecker -t 1 --check-extern --ignore-url 'file:///.*' --ignore-url https://fonts.gstatic.com ~/build/site/*html ~/build/site/*/*.html
+            linkchecker -t 1 --check-extern \
+              --ignore-url 'file:///.*' \
+              --ignore-url https://fonts.gstatic.com \
+              --ignore-url https://github.com/bids-standard/bids-specification/(pull|tree)/.* \
+              ~/build/site/*html ~/build/site/*/*.html
             else
             echo "Release PR - do nothing"
             fi


### PR DESCRIPTION
It causes github to spit out "429 too many requests" HTTP error (Closes #474).
With this change we should skip ATM about 200 github URLs and be left
with only about 30. Hopefully that would suffice