### PR TITLE
Clarify mask/dseg/probseg in common derivatives

### DIFF
--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -122,9 +122,8 @@ Template:
             <source_entities>[_space-<space>][_res-<label>][_den-<label>][_desc-<label>]_mask.nii.gz
 ```
 
-A binary (1 - inside, 0 - outside) mask in the space defined by `<space>`. By
-default (i.e., if no transformation has taken place) the value of `space` should
-be set to `orig`.
+A binary (1 - inside, 0 - outside) mask in the space defined by `<space>`.
+If no transformation has taken place, the value of `space` SHOULD be set to `orig`.
 
 JSON metadata fields:
 
@@ -132,6 +131,7 @@ JSON metadata fields:
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | RawSources   | Same as defined in [Introduction][intro], but elevated from OPTIONAL to REQUIRED                                                               |
 | Type         | RECOMMENDED. Short identifier of the mask. Reserved values: `Brain` - brain mask, `Lesion` - lesion mask, `Face` - face mask, `ROI` - ROI mask |
+| Atlas        | OPTIONAL. Which atlas (if any) was used to generate the mask.                                                                                  |
 | Resolution   | REQUIRED if `res` is present. String, or [object][] mapping labels to strings. Specifies the interpretation of the resolution keyword.         |
 | Density      | REQUIRED if `den` is present. String, or [object][] mapping labels to strings. Specifies the interpretation of the density keyword.            |
 
@@ -153,9 +153,24 @@ manual_masks/
             sub-001_desc-tumor_mask.json
 ```
 
-## Segmentations and parcellations
+## Segmentations
 
-Common JSON metadata fields:
+A *segmentation* is a labeling of a spatial image with anatomical structures
+such that each voxel is identified with a label or a combination of labels.
+A *discrete segmentation* represents each tissue class with a unique integer
+label.
+A *probabilistic segmentation* represents each tissue class as values between
+0 and 1 (inclusive) at each location in the image, and one volume/frame per
+tissue class are concatenated in a single file.
+
+Segmentations may be defined in a volume (labeled voxels), a surface (labeled
+vertices) or a combined volume/surface space.
+
+The following section describes discrete and probabilistic segmentations of
+volumes, followed by discrete segmentations of surface/combined spaces.
+Probabilistic segmentations of surfaces are currently [unspecified][].
+
+The following metadata fields apply to all segmentation files:
 
 | **Key name** | **Description**                                                                                                                        |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -189,24 +204,25 @@ pipeline/
             sub-001_space-orig_dseg.json
 ```
 
-A segmentation could be a binary mask that functions as a discrete `label` for a
-single structure. In this case, the label key must be used to specify the
-corresponding structure. For example:
+A segmentation can be used to generate a binary mask that functions as a
+discrete "label" for a single structure.
+In this case, the mask suffix MUST be used, and the `desc` entity SHOULD be used
+to specify the masked structure (see [Anatomical labels](#anatomical-labels), and
+the `Atlas` metadata SHOULD be defined.
+For example:
 
 ```Text
 pipeline/
     sub-001/
         anat/
-            sub-001_space-orig_label-GM_dseg.nii.gz
+            sub-001_space-orig_desc-GM_mask.nii.gz
 ```
-
-See [Anatomical Labels](#anatomical-labels) for reserved key values for `label`.
 
 ### Probabilistic Segmentations
 
 Probabilistic segmentations of brain tissue represent a single tissue class with
 values ranging from 0 to 1 in individual 3D volumes or across multiple frames.
-Similarly to a discrete, binary segmentation, the label key can be used to
+If a single tissue class is included the `label` entity SHOULD be used to
 specify the corresponding structure.
 
 Template:
@@ -366,3 +382,4 @@ index   name            abbreviation    color       mapping
 [intro]: 01-introduction.md
 [common_preproc]: 02-common-data-types.md#preprocessed-or-cleaned-data
 [object]: https://www.json.org/json-en.html
+[unspecified]: ../02-common-principles.md#unspecified-data

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -119,11 +119,14 @@ Template:
 <pipeline_name>/
     sub-<participant_label>/
         anat|func|dwi/
-            <source_entities>[_space-<space>][_res-<label>][_den-<label>][_desc-<label>]_mask.nii.gz
+            <source_entities>[_space-<space>][_res-<label>][_den-<label>][_label-<label>][_desc-<label>]_mask.nii.gz
 ```
 
 A binary (1 - inside, 0 - outside) mask in the space defined by `<space>`.
 If no transformation has taken place, the value of `space` SHOULD be set to `orig`.
