### PR TITLE
[FIX] clarify MEG empty-room recording naming conventions

### DIFF
--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -430,11 +430,12 @@ Empty-room MEG recordings capture the environmental and recording system's
 noise.
 There are two widely used strategies for collecting these recordings:
 
-1.   Some labs record one empty-room recording per day, which is then shared by
-     all researchers of the lab that record data from a study subject that day
-1.   Some labs make it the responsibility of the researcher to record a short
-     empty-room recording prior to each subject specific recording
-     (e.g., while preparing the study subject for the task)
+1.  Some labs record one empty-room recording per day, which is then shared by
+    all researchers of the lab that record data from a study subject that day
+
+1.  Some labs make it the responsibility of the researcher to record a short
+    empty-room recording prior to each subject specific recording
+    (e.g., while preparing the study subject for the task)
 
 For cases resembling the first strategy, it is RECOMMENDED to store the
 empty-room recording inside a subject folder named `sub-emptyroom`.

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -426,13 +426,16 @@ has to be updated, then for MEG it could be considered to be a new session.
 
 ## Empty-room MEG recordings
 
-Empty-room MEG recordings capture the environment and system noise. Their
-collection is RECOMMENDED, before/during/after each session. This data is stored
-inside a subject folder named `sub-emptyroom`. The `session label` SHOULD be
-that of the date of the empty-room recording (e.g. `ses-YYYYMMDD`). The
-`scans.tsv` file containing the date/time of the acquisition SHOULD also be
-included. Hence, users will be able to retrieve the empty-room recording that
-best matches a particular session with a participant, based on date/time of
+Empty-room MEG recordings capture the environment and system noise.
+Their collection is RECOMMENDED, before/during/after each session.
+This data MUST be stored inside a subject folder named `sub-emptyroom`.
+The `session label` SHOULD be that of the date of the empty-room recording
+(e.g., `ses-YYYYMMDD`).
+The task label in the `*_meg.json` file SHOULD be set to `noise`.
+The `scans.tsv` file containing the date/time of the acquisition SHOULD also be
+included.
+Hence, users will be able to retrieve the empty-room recording that best
+matches a particular session with a participant, based on date/time of
 recording.
 
 Example:
@@ -447,5 +450,3 @@ sub-emptyroom/
             sub-emptyroom_ses-20170801_task-noise_meg.ds
             sub-emptyroom_ses-20170801_task-noise_meg.json
 ```
-
-`TaskName` in the `*_meg.json` file should be set to "noise".

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -477,6 +477,6 @@ sub-control01/
 sub-control02/
     sub-control01_task-bart_meg.ds
     sub-control01_task-noise_meg.ds
-    sub-control01_task-noise_bart.json
+    sub-control01_task-bart_meg.json
     sub-control01_task-noise_meg.json
 ```

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -428,39 +428,24 @@ has to be updated, then for MEG it could be considered to be a new session.
 
 Empty-room MEG recordings capture the environmental and recording system's
 noise.
-There are two widely used strategies for collecting these recordings:
-
-1.  Some labs record one empty-room measurement per day, which is then shared by
-    all researchers that record subject data on that day
-
-1.  Some labs make it the responsibility of each researcher to record a short
-    empty-room measurement prior to each subject-specific recording
-    (e.g., while preparing the study subject for the task)
-
-For cases resembling the **first** strategy, it is RECOMMENDED to store the
-empty-room recording inside a subject folder named `sub-emptyroom`.
+In the context of BIDS it is RECOMMENDED to perform an empty-room recording for
+each experimental session.
+It is RECOMMENDED to store the empty-room recording inside a subject folder
+named `sub-emptyroom`.
+The label for the `task-<label>` entity in the empty-room recording SHOULD be
+set to `noise`.
 If a `session-<label>` entity is present, its label SHOULD be the date of the
 empty-room recording in the format `YYYYMMDD`, i.e., `ses-YYYYMMDD`.
-For these cases, the `scans.tsv` file containing the date and time of the
-acquisition SHOULD also be included.
-
-However, for cases resembling the **second** strategy, the subject data and
-empty-room recording are naturally linked and it is thus RECOMMENDED to instead
-store the empty-room recording inside the study subject's folder.
-
-Furthermore, in **both** cases the label for the `task-<label>` entity in the
-`*_meg.json` file SHOULD be set to `noise`.
-
+The `scans.tsv` file containing the date and time of the acquisition SHOULD
+also be included.
 The rationale is that this naming scheme will allow users to easily retrieve the
 empty-room recording that best matches a particular experimental session, based
 on date and time of the recording.
 It should be possible to query empty-room recordings just like usual subject
 recordings, hence all metadata sidecar files (such as the `channels.tsv`) file
-SHOULD be present as well, irrespective of the storing strategy.
-In the context of BIDS it is RECOMMENDED to perform an empty-room recording for
-each experimental session.
+SHOULD be present as well.
 
