### PR TITLE
[ENH] Update `beh/` specification to contrast with any neural recordings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ nav:
         - Intracranial Electroencephalography: 04-modality-specific-files/04-intracranial-electroencephalography.md
         - Task events: 04-modality-specific-files/05-task-events.md
         - Physiological and other continuous recordings: 04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
-        - Behavioral experiments (with no MRI): 04-modality-specific-files/07-behavioral-experiments.md
+        - Behavioral experiments (with no neural recordings): 04-modality-specific-files/07-behavioral-experiments.md
         - Genetic Descriptor: 04-modality-specific-files/08-genetic-descriptor.md
       - Derivatives:
         - BIDS Derivatives: 05-derivatives/01-introduction.md

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -1,4 +1,4 @@
-# Behavioral experiments (with no MRI)
+# Behavioral experiments (with no neural recordings)
 
 Template:
 
@@ -17,10 +17,12 @@ sub-<label>/[ses-<label>/]
 
 In addition to logs from behavioral experiments performed along imaging data
 acquisitions one can also include data from experiments performed outside of the
-scanner. The results of those experiments can be stored in the `beh` folder using
-the same formats for event timing (`_events.tsv`), metadata (`_events.json`),
-physiological (`_physio.tsv.gz`, `_physio.json`) and other continuous recordings
-(`_stim.tsv.gz`, `_stim.json`) as for tasks performed during MRI acquisitions.
+scanner.
+The results of those experiments can be stored in the `beh` folder using the same
+formats for event timing (`_events.tsv`), metadata (`_events.json`),
+physiological (`_physio.tsv.gz`, `_physio.json`)
+and other continuous recordings (`_stim.tsv.gz`, `_stim.json`)
+as for tasks performed during MRI, electrophysiological or other neural recordings.
 Additionally, events files that do not include the mandatory `onset` and
 `duration` columns can still be included, but should be labeled `_beh.tsv`
 rather than `_events.tsv`.

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -15,9 +15,9 @@ sub-<label>/[ses-<label>/]
         sub-<label>[_ses-<label>]_task-<label>_stim.json
 ```
 
-In addition to logs from behavioral experiments performed along imaging data
-acquisitions one can also include data from experiments performed outside of the
-scanner.
+In addition to logs from behavioral experiments performed alongside imaging data
+acquisitions, one can also include data from experiments performed with no neural
+recordings.
 The results of those experiments can be stored in the `beh` folder using the same
 formats for event timing (`_events.tsv`), metadata (`_events.json`),
 physiological (`_physio.tsv.gz`, `_physio.json`)


### PR DESCRIPTION
Reread the behavioral section in light of #513, and realized it's still written in reference to MRI and not electrophysiological or other recordings that we might end up specifying with an alternative data type directory.

Also tried to apply something like a semantic line-breaking scheme, but it wasn't 100% principled and can probably be improved if it seems important.