### PR TITLE
FIX: clarify that <physio|stim>.json is REQUIRED

### DIFF
--- a/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
+++ b/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
@@ -37,6 +37,9 @@ continuous measures (such as parameters of a film or audio stimuli) can be
 specified using two files: a gzip compressed TSV file with data (without header
 line) and a JSON for storing the following metadata fields:
 
+Note that when supplying a `*_<physio|stim>.tsv.gz` file, an accompanying
+`*_<physio|stim>.json` MUST be supplied as well.
+
 | Field name        | Definition                                                                                                                                                          |
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | SamplingFrequency | REQUIRED. Sampling frequency in Hz of all columns in the file.                                                                                                      |


### PR DESCRIPTION
crossref:
- https://github.com/bids-standard/bids-validator/issues/1024
- https://github.com/bids-standard/bids-examples/issues/186

I think my proposed change here is already implicit in the specification.

When a TSV is supplied, a JSON MUST be included as well.

Because in _physio or _stim files, the file headers of the TSV are stripped and are shipped in the sidecar JSON.

So if a TSV is supplied but no JSON, the TSV becomes meaningless, because nobody knows about the columns anymore.

This will also have to be checked in the validator bids-standard/bids-validator#1024