### PR TITLE
[FIX] Replace all non-breaking spaces with vanilla spaces

### DIFF
--- a/src/01-introduction.md
+++ b/src/01-introduction.md
@@ -64,5 +64,5 @@ as well as other papers describing specific BIDS extensions (see below).
 
 BIDS has also a
 [Research Resource Identifier (RRID)](https://www.force11.org/group/resource-identification-initiative)
--  `RRID:SCR_016124` - which you can also include in your manuscript in addition
+-   `RRID:SCR_016124` - which you can also include in your manuscript in addition
 to citing the paper.

--- a/src/01-introduction.md
+++ b/src/01-introduction.md
@@ -7,7 +7,7 @@ different ways. So far there is no consensus how to organize and share data
 obtained in neuroimaging experiments. Even two researchers working in the same
 lab can opt to arrange their data in a different way. Lack of consensus (or a
 standard) leads to misunderstandings and time wasted on rearranging data or
-rewriting scripts expecting certain structure. Here we describe a simple and
+rewriting scripts expecting certain structure. Here we describe a simple and
 easy-to-adopt way of organising neuroimaging and behavioral data. By using this
 standard you will benefit in the following ways:
 
@@ -18,9 +18,9 @@ standard you will benefit in the following ways:
     time. By using BIDS you will save time trying to understand and reuse data
     acquired by a graduate student or postdoc that has already left the lab.
 
--   There are a growing number of data analysis software packages that can
+-   There are a growing number of data analysis software packages that can
     understand data organised according to BIDS (see
-    [http://bids.neuroimaging.io](http://bids.neuroimaging.io) for the most up
+    [http://bids.neuroimaging.io](http://bids.neuroimaging.io) for the most up
     to date list).
 
 -   Databases such as OpenNeuro.org accept datasets organised according to BIDS.
@@ -64,5 +64,5 @@ as well as other papers describing specific BIDS extensions (see below).
 
 BIDS has also a
 [Research Resource Identifier (RRID)](https://www.force11.org/group/resource-identification-initiative)
-- `RRID:SCR_016124` - which you can also include in your manuscript in addition
+- `RRID:SCR_016124` - which you can also include in your manuscript in addition
 to citing the paper.

--- a/src/01-introduction.md
+++ b/src/01-introduction.md
@@ -64,5 +64,5 @@ as well as other papers describing specific BIDS extensions (see below).
 
 BIDS has also a
 [Research Resource Identifier (RRID)](https://www.force11.org/group/resource-identification-initiative)
-- `RRID:SCR_016124` - which you can also include in your manuscript in addition
+-  `RRID:SCR_016124` - which you can also include in your manuscript in addition
 to citing the paper.

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -9,11 +9,11 @@ interpreted as described in [[RFC2119](https://www.ietf.org/rfc/rfc2119.txt)].
 Throughout this specification we use a list of terms and abbreviations. To avoid
 misunderstanding we clarify them here.
 
-1.  **Dataset** - a set of neuroimaging and behavioral data acquired for a
+1.  **Dataset** - a set of neuroimaging and behavioral data acquired for a
     purpose of a particular study. A dataset consists of data acquired from one
     or more subjects, possibly from multiple sessions.
 
-1.  **Subject** - a person or animal participating in the study.  Used
+1.  **Subject** - a person or animal participating in the study.  Used
     interchangeably with term **Participant**.
 
 1.  **Session** - a logical grouping of neuroimaging and behavioral data
@@ -118,7 +118,7 @@ A summary of all entities in BIDS and the order in which they MUST be
 specified is available in the [entity table](./99-appendices/04-entity-table.md)
 in the appendix.
 
-## Source vs. raw vs. derived data
+## Source vs. raw vs. derived data
 
 BIDS was originally designed to describe and apply consistent naming conventions
 to raw (unprocessed or minimally processed due to file format conversion) data.
@@ -379,9 +379,9 @@ possible. Since the NIfTI standard offers limited support for the various image
 acquisition parameters available in DICOM files, we RECOMMEND that users provide
 additional meta information extracted from DICOM files in a sidecar JSON file
 (with the same filename as the `.nii[.gz]` file, but with a `.json` extension).
-Extraction of BIDS compatible metadata can be performed using [dcm2niix](https://github.com/rordenlab/dcm2niix)
+Extraction of BIDS compatible metadata can be performed using [dcm2niix](https://github.com/rordenlab/dcm2niix)
 and [dicm2nii](http://www.mathworks.com/matlabcentral/fileexchange/42997-dicom-to-nifti-converter/content/dicm2nii.m)
-DICOM to NIfTI converters. The [BIDS-validator](https://github.com/bids-standard/bids-validator)
+DICOM to NIfTI converters. The [BIDS-validator](https://github.com/bids-standard/bids-validator)
 will check for conflicts between the JSON file and the data recorded in the
 NIfTI header.
 
@@ -459,7 +459,7 @@ pairs. JSON files MUST be in UTF-8 encoding. Extensive documentation of the
 format can be found here: [http://json.org/](http://json.org/). Several editors
 have built-in support for JSON syntax highlighting that aids manual creation of
 such files. An online editor for JSON with built-in validation is available at:
-[http://jsoneditoronline.org](http://jsoneditoronline.org). 
+[http://jsoneditoronline.org](http://jsoneditoronline.org). 
 It is RECOMMENDED that keys in a JSON file are written in [CamelCase](https://en.wikipedia.org/wiki/Camel_case)
 with the first letter in upper case (e.g., `SamplingFrequency`, not
 `samplingFrequency`). Note however, when a JSON file is used as an accompanying
@@ -548,7 +548,7 @@ Describing dates and timestamps:
     SHOULD be consistent across the dataset.
     For example `2009-06-15T13:45:30`
 
--   Time stamp information MUST be expressed in the following format:
+-   Time stamp information MUST be expressed in the following format:
     `13:45:30[.000000]`
 
 -   Dates can be shifted by a random number of days for privacy protection
@@ -569,7 +569,7 @@ Describing dates and timestamps:
 ### Single session example
 
 This is an example of the folder and file structure. Because there is only one
-session, the session level is not required by the format. For details on
+session, the session level is not required by the format. For details on
 individual files see descriptions in the next section:
 
 ```Text

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -56,7 +56,7 @@ by Ben Inglis:
 "`BandwidthPerPixelPhaseEncode` in DICOM tag (0019,1028) and ReconMatrixPE is
 the size of the actual reconstructed data in the phase direction (which is NOT
 reflected in a single DICOM tag for all possible aforementioned scan
-manipulations). See [here](https://lcni.uoregon.edu/kb-articles/kb-0003) and
+manipulations). See [here](https://lcni.uoregon.edu/kb-articles/kb-0003) and
 [here](https://github.com/neurolabusc/dcm_qa/tree/master/In/TotalReadoutTime)
 
 <sup>3</sup>We use the "FSL definition", i.e, the time between the center of the
@@ -102,7 +102,7 @@ Useful for multimodal co-registration with MEG, (S)EEG, TMS, etc.
 | InstitutionAddress          | RECOMMENDED. The address of the institution in charge of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.               |
 | InstitutionalDepartmentName | RECOMMENDED. The department in the institution in charge of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`. |
 
-When adding additional metadata please use the CamelCase version of
+When adding additional metadata please use the CamelCase version of
 [DICOM ontology terms](https://scicrunch.org/scicrunch/interlex/dashboard)
 whenever possible. See also
 [recommendations on JSON files](../02-common-principles.md#keyvalue-files-dictionaries).
@@ -148,12 +148,12 @@ below).
 
 #### The `acq` entity
 
-The OPTIONAL `acq-<label>` key/value pair corresponds to a custom label the user
+The OPTIONAL `acq-<label>` key/value pair corresponds to a custom label the user
 MAY use to distinguish a different set of parameters used for acquiring the same
 modality. For example this should be used when a study includes two T1w images -
 one full brain low resolution and and one restricted field of view but high
 resolution. In such case two files could have the following names:
-`sub-01_acq-highres_T1w.nii.gz` and `sub-01_acq-lowres_T1w.nii.gz`, however the
+`sub-01_acq-highres_T1w.nii.gz` and `sub-01_acq-lowres_T1w.nii.gz`, however the
 user is free to choose any other label than `highres` and `lowres` as long as
 they are consistent across subjects and sessions. In case different sequences
 are used to record the same modality (e.g. RARE and FLASH for T1w) this field
@@ -249,7 +249,7 @@ reconstruction algorithms (for example ones using motion correction).
 See [`fmap` Case 4](01-magnetic-resonance-imaging-data.md#case-4-multiple-phase-encoded-directions-pepolar)
 for more information on `dir` field specification.
 
-Multi-echo data MUST be split into one file per echo. Each file shares the same
+Multi-echo data MUST be split into one file per echo. Each file shares the same
 name with the exception of the `_echo-<index>` key/value. For example:
 
 ```Text
@@ -267,7 +267,7 @@ Please note that the `<index>` denotes the number/index (in a form of an
 integer) of the echo not the echo time value which needs to be stored in the
 field EchoTime of the separate JSON file.
 
-Some meta information about the acquisition MUST be provided in an additional
+Some meta information about the acquisition MUST be provided in an additional
 JSON file.
 
 #### Required fields
@@ -351,10 +351,10 @@ sub-control01/
 ```
 
 If this information is the same for all participants, sessions and runs it can
-be provided in `task-<label>_bold.json` (in the root directory of the
+be provided in `task-<label>_bold.json` (in the root directory of the
 dataset). However, if the information differs between subjects/runs it can be
 specified in the
-`sub-<label>/func/sub-<label>_task-<label>[_acq-<label>][_run-<index>]_bold.json` file.
+`sub-<label>/func/sub-<label>_task-<label>[_acq-<label>][_run-<index>]_bold.json` file.
 If both files are specified fields from the file corresponding to a particular
 participant, task and run takes precedence.
 
@@ -569,7 +569,7 @@ specified in the corresponding JSON file as one of: `i`, `j`, `k`, `i-`, `j-`,
 `k-`. For these differentially phase encoded sequences, one also needs to
 specify the Total Readout Time defined as the time (in seconds) from the center
 of the first echo to the center of the last echo (aka "FSL definition" - see
-[here](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/topup/Faq#How_do_I_know_what_phase-encode_vectors_to_put_into_my_--datain_text_file.3F) and
+[here](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/topup/Faq#How_do_I_know_what_phase-encode_vectors_to_put_into_my_--datain_text_file.3F) and
 [here](https://lcni.uoregon.edu/kb-articles/kb-0003) how to calculate it). For
 example
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -141,7 +141,7 @@ Example:
 ```JSON
 {
    "InstitutionName": "Stanford University",
-   "InstitutionAddress": "450 Serra Mall, Stanford, CA 94305-2004, USA",
+   "InstitutionAddress": "450 Serra Mall, Stanford, CA 94305-2004, USA",
    "Manufacturer": "CTF",
    "ManufacturersModelName": "CTF-275",
    "DeviceSerialNumber": "11035",
@@ -173,7 +173,7 @@ Note that the date and time information SHOULD be stored in the Study key file
 (`scans.tsv`), see [Scans file](../03-modality-agnostic-files.md#scans-file). As
 it is indicated there, date time information MUST be expressed in the following
 format `YYYY-MM-DDThh:mm:ss`
-([ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date-time format). For
+([ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date-time format). For
 example: 2009-06-15T13:45:30. It does not need to be fully detailed, depending
 on local REB/IRB ethics board policy.
 
@@ -226,7 +226,7 @@ UDIO001 TRIG V analogue trigger 1200  0.1 300 0 n/a good
 MLC11 MEGGRADAXIAL T sensor 1st-order grad 1200 0 n/a 50 SSS bad
 ```
 
-Restricted keyword list for field `type`
+Restricted keyword list for field `type`
 
 | Keyword          | Definition                                           |
 | ---------------- | ---------------------------------------------------- |
@@ -259,7 +259,7 @@ Restricted keyword list for field `type`
 | FITERR           | Fit error signal from each head localization coil    |
 | OTHER            | Any other type of channel                            |
 
-Example of free text for field `description`
+Example of free text for field `description`
 
 -   stimulus, response, vertical EOG, horizontal EOG, skin conductance, sats,
     intracranial, eyetracker
@@ -353,10 +353,10 @@ Fiducials information:
 | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | FiducialsDescription | OPTIONAL. A freeform text field documenting the anatomical landmarks that were used and how the head localization coils were placed relative to these. This field can describe, for instance, whether the true anatomical locations of the left and right pre-auricular points were used and digitized, or rather whether they were defined as the intersection between the tragus and the helix (the entry of the ear canal), or any other anatomical description of selected points in the vicinity of the ears. |
 
-For more information on the definition of anatomical landmarks, please visit:
+For more information on the definition of anatomical landmarks, please visit:
 [http://www.fieldtriptoolbox.org/faq/how_are_the_lpa_and_rpa_points_defined](http://www.fieldtriptoolbox.org/faq/how_are_the_lpa_and_rpa_points_defined)
 
-For more information on typical coordinate systems for MEG-MRI coregistration:
+For more information on typical coordinate systems for MEG-MRI coregistration:
 [http://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined](http://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined),
 or:
 [http://neuroimage.usc.edu/brainstorm/CoordinateSystems](http://neuroimage.usc.edu/brainstorm/CoordinateSystems)
@@ -405,10 +405,10 @@ sub-<label>/
 This file is RECOMMENDED.
 
 The 3-D locations of points that describe the head shape and/or EEG
-electrode locations can be digitized and stored in separate files. The
+electrode locations can be digitized and stored in separate files. The
 `*_acq-<label>` can be used when more than one type of digitization in done for
 a session, for example when the head points are in a separate file from the EEG
-locations. These files are stored in the specific format of the 3-D digitizer’s
+locations. These files are stored in the specific format of the 3-D digitizer’s
 manufacturer (see [Appendix VI](../99-appendices/06-meg-file-formats.md)).
 
 Example:
@@ -422,7 +422,7 @@ sub-control01
 
 Note that the `*_headshape` file(s) is shared by all the runs and tasks in a
 session. If the subject needs to be taken out of the scanner and the head-shape
-has to be updated, then for MEG it could be considered to be a new session.
+has to be updated, then for MEG it could be considered to be a new session.
 
 ## Empty-room MEG recordings
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -186,7 +186,7 @@ Note that the date and time information SHOULD be stored in the Study key file
 ([`scans.tsv`](../03-modality-agnostic-files.md#scans-file)). As it is
 indicated there, date time information MUST be expressed in the following
 format `YYYY-MM-DDThh:mm:ss`
-([ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date-time format). For
+([ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date-time format). For
 example: 2009-06-15T13:45:30. It does not need to be fully detailed, depending
 on local REB/IRB ethics board policy.
 
@@ -235,7 +235,7 @@ SHOULD be present:
 | status             | OPTIONAL. Data quality observed on the channel `(good/bad)`. A channel is considered `bad` if its data quality is compromised by excessive noise. Description of noise type SHOULD be provided in `[status_description]`.                                                     |
 | status_description | OPTIONAL. Free-form text description of noise or artifact affecting data quality on the channel. It is meant to explain why the channel was declared bad in `[status]`.                                                                                                       |
 
-Restricted keyword list for field `type` in alphabetic order (shared with the
+Restricted keyword list for field `type` in alphabetic order (shared with the
 MEG and iEEG modality; however, only the types that are common in EEG data are listed here):
 
 | Keyword  | Description                                                  |
@@ -361,7 +361,7 @@ landmarks, or the placement of LEDs on the nasion and preauricular points to
 triangulate the position of other LED-lit electrodes on a research subject's
 head.
 
--   For more information on the definition of anatomical landmarks, please visit:
+-   For more information on the definition of anatomical landmarks, please visit:
     [http://www.fieldtriptoolbox.org/faq/how_are_the_lpa_and_rpa_points_defined](http://www.fieldtriptoolbox.org/faq/how_are_the_lpa_and_rpa_points_defined)
 
 -   For more information on coordinate systems for coregistration, please visit:

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -203,7 +203,7 @@ Note that the date and time information SHOULD be stored in the Study key file
 ([`scans.tsv`](../03-modality-agnostic-files.md#scans-file)). As it is indicated
 there, date time information MUST be expressed in the following format
 `YYYY-MM-DDThh:mm:ss`
-([ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date-time format). For
+([ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date-time format). For
 example: 2009-06-15T13:45:30. It does not need to be fully detailed, depending
 on local REB/IRB ethics board policy.
 

--- a/src/99-appendices/04-entity-table.md
+++ b/src/99-appendices/04-entity-table.md
@@ -1,7 +1,7 @@
 # Appendix IV: Entity table
 
 This section compiles the entities (key-value pairs) described throughout this
-specification, and establishes a common order within a filename. For example, if
+specification, and establishes a common order within a filename. For example, if
 a file has an acquisition and reconstruction label, the acquisition entity must
 precede the reconstruction entity. REQUIRED and OPTIONAL entities for a given
 file type are denoted. Entity formats indicate whether the value is alphanumeric

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -6,7 +6,7 @@ RECOMMENDED values for `manufacturer_specific_extensions`:
 | Value                                                 | Definition                                                                            |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [`ctf`](06-meg-file-formats.md#ctf)                   | CTF (folder with `.ds` extension)                                                     |
-| [`fif`](06-meg-file-formats.md#neuromagelektamegin)   | Neuromag / Elekta / MEGIN and BabyMEG (file with extension `.fif`)                   |
+| [`fif`](06-meg-file-formats.md#neuromagelektamegin)   | Neuromag / Elekta / MEGIN and BabyMEG (file with extension `.fif`)                    |
 | [`4d`](06-meg-file-formats.md#bti4d-neuroimaging)     | BTi / 4D Neuroimaging (folder containing multiple files without extensions)           |
 | [`kit`](06-meg-file-formats.md#kityokogawaricoh)      | KIT / Yokogawa / Ricoh (file with extension `.sqd`, `.con`, `.raw`, `.ave` or `.mrk`) |
 | [`kdf`](06-meg-file-formats.md#kriss)                 | KRISS (file with extension `.kdf`)                                                    |

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -6,7 +6,7 @@ RECOMMENDED values for `manufacturer_specific_extensions`:
 | Value                                                 | Definition                                                                            |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [`ctf`](06-meg-file-formats.md#ctf)                   | CTF (folder with `.ds` extension)                                                     |
-| [`fif`](06-meg-file-formats.md#neuromagelektamegin)   | Neuromag / Elekta / MEGIN  and BabyMEG (file with extension `.fif`)                   |
+| [`fif`](06-meg-file-formats.md#neuromagelektamegin)   | Neuromag / Elekta / MEGIN and BabyMEG (file with extension `.fif`)                   |
 | [`4d`](06-meg-file-formats.md#bti4d-neuroimaging)     | BTi / 4D Neuroimaging (folder containing multiple files without extensions)           |
 | [`kit`](06-meg-file-formats.md#kityokogawaricoh)      | KIT / Yokogawa / Ricoh (file with extension `.sqd`, `.con`, `.raw`, `.ave` or `.mrk`) |
 | [`kdf`](06-meg-file-formats.md#kriss)                 | KRISS (file with extension `.kdf`)                                                    |
@@ -47,7 +47,7 @@ sub-control01/
             sub-control01_ses-001_task-rest_run-01_channels.tsv
 ```
 
-To learn more about  CTF’s data organization:
+To learn more about CTF’s data organization:
 [http://www.fieldtriptoolbox.org/getting_started/ctf](http://www.fieldtriptoolbox.org/getting_started/ctf)
 
 ## Neuromag/Elekta/MEGIN

--- a/src/99-appendices/07-meg-systems.md
+++ b/src/99-appendices/07-meg-systems.md
@@ -11,7 +11,7 @@ Perferred names of MEG systems comprise restricted keywords for Manufacturer fie
 -   [`Aalto/MEG-MRI`](06-meg-file-formats.md#aalto-megmri)
 -   `Other`
 
-Restricted keywords for ManufacturersModelName field in the `*_meg.json` file:
+Restricted keywords for ManufacturersModelName field in the `*_meg.json` file:
 
 | System Model Name     | Manufacturer          | Details                                                                                      |
 |--------------------------------------------------------------------------------- | -----------------------------------------------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -50,7 +50,7 @@ restricted keywords, as listed in the sections below. If no value from the list
 of restricted keywords fits, there is always the option to specify the value as
 follows:
 
--   `Other`: Use this for other coordinate systems and specify further details
+-   `Other`: Use this for other coordinate systems and specify further details
     in the `XXXCoordinateSystemDescription` field
 
 ## MEG Specific Coordinate Systems
@@ -58,10 +58,10 @@ follows:
 Restricted keywords for the `XXXCoordinateSystem` field in the
 `coordinatesystem.json` file for MEG datasets:
 
--   `CTF`: ALS orientation and the origin between the ears
+-   `CTF`: ALS orientation and the origin between the ears
 -   `ElektaNeuromag`: RAS orientation and the origin between the ears
 -   `4DBti`: ALS orientation and the origin between the ears
--   `KitYokogawa`: ALS orientation and the origin between the ears
+-   `KitYokogawa`: ALS orientation and the origin between the ears
 -   `ChietiItab`: RAS orientation and the origin between the ears
 
 Note that the short descriptions above do not capture all details, There are


### PR DESCRIPTION
This PR replaces all non-breaking spaces with spaces (or deletes them if they were adjacent to a space).

As far as I could tell, none of these non-breaking spaces occurred with purpose, but were rather accidental. (Only purpose I can think of is to avoid a number getting separated from a unit, but they have not been used in this way so far in the BIDS spec.)

I realise it doesn't really matter, but my editor highlights them and, in the spirit of keeping clean and simple ascii markdown, I thought they should go.

(For reference these were found with `grep $'\xc2\xa0' *.md`)