### PR TITLE
[FIX] Clarify indices are nonnegative integers.

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -140,11 +140,11 @@ modalities include:
 
 #### The `run` entity
 
-If several scans of the same modality are acquired they MUST be indexed with a key-value pair:
-`_run-1`, `_run-2`, `_run-3` etc.
-(only nonnegative integers are allowed as run labels).
-When there is only one scan of a given type the run key MAY be omitted.
-Please note that diffusion imaging data is stored elsewhere (see below).
+If several scans of the same modality are acquired they MUST be indexed with a
+key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only nonnegative integers are allowed as
+run labels). When there is only one scan of a given type the run key MAY be
+omitted. Please note that diffusion imaging data is stored elsewhere (see
+below).
 
 #### The `acq` entity
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -140,11 +140,8 @@ modalities include:
 
 #### The `run` entity
 
-If several scans of the same modality are acquired they MUST be indexed with a
-key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only integers are allowed as
-run labels). When there is only one scan of a given type the run key MAY be
-omitted. Please note that diffusion imaging data is stored elsewhere (see
-below).
+If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only natural numbers are allowed as run labels). When there is only one scan of a given type the run key MAY be omitted. 
+Please note that diffusion imaging data is stored elsewhere (see below).
 
 #### The `acq` entity
 
@@ -264,7 +261,7 @@ sub-01/
 ```
 
 Please note that the `<index>` denotes the number/index (in a form of an
-integer) of the echo not the echo time value which needs to be stored in the
+natural number) of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 
 Some meta information about the acquisition MUST be provided in an additional

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -140,7 +140,7 @@ modalities include:
 
 #### The `run` entity
 
-If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only positive integers are allowed as run labels). When there is only one scan of a given type the run key MAY be omitted. 
+If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only integers are allowed as run labels, with indexing starting from 1 RECOMMENDED). When there is only one scan of a given type the run key MAY be omitted. 
 Please note that diffusion imaging data is stored elsewhere (see below).
 
 #### The `acq` entity
@@ -261,7 +261,7 @@ sub-01/
 ```
 
 Please note that the `<index>` denotes the number/index (in a form of an
-positive integer) of the echo not the echo time value which needs to be stored in the
+positive integer, with indexing starting from 1 RECOMMENDED) of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 
 Some meta information about the acquisition MUST be provided in an additional

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -140,7 +140,10 @@ modalities include:
 
 #### The `run` entity
 
-If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only positive integers are allowed as run labels, with indexing starting from 1 RECOMMENDED). When there is only one scan of a given type the run key MAY be omitted. 
+If several scans of the same modality are acquired they MUST be indexed with a key-value pair:
+`_run-1`, `_run-2`, `_run-3` etc.
+(only positive integers are allowed as run labels, with indexing starting from 1 RECOMMENDED).
+When there is only one scan of a given type the run key MAY be omitted.
 Please note that diffusion imaging data is stored elsewhere (see below).
 
 #### The `acq` entity
@@ -260,7 +263,9 @@ sub-01/
       sub-01_task-cuedSGT_run-1_echo-3_bold.json
 ```
 
-Please note that the `<index>` denotes the number/index (in a form of a positive integer, with indexing starting from 1 RECOMMENDED) of the echo not the echo time value which needs to be stored in the
+Please note that the `<index>` denotes the number/index
+(in a form of a positive integer, with indexing starting from 1 RECOMMENDED)
+of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 
 Some meta information about the acquisition MUST be provided in an additional

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -263,7 +263,7 @@ sub-01/
       sub-01_task-cuedSGT_run-1_echo-3_bold.json
 ```
 
-Please note that the `<index>` denotes the number/index (in a form of a
+Please note that the `<index>` denotes the number/index (in the form of a
 nonnegative integer) of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -140,7 +140,7 @@ modalities include:
 
 #### The `run` entity
 
-If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only natural numbers are allowed as run labels). When there is only one scan of a given type the run key MAY be omitted. 
+If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only positive integers are allowed as run labels). When there is only one scan of a given type the run key MAY be omitted. 
 Please note that diffusion imaging data is stored elsewhere (see below).
 
 #### The `acq` entity
@@ -261,7 +261,7 @@ sub-01/
 ```
 
 Please note that the `<index>` denotes the number/index (in a form of an
-natural number) of the echo not the echo time value which needs to be stored in the
+positive integer) of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 
 Some meta information about the acquisition MUST be provided in an additional

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -142,7 +142,7 @@ modalities include:
 
 If several scans of the same modality are acquired they MUST be indexed with a key-value pair:
 `_run-1`, `_run-2`, `_run-3` etc.
-(only positive integers are allowed as run labels, with indexing starting from 1 RECOMMENDED).
+(only nonnegative integers are allowed as run labels).
 When there is only one scan of a given type the run key MAY be omitted.
 Please note that diffusion imaging data is stored elsewhere (see below).
 
@@ -263,9 +263,8 @@ sub-01/
       sub-01_task-cuedSGT_run-1_echo-3_bold.json
 ```
 
-Please note that the `<index>` denotes the number/index
-(in a form of a positive integer, with indexing starting from 1 RECOMMENDED)
-of the echo not the echo time value which needs to be stored in the
+Please note that the `<index>` denotes the number/index (in a form of a
+nonnegative integer) of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 
 Some meta information about the acquisition MUST be provided in an additional

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -140,7 +140,7 @@ modalities include:
 
 #### The `run` entity
 
-If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only integers are allowed as run labels, with indexing starting from 1 RECOMMENDED). When there is only one scan of a given type the run key MAY be omitted. 
+If several scans of the same modality are acquired they MUST be indexed with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only positive integers are allowed as run labels, with indexing starting from 1 RECOMMENDED). When there is only one scan of a given type the run key MAY be omitted. 
 Please note that diffusion imaging data is stored elsewhere (see below).
 
 #### The `acq` entity
@@ -260,8 +260,7 @@ sub-01/
       sub-01_task-cuedSGT_run-1_echo-3_bold.json
 ```
 
-Please note that the `<index>` denotes the number/index (in a form of an
-positive integer, with indexing starting from 1 RECOMMENDED) of the echo not the echo time value which needs to be stored in the
+Please note that the `<index>` denotes the number/index (in a form of a positive integer, with indexing starting from 1 RECOMMENDED) of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 
 Some meta information about the acquisition MUST be provided in an additional


### PR DESCRIPTION
At present, zero is not excluded for run and echo indices.  Is this accidental or intended?

If zero's are excluded, this PR will make this explicit.

If zeros are to be discouraged, then perhaps we should say so?