-Example for cases resembling strategy 1:
+Example:
 
 ```Text
 sub-control01/
@@ -472,18 +457,4 @@ sub-emptyroom/
             sub-emptyroom_ses-20170801_task-noise_meg.ds
             sub-emptyroom_ses-20170801_task-noise_meg.json
             sub-emptyroom_ses-20170801_task-noise_channels.tsv
-```
-
-Example for cases resembling strategy 2:
-
-```Text
-sub-control01/
-sub-control02/
-    meg/
-        sub-control01_task-bart_meg.ds
-        sub-control01_task-bart_meg.json
-        sub-control01_task-bart_channels.tsv
-        sub-control01_task-noise_meg.ds        
-        sub-control01_task-noise_meg.json
-        sub-control01_task-noise_channels.tsv
 ```

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -426,19 +426,37 @@ has to be updated, then for MEG it could be considered to be a new session.
 
 ## Empty-room MEG recordings
 
-Empty-room MEG recordings capture the environmental and recording system's noise.
-Their collection is RECOMMENDED, before/during/after each session.
-This data MUST be stored inside a subject folder named `sub-emptyroom`.
-The `session label` SHOULD be the date of the empty-room recording in
-the format `YYYYMMDD`, i.e.,  `ses-YYYYMMDD`.
-The `task label` in the `*_meg.json` file SHOULD be set to `noise`.
-The `scans.tsv` file containing the date and time of the acquisition SHOULD also be
-included.
-The rationale is that this naming scheme will allow users to easily retrieve the
- empty-room recording that best matches a particular experimental session,
- based on date and time of the recording.
+Empty-room MEG recordings capture the environmental and recording system's
+noise.
+There are two widely used strategies for collecting these recordings:
 
-Example:
+1.   Some labs record one empty-room recording per day, which is then shared by
+     all researchers of the lab that record data from a study subject that day
+1.   Some labs make it the responsibility of the researcher to record a short
+     empty-room recording prior to each subject specific recording
+     (e.g., while preparing the study subject for the task)
+
+For cases resembling the first strategy, it is RECOMMENDED to store the
+empty-room recording inside a subject folder named `sub-emptyroom`.
+If a `session-<label>` entity is present, its label SHOULD be the date of the
+empty-room recording in the format `YYYYMMDD`, i.e., `ses-YYYYMMDD`.
+For these cases, the `scans.tsv` file containing the date and time of the
+acquisition SHOULD also be included.
+
+However, for cases resembling the second strategy, the subject data and
+empty-room recording are naturally linked and it is thus RECOMMENDED to instead
+store the empty-room recording inside the study subject's folder.
+
+Furthermore, in both cases the label for the `task-<label>` entity in the
+`*_meg.json` file SHOULD be set to `noise`.
+
+The rationale is that this naming scheme will allow users to easily retrieve the
+empty-room recording that best matches a particular experimental session, based
+on date and time of the recording.
+In the context of BIDS it is RECOMMENDED to record an empty-room recording for
+each session.
+
+Example for cases resembling strategy 1:
 
 ```Text
 sub-control01/
@@ -449,4 +467,15 @@ sub-emptyroom/
         meg/
             sub-emptyroom_ses-20170801_task-noise_meg.ds
             sub-emptyroom_ses-20170801_task-noise_meg.json
+```
+
+Example for cases resembling strategy 2:
+
+```Text
+sub-control01/
+sub-control02/
+    sub-control01_task-bart_meg.ds
+    sub-control01_task-noise_meg.ds
+    sub-control01_task-noise_bart.json
+    sub-control01_task-noise_meg.json
 ```

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -475,8 +475,11 @@ Example for cases resembling strategy 2:
 ```Text
 sub-control01/
 sub-control02/
-    sub-control01_task-bart_meg.ds
-    sub-control01_task-noise_meg.ds
-    sub-control01_task-bart_meg.json
-    sub-control01_task-noise_meg.json
+    meg/
+        sub-control01_task-bart_meg.ds
+        sub-control01_task-bart_meg.json
+        sub-control01_task-bart_channels.tsv
+        sub-control01_task-noise_meg.ds        
+        sub-control01_task-noise_meg.json
+        sub-control01_task-noise_channels.tsv
 ```

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -426,17 +426,17 @@ has to be updated, then for MEG it could be considered to be a new session.
 
 ## Empty-room MEG recordings
 
-Empty-room MEG recordings capture the environment and system noise.
+Empty-room MEG recordings capture the environmental and recording system's noise.
 Their collection is RECOMMENDED, before/during/after each session.
 This data MUST be stored inside a subject folder named `sub-emptyroom`.
-The `session label` SHOULD be that of the date of the empty-room recording
-(e.g., `ses-YYYYMMDD`).
+The `session label` SHOULD be the date of the empty-room recording in
+the format `YYYYMMDD`, i.e.,  `ses-YYYYMMDD`.
 The task label in the `*_meg.json` file SHOULD be set to `noise`.
