### PR TITLE
[FIX] clarify that scans.json is allowed and recommended

### DIFF
--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -351,15 +351,15 @@ scan.
 For example vigilance questionnaire score administered after a resting
 state scan.
 All such included additional fields SHOULD be documented in an accompanying
-`scans.json` file that describes these fields in detail
+`_scans.json` file that describes these fields in detail
 (see [Tabular files](02-common-principles.md#tabular-files)).
 
-Example `scans.tsv`:
+Example `_scans.tsv`:
 
 ```Text
-filename    acq_time
-func/sub-control01_task-nback_bold.nii.gz    1877-06-15T13:45:30
-func/sub-control01_task-motor_bold.nii.gz    1877-06-15T13:55:33
+filename	acq_time
+func/sub-control01_task-nback_bold.nii.gz	1877-06-15T13:45:30
+func/sub-control01_task-motor_bold.nii.gz	1877-06-15T13:55:33
 ```
 
 ## Code

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -327,13 +327,14 @@ Template:
 ```Text
 sub-<label>/[ses-<label>/]
     sub-<label>[_ses-<label>]_scans.tsv
+    sub-<label>[_ses-<label>]_scans.json    
 ```
 
 Optional: Yes
 
 The purpose of this file is to describe timing and other properties of each
-imaging acquisition sequence (each run `.nii[.gz]` file) within one session.
-Each `.nii[.gz]` file should be described by at most one row.
+imaging acquisition sequence (each *run* file) within one session.
+Each neural recording file should be described by at most one row.
 Relative paths to files should be used under a compulsory `filename` header.
 If acquisition time is included it should be under `acq_time` header.
 Datetime should be expressed as described in [Units](./02-common-principles.md#units).
@@ -349,13 +350,16 @@ Additional fields can include external behavioral measures relevant to the
 scan.
 For example vigilance questionnaire score administered after a resting
 state scan.
+All such included additional fields SHOULD be documented in an accompanying
+`scans.json` file that describes these fields in detail
+(see [Tabular files](02-common-principles.md#tabular-files)).
 
-Example:
+Example `scans.tsv`:
 
 ```Text
-filename  acq_time
-func/sub-control01_task-nback_bold.nii.gz 1877-06-15T13:45:30
-func/sub-control01_task-motor_bold.nii.gz 1877-06-15T13:55:33
+filename    acq_time
+func/sub-control01_task-nback_bold.nii.gz    1877-06-15T13:45:30
+func/sub-control01_task-motor_bold.nii.gz    1877-06-15T13:55:33
 ```
 
 ## Code


### PR DESCRIPTION
closes #450 

Explicitly say that `scans.json` is allowed and recommended if any arbitrary column beyond `filename` and `acq_time` are included.

As discussed in #450 this seems already to be controlled in the validator (to some extend) and reading the remaining spec, this particular style of handling "arbitrary columns" is not new --> thus, I see this rather as a clarification than an enhancement.

