### PR TITLE
[FIX] Clarify language on unsetting a key/value pair

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -187,9 +187,10 @@ levels unless they are overridden by a file at the lower level. For example,
 TR to a specific value. If one of the runs has a different TR than the one
 specified in that file, another `sub-*_task-rest_bold.json` file can be placed
 within that specific series directory specifying the TR for that specific run.
-There is no notion of "unsetting" a key/value pair. Once a key/value pair is 
-set in a given level in the dataset, lower down in the hierarchy that 
-key/value pair will always have some assigned value. Files for a particular 
+There is no notion of "unsetting" a key/value pair.
+Once a key/value pair is set in a given level in the dataset, lower down in
+the hierarchy that key/value pair will always have some assigned value.
+Files for a particular 
 participant can exist only at participant level directory, i.e
 `/dataset/sub-*[/ses-*]/sub-*_T1w.json`. Similarly, any file that is not
 specific to a participant is to be declared only at top level of dataset for eg:

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -187,10 +187,9 @@ levels unless they are overridden by a file at the lower level. For example,
 TR to a specific value. If one of the runs has a different TR than the one
 specified in that file, another `sub-*_task-rest_bold.json` file can be placed
 within that specific series directory specifying the TR for that specific run.
-There is no notion of "unsetting" a key/value pair. There is no notion of 
-"unsetting" a key/value pair. Once a key/value pair is set in a given level in 
-the dataset, lower down in the hierarchy that key/value pair will always have 
-some assigned value. Files for a particular 
+There is no notion of "unsetting" a key/value pair. Once a key/value pair is 
+set in a given level in the dataset, lower down in the hierarchy that 
+key/value pair will always have some assigned value. Files for a particular 
 participant can exist only at participant level directory, i.e
 `/dataset/sub-*[/ses-*]/sub-*_T1w.json`. Similarly, any file that is not
 specific to a participant is to be declared only at top level of dataset for eg:

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -187,10 +187,10 @@ levels unless they are overridden by a file at the lower level. For example,
 TR to a specific value. If one of the runs has a different TR than the one
 specified in that file, another `sub-*_task-rest_bold.json` file can be placed
 within that specific series directory specifying the TR for that specific run.
-There is no notion of "unsetting" a key/value pair. For example if there is a
-JSON file corresponding to particular participant/run defining a key/value and
-there is a JSON file on the root level of the dataset that does not define this
-key/value it will not be "unset" for all subjects/runs. Files for a particular
+There is no notion of "unsetting" a key/value pair. There is no notion of 
+"unsetting" a key/value pair. Once a key/value pair is set in a given level in 
+the dataset, lower down in the hierarchy that key/value pair will always have 
+some assigned value. Files for a particular 
 participant can exist only at participant level directory, i.e
 `/dataset/sub-*[/ses-*]/sub-*_T1w.json`. Similarly, any file that is not
 specific to a participant is to be declared only at top level of dataset for eg:


### PR DESCRIPTION
closes #492 where @Lestropie observed that the current language on inheritance is very confusing.  

This small PR simply replaces this (common principles) text

> There is no notion of "unsetting" a key/value pair. For example if there is a JSON file corresponding to particular participant/run defining a key/value and there is a JSON file on the root level of the dataset that does not define this key/value it will not be "unset" for all subjects/runs.

with

> There is no notion of "unsetting" a key/value pair. Once a key/value pair is set in a given level in the dataset, lower down in the hierarchy that key/value pair will always have some assigned value.