### PR TITLE
[ENH] Specify echo and run indices are nonnegative integers in schema

### DIFF
--- a/src/schema/entities.yaml
+++ b/src/schema/entities.yaml
@@ -75,8 +75,8 @@ run:
   name: Run
   description: |
     If several scans of the same modality are acquired they MUST be indexed
-    with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only nonnegative
-    integers are allowed as run labels).
+    with a key-value pair: `_run-1`, `_run-2`, ..., `_run-<index>`
+    (only nonnegative integers are allowed for the `<index>`).
     When there is only one scan of a given type the run key MAY be omitted.
   format: index
 mod:

--- a/src/schema/entities.yaml
+++ b/src/schema/entities.yaml
@@ -94,7 +94,7 @@ echo:
     key/value.
     Please note that the `<index>` denotes the number/index (in the form of a
     nonnegative integer) of the echo not the echo time value which needs to be
-    stored in the field EchoTime of the separate JSON file.
+    stored in the field `EchoTime` of the separate JSON file.
   format: index
 recording:
   name: Recording

--- a/src/schema/entities.yaml
+++ b/src/schema/entities.yaml
@@ -75,10 +75,9 @@ run:
   name: Run
   description: |
     If several scans of the same modality are acquired they MUST be indexed
-    with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only integers
-    are allowed as run labels).
+    with a key-value pair: `_run-1`, `_run-2`, `_run-3` etc. (only nonnegative
+    integers are allowed as run labels).
     When there is only one scan of a given type the run key MAY be omitted.
-    Please note that diffusion imaging data is stored elsewhere (see below).
   format: index
 mod:
   name: Corresponding Modality
@@ -93,6 +92,9 @@ echo:
     Multi-echo data MUST be split into one file per echo.
     Each file shares the same name with the exception of the `_echo-<index>`
     key/value.
+    Please note that the `<index>` denotes the number/index (in the form of a
+    nonnegative integer) of the echo not the echo time value which needs to be
+    stored in the field EchoTime of the separate JSON file.
   format: index
 recording:
   name: Recording


### PR DESCRIPTION
This incorporates the changes in #535 to the definitions for the `echo` and `run` entities to the schema. I should have commented directly on #535 about this, but I didn't think of it until this morning.