### PR TITLE
[ENH] added PPG as an accepted channel type for EEG, MEG and iEEG

### DIFF
--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -246,6 +246,7 @@ Note that upper-case is REQUIRED:
 | GSR      | Galvanic skin response                                       |
 | HEOG     | Horizontal EOG (eye)                                         |
 | MISC     | Miscellaneous                                                |
+| PPG      | Photoplethysmography                                         |
 | PUPIL    | Eye tracker pupil diameter                                   |
 | REF      | Reference channel                                            |
 | RESP     | Respiration                                                  |


### PR DESCRIPTION
See #561 and https://github.com/bids-standard/bids-examples/pull/197#discussion_r469153788

This does not close ... #561 since I think that the ACCEL requires some more thought and discussion with other stakeholders. 