+If the mask is an ROI mask derived from an atlas, then the `label` entity SHOULD
+be used to specify the masked structure (see [Anatomical labels](#anatomical-labels),
+and the `Atlas` metadata SHOULD be defined.
 
 JSON metadata fields:
 
@@ -131,7 +134,7 @@ JSON metadata fields:
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | RawSources   | Same as defined in [Introduction][intro], but elevated from OPTIONAL to REQUIRED                                                               |
 | Type         | RECOMMENDED. Short identifier of the mask. Reserved values: `Brain` - brain mask, `Lesion` - lesion mask, `Face` - face mask, `ROI` - ROI mask |
-| Atlas        | OPTIONAL. Which atlas (if any) was used to generate the mask.                                                                                  |
+| Atlas        | OPTIONAL. Which atlas (if any) was used to generate the mask. RECOMMENDED if `label` entity is defined.                                        |
 | Resolution   | REQUIRED if `res` is present. String, or [object][] mapping labels to strings. Specifies the interpretation of the resolution keyword.         |
 | Density      | REQUIRED if `den` is present. String, or [object][] mapping labels to strings. Specifies the interpretation of the density keyword.            |
 
@@ -208,7 +211,7 @@ pipeline/
 
 A segmentation can be used to generate a binary mask that functions as a
 discrete "label" for a single structure.
-In this case, the mask suffix MUST be used, and the `desc` entity SHOULD be used
+In this case, the mask suffix MUST be used, and the `label` entity SHOULD be used
 to specify the masked structure (see [Anatomical labels](#anatomical-labels), and
 the `Atlas` metadata SHOULD be defined.
 For example:

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -156,12 +156,13 @@ manual_masks/
 ## Segmentations
 
 A *segmentation* is a labeling of a spatial image with anatomical structures
-such that each voxel is identified with a label or a combination of labels.
-A *discrete segmentation* represents each tissue class with a unique integer
+such that each location (for example, a voxel or a surface vertex) is identified
+with a label or a combination of labels.
+A *discrete segmentation* represents each structure with a unique integer
 label.
-A *probabilistic segmentation* represents each tissue class as values between
+A *probabilistic segmentation* represents each structure as values between
 0 and 1 (inclusive) at each location in the image, and one volume/frame per
-tissue class are concatenated in a single file.
+structure may be concatenated in a single file.
 
 Segmentations may be defined in a volume (labeled voxels), a surface (labeled
 vertices) or a combined volume/surface space.
@@ -181,9 +182,10 @@ The following metadata fields apply to all segmentation files:
 
 ### Discrete Segmentations
 
-Discrete segmentations of brain tissue represent each tissue class with a unique
-integer label in a 3D volume. See [Anatomical Labels](#anatomical-labels) for interpretation how
-integer values map to tissue classes.
+Discrete segmentations of brain tissue represent multiple anatomical structures
+(such as tissue class or Brodmann area) with a unique integer label in a 3D volume.
+See [Anatomical Labels](#anatomical-labels) for interpretation how integer values
+map to anatomical structures.
 
 Template:
 
@@ -215,15 +217,16 @@ For example:
 pipeline/
     sub-001/
         anat/
-            sub-001_space-orig_desc-GM_mask.nii.gz
+            sub-001_space-orig_label-GM_mask.nii.gz
 ```
 
 ### Probabilistic Segmentations
 
-Probabilistic segmentations of brain tissue represent a single tissue class with
-values ranging from 0 to 1 in individual 3D volumes or across multiple frames.
-If a single tissue class is included the `label` entity SHOULD be used to
-specify the corresponding structure.
+Probabilistic segmentations of brain tissue represent a single anatomical
+structure with values ranging from 0 to 1 in individual 3D volumes or across
+multiple frames.
+If a single structure is included the `label` entity SHOULD be used to specify
+the structure.
 
 Template:
 

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -365,16 +365,26 @@ These TSV lookup tables contain the following columns:
 | index        | REQUIRED. The label integer index                                       |
 | name         | REQUIRED. The unique label name                                         |
 | abbreviation | OPTIONAL. The unique label abbreviation                                 |
-| mapping      | OPTIONAL. Corresponding integer label in the standard BIDS label lookup |
 | color        | OPTIONAL. Hexadecimal. Label color for visualization                    |
+| mapping      | OPTIONAL. Corresponding integer label in the standard BIDS label lookup |
 
-An example, custom dseg.tsv that defines three labels:
+An example, custom `dseg.tsv` that defines three labels:
 
 ```Text
 index   name            abbreviation    color       mapping
 100     Gray Matter     GM              #ff53bb     1
 101     White Matter    WM              #2f8bbe     2
 102     Brainstem       BS              #36de72     11
+```
+
+The following example `dseg.tsv` defines regions that are not part of the
+standard BIDS labels:
+
+```Text
+index   name                abbreviation
+137     pars opercularis    IFGop
+138     pars triangularis   IFGtr
+139     pars orbitalis      IFGor
 ```
 
 []: <> (################)

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -273,10 +273,12 @@ for each volume:
 Values of `label` SHOULD correspond to abbreviations defined in
 [Anatomical Labels](#anatomical-labels).
 
-### Surface Parcellations
+### Discrete surface segmentations
 
-Discrete parcellations (surface segmentations) of cortical structures should be
-stored as GIFTI or CIFTI file.
+Discrete surface segmentations (sometimes called *parcellations*) of cortical
+structures MUST be stored as GIFTI label files, with extension `.label.gii`.
+For combined volume/surface spaces, discrete segmentations MUST be stored as
+CIFTI-2 dense label fles, with extension `.dlabel.nii`.
 
 Template:
 
@@ -287,8 +289,7 @@ Template:
             <source_entities>[_hemi-{L|R}][_space-<space>][_res-<label>][_den-<label>]_dseg.{label.gii|dlabel.nii}
 ```
 
-The REQUIRED extension for GIFTI parcellations is `.label.gii`. The `hemi` tag is
-REQUIRED for GIFTI files. For example:
+The `hemi` tag is REQUIRED for GIFTI files. For example:
 
 ```Text
 pipeline/

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -270,7 +270,8 @@ for each volume:
 }
 ```
 
-Values of `label` need to map to Abbreviations defined in [Anatomical Labels](#anatomical-labels).
+Values of `label` SHOULD correspond to abbreviations defined in
+[Anatomical Labels](#anatomical-labels).
 
 ### Surface Parcellations
 


### PR DESCRIPTION
This PR does the following:

1) Remove conceptual overlap of binary masks and binary dsegs by standardizing on mask and updating the example to show that a single ROI should be renamed to `mask`. I left it under `dseg` to make the connection plain, as I don't think anything would be gained by moving it to mask (which has an ROI example already). This follows a brief discussion with @Lestropie and @edickie in https://github.com/bids-standard/bids-specification/pull/265#discussion_r432818644/https://github.com/bids-standard/bids-specification/pull/265#discussion_r432874774.
2) I added a preface to segmentations (removing parcellation from the section title) to place a conceptual hierarchy of type (discrete vs probabilistic) and a subordinate consideration of representation (volume vs surface) and further that we are not currently specifying probabilistic surface segmentations. This follows a discussion with @Lestropie and @satra in https://github.com/bids-standard/bids-specification/pull/265#discussion_r432816173. While there is a desire to specify here, I'm refraining from doing so. It can be added without breaking backwards compatibility in the future.
3) I also addressed @satra's https://github.com/bids-standard/bids-specification/pull/265#discussion_r432845797 while here.

Please read and let me know what you think.