-The `scans.tsv` file containing the date/time of the acquisition SHOULD also be
+The `scans.tsv` file containing the date and time of the acquisition SHOULD also be
 included.
-Hence, users will be able to retrieve the empty-room recording that best
-matches a particular session with a participant, based on date/time of
-recording.
+The rationale is that this naming scheme will allow users to easily retrieve the
+ empty-room recording that best matches a particular experimental session,
+ based on date and time of the recording.
 
 Example:
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -454,6 +454,9 @@ Furthermore, in **both** cases the label for the `task-<label>` entity in the
 The rationale is that this naming scheme will allow users to easily retrieve the
 empty-room recording that best matches a particular experimental session, based
 on date and time of the recording.
+It should be possible to query empty-room recordings just like usual subject
+recordings, hence all metadata sidecar files (such as the `channels.tsv`) file
+SHOULD be present as well, irrespective of the storing strategy.
 In the context of BIDS it is RECOMMENDED to perform an empty-room recording for
 each experimental session.
 
@@ -468,6 +471,7 @@ sub-emptyroom/
         meg/
             sub-emptyroom_ses-20170801_task-noise_meg.ds
             sub-emptyroom_ses-20170801_task-noise_meg.json
+            sub-emptyroom_ses-20170801_task-noise_channels.tsv
 ```
 
 Example for cases resembling strategy 2:

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -431,7 +431,7 @@ Their collection is RECOMMENDED, before/during/after each session.
 This data MUST be stored inside a subject folder named `sub-emptyroom`.
 The `session label` SHOULD be the date of the empty-room recording in
 the format `YYYYMMDD`, i.e.,  `ses-YYYYMMDD`.
-The task label in the `*_meg.json` file SHOULD be set to `noise`.
+The `task label` in the `*_meg.json` file SHOULD be set to `noise`.
 The `scans.tsv` file containing the date and time of the acquisition SHOULD also be
 included.
 The rationale is that this naming scheme will allow users to easily retrieve the

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -430,32 +430,32 @@ Empty-room MEG recordings capture the environmental and recording system's
 noise.
 There are two widely used strategies for collecting these recordings:
 
-1.  Some labs record one empty-room recording per day, which is then shared by
-    all researchers of the lab that record data from a study subject that day
+1.  Some labs record one empty-room measurement per day, which is then shared by
+    all researchers that record subject data on that day
 
-1.  Some labs make it the responsibility of the researcher to record a short
-    empty-room recording prior to each subject specific recording
+2.  Some labs make it the responsibility of each researcher to record a short
+    empty-room measurement prior to each subject-specific recording
     (e.g., while preparing the study subject for the task)
 
-For cases resembling the first strategy, it is RECOMMENDED to store the
+For cases resembling the **first** strategy, it is RECOMMENDED to store the
 empty-room recording inside a subject folder named `sub-emptyroom`.
 If a `session-<label>` entity is present, its label SHOULD be the date of the
 empty-room recording in the format `YYYYMMDD`, i.e., `ses-YYYYMMDD`.
 For these cases, the `scans.tsv` file containing the date and time of the
 acquisition SHOULD also be included.
 
-However, for cases resembling the second strategy, the subject data and
+However, for cases resembling the **second** strategy, the subject data and
 empty-room recording are naturally linked and it is thus RECOMMENDED to instead
 store the empty-room recording inside the study subject's folder.
 
-Furthermore, in both cases the label for the `task-<label>` entity in the
+Furthermore, in **both** cases the label for the `task-<label>` entity in the
 `*_meg.json` file SHOULD be set to `noise`.
 
 The rationale is that this naming scheme will allow users to easily retrieve the
 empty-room recording that best matches a particular experimental session, based
 on date and time of the recording.
-In the context of BIDS it is RECOMMENDED to record an empty-room recording for
-each session.
+In the context of BIDS it is RECOMMENDED to perform an empty-room recording for
+each experimental session.
 
 Example for cases resembling strategy 1:
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -433,7 +433,7 @@ There are two widely used strategies for collecting these recordings:
 1.  Some labs record one empty-room measurement per day, which is then shared by
     all researchers that record subject data on that day
 
-2.  Some labs make it the responsibility of each researcher to record a short
+1.  Some labs make it the responsibility of each researcher to record a short
     empty-room measurement prior to each subject-specific recording
     (e.g., while preparing the study subject for the task)
 


### PR DESCRIPTION
this section was unclear, see https://github.com/mne-tools/mne-bids/pull/421#issuecomment-633005511

This PR aims at improving / clarifying the used language and examples.

---

I am wondering, why `noise` as a task name and date as a session label have only "SHOULD", and not "MUST" definitions :thinking: anyone got a clue?