### PR TITLE
ENH: Add RECOMMENDED DatasetType key to dataset description

### DIFF
--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -17,6 +17,7 @@ dataset MUST include this file with the following fields:
 | ------------------------------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Name               | REQUIRED. Name of the dataset.                                                                                                                                                                                                       |
 | BIDSVersion        | REQUIRED. The version of the BIDS standard that was used.                                                                                                                                                                            |
+| DatasetType        | RECOMMENDED. The interpretaton of the dataset. MUST be one of `"raw"` or `"derivative"`. For backwards compatibility, the default value is `"raw"`.                                                                                  |
 | License            | RECOMMENDED. What license is this dataset distributed under? The use of license name abbreviations is suggested for specifying a license. A list of common licenses with suggested abbreviations can be found in Appendix II.        |
 | Authors            | OPTIONAL. List of individuals who contributed to the creation/curation of the dataset.                                                                                                                                               |
 | Acknowledgements   | OPTIONAL. Text acknowledging contributions of individuals or institutions beyond those listed in Authors or Funding.                                                                                                                 |
@@ -31,7 +32,8 @@ Example:
 ```JSON
 {
   "Name": "The mother of all experiments",
-  "BIDSVersion": "1.0.1",
+  "BIDSVersion": "1.4.0",
+  "DatasetType": "raw",
   "License": "CC0",
   "Authors": [
     "Paul Broca",
@@ -86,6 +88,7 @@ Example:
 {
   "Name": "FMRIPREP Outputs",
   "BIDSVersion": "1.4.0",
+  "DatasetType": "derivative",
   "GeneratedBy": [
     {
       "Name": "fmriprep",


### PR DESCRIPTION
Last-minute addition to #265 (Common Derivatives).

This allows for unambiguous identification of raw or derivatives datasets by parsing a single file. This is needed because any feature of derivatives has the potential to be incorporated back into raw, unless it breaks backwards compatibility. In the extreme, it may only be possible to distinguish the two by determining whether a dataset validates as raw or as derivative.

cc @bids-standard/derivatives 