### PR TITLE
[ENH] Specify how to share cross-talk and fine-calibration for Neuromag/Elekta/MEGIN data

### DIFF
--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -52,10 +52,10 @@ To learn more about CTF’s data organization:
 
 ## Neuromag/Elekta/MEGIN
 
-Neuromag/Elekta/MEGIN data and Tristan Technologies BabyMEG data is stored with
-file extension `.fif`. The digitized positions of the head points are saved
-inside the fif file along with the MEG data, with typically no `_headshape`
-file.
+Neuromag/Elekta/MEGIN and Tristan Technologies BabyMEG data is stored as
+FIFF files with the extension `.fif`. The digitized positions of the head
+points are saved inside the fif file along with the MEG data, with typically no
+`_headshape` file.
 
 ```Text
 sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_meg.fif
@@ -63,12 +63,14 @@ sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_meg.fif
 
 ### Cross-talk and fine-calibration files
 
-All raw fif files need to be processed using Maxwell filtering to make them usable.
+Raw FIFF files typically need to be processed using Maxwell filtering
+(signal-space separation, SSS) to make the data usable.
 To this end, two specific files are needed:
 The *cross-talk* file, and the *fine-calibration* file,
-both of which result from the Neuromag software
+both of which are produced by the MaxFilter software
 and the work of the Neuromag/Elekta/MEGIN engineers during maintenance of the MEG acquisition system.
-Both files are thus specific to the site of recording and nearest date of maintenance.
+Both files are thus specific to the site of recording and may change in the
+process of regular system maintenance.
 
 In BIDS, the cross-talk and fine-calibration files are shared unmodified,
 but with BIDS file naming convention and by using the `acq` entity.
@@ -98,11 +100,11 @@ sub-control01/
             sub-control01_ses-001_task-rest_run-01_channels.tsv
 ```
 
-### Sharing fif data *after* Maxwell filtering
+### Sharing FIFF data *after* Maxwell filtering
 
-After applying Maxwell filtering (e.g., by using the MaxFilter pre-processing tool),
+After applying Maxwell filtering (e.g., by using the MaxFilter software),
 files should be renamed with the corresponding label (e.g., `proc-sss`)
-and placed into a `derivatives` subfolder.
+and placed in a `derivatives` subfolder.
 
 Example:
 
@@ -129,7 +131,7 @@ names with dedicated tools like [MNE](https://mne.tools), which will ensure
 that not only the file names, but also the internal file pointers will be
 updated.
 
-It is RECOMMENDED that `.fif` files with multiple parts use the `split-<index>`
+It is RECOMMENDED that FIFF files with multiple parts use the `split-<index>`
 entity to indicate each part.
 
 Example:

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -104,7 +104,7 @@ sub-control01/
 ### Sharing FIFF data after signal-space separation (SSS)
 
 After applying SSS (e.g., by using the MaxFilter software),
-files should be renamed with the corresponding label (e.g., `proc-sss`)
+files SHOULD be renamed with the corresponding label (e.g., `proc-sss`)
 and placed in a `derivatives` subfolder.
 
 Example:

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -86,7 +86,7 @@ By making use of the [Inheritance Principle](../02-common-principles.md#the-inhe
 the cross-talk and fine-calibration data can be stored at any level of nesting within the BIDS dataset.
 For example for each session, or only once for a whole dataset.
 
-Example fif dataset with cross-talk and fine-calibration files stored once at the dataset root:
+Example FIFF dataset with cross-talk and fine-calibration files stored once at the dataset root:
 
 ```Text
 acq-crosstalk_meg.dat

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -77,10 +77,10 @@ In BIDS, the cross-talk and fine-calibration files are shared unmodified,
 but with BIDS file naming convention and by using the `acq` entity.
 
 -   cross-talk file template: `[sub-<label>][_ses-<label>][_]acq-crosstalk_meg.dat`
--   fine-calibration file template: `[sub-<label>][_ses-<label>][_]acq-finecalib_meg.fif`
+-   fine-calibration file template: `[sub-<label>][_ses-<label>][_]acq-calibration_meg.fif`
 
 Note that cross-talk files MUST be denoted using `acq-crosstalk` and
-fine-calibration files MUST be denoted using `acq-finecalib`.
+fine-calibration files MUST be denoted using `acq-calibration`.
 
 By making use of the [Inheritance Principle](../02-common-principles.md#the-inheritance-principle),
 the cross-talk and fine-calibration data can be stored at any level of nesting within the BIDS dataset.
@@ -89,8 +89,8 @@ For example for each session, or only once for a whole dataset.
 Example fif dataset with cross-talk and fine-calibration files stored once at the dataset root:
 
 ```Text
-acq_crosstalk_meg.dat
-acq_finecalib_meg.fif
+acq-crosstalk_meg.dat
+acq-calibration_meg.fif
 sub-control01/
     ses-001/
         sub-control01_ses-001_scans.tsv

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -73,18 +73,22 @@ Both files are thus specific to the site of recording and nearest date of mainte
 In BIDS, the cross-talk and fine-calibration files are shared unmodified,
 but with BIDS file naming convention and by using the `acq` entity.
 
--   cross-talk file example: `sub-01_task-rest_acq-crosstalk_meg.dat`
--   fine-calibration file example: `sub-01_task-rest_acq-finecalibration_meg.fif`
+
+-   cross-talk file template: `[sub-<label>][_ses-<label>][_]acq-crosstalk_meg.dat`
+-   fine-calibration file template: `[sub-<label>][_ses-<label>][_]acq-finecalib_meg.fif`
+
+Note that cross-talk files MUST be denoted using `acq-crosstalk` and
+fine-calibration files MUST be denoted using `acq-finecalib`.
 
 By making use of the [Inheritance Principle](../02-common-principles.md#the-inheritance-principle),
 the cross-talk and fine-calibration data can be stored at any level of nesting within the BIDS dataset.
-For example for each subject and task, or for each session, or only once for a whole dataset.
+For example for each session, or only once for a whole dataset.
 
-Example fif dataset:
+Example fif dataset with cross-talk and fine-calibration files stored once at the dataset root:
 
 ```Text
 acq_crosstalk_meg.dat
-acq_finecalibration_meg.fif
+acq_finecalib_meg.fif
 sub-control01/
     ses-001/
         sub-control01_ses-001_scans.tsv

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -73,7 +73,6 @@ Both files are thus specific to the site of recording and nearest date of mainte
 In BIDS, the cross-talk and fine-calibration files are shared unmodified,
 but with BIDS file naming convention and by using the `acq` entity.
 
-
 -   cross-talk file template: `[sub-<label>][_ses-<label>][_]acq-crosstalk_meg.dat`
 -   fine-calibration file template: `[sub-<label>][_ses-<label>][_]acq-finecalib_meg.fif`
 

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -54,7 +54,7 @@ To learn more about CTF’s data organization:
 
 Neuromag/Elekta/MEGIN and Tristan Technologies BabyMEG data is stored as
 FIFF files with the extension `.fif`. The digitized positions of the head
-points are saved inside the fif file along with the MEG data, with typically no
+points are saved inside the FIFF file along with the MEG data, with typically no
 `_headshape` file.
 
 ```Text

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -61,12 +61,31 @@ file.
 sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_meg.fif
 ```
 
-Note that we do not provide specifications for cross-talk and
-fine-calibration matrix files in the current version of BIDS.
+### Cross-talk and fine-calibration files
 
-Example:
+All raw fif files need to be processed using Maxwell filtering to make them usable.
+To this end, two specific files are needed:
+The *cross-talk* file, and the *fine-calibration* file,
+both of which result from the Neuromag software
+and the work of the Neuromag/Elekta/MEGIN engineers during maintenance of the MEG acquisition system.
+Both files are thus specific to the site of recording and nearest date of maintenance.
+
+In BIDS, the cross-talk and fine-calibration files are shared unmodified,
+but with BIDS file naming convention and by using the `acq` entity.
+
+-   cross-talk file example: `sub-01_task-rest_acq-crosstalk_meg.dat`
+-   fine-calibration file example: `sub-01_task-rest_acq-finecalibration_meg.fif`
+
+By making use of the [Inheritance Principle](../02-common-principles.md#the-inheritance-principle),
+the cross-talk and fine-calibration data can be stored at any level of nesting within the BIDS dataset.
+For example for each subject and task, or for each session, or only once for a whole dataset.
+
+
+Example fif dataset:
 
 ```Text
+acq_crosstalk_meg.dat
+acq_finecalibration_meg.fif
 sub-control01/
     ses-001/
         sub-control01_ses-001_scans.tsv
@@ -77,9 +96,11 @@ sub-control01/
             sub-control01_ses-001_task-rest_run-01_channels.tsv
 ```
 
-After applying the MaxFilter pre-processing tool, files should be renamed with
-the corresponding label (e.g., `proc-sss`) and placed into a `derivatives`
-subfolder.
+# Sharing fif data *after* Maxwell filtering
+
+After applying Maxwell filtering (e.g., by using the MaxFilter pre-processing tool),
+files should be renamed with the corresponding label (e.g., `proc-sss`)
+and placed into a `derivatives` subfolder.
 
 Example:
 
@@ -88,8 +109,11 @@ sub-control01_ses-001_task-rest_run-01_proc-sss_meg.fif
 sub-control01_ses-001_task-rest_run-01_proc-sss_meg.json
 ```
 
+### Split files
+
 In the case of long data recordings that exceed a file size of 2Gb, the `.fif`
-files are conventionally split into multiple parts. For example:
+files are conventionally split into multiple parts.
+For example:
 
 ```Text
 some_file.fif
@@ -118,7 +142,7 @@ More information can be found under the following links:
 -   [Neuromag/Elekta/MEGIN data organization](http://www.fieldtriptoolbox.org/getting_started/neuromag)
 -   [BabyMEG](http://www.fieldtriptoolbox.org/getting_started/babysquid)
 
-### recording dates in `.fif` files
+### Recording dates in `.fif` files
 
 It is important to note that recording dates in `.fif` files are represented
 as `int32` format seconds since (or before) [*the Epoch*](https://en.wikipedia.org/wiki/Unix_time)

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -80,7 +80,6 @@ By making use of the [Inheritance Principle](../02-common-principles.md#the-inhe
 the cross-talk and fine-calibration data can be stored at any level of nesting within the BIDS dataset.
 For example for each subject and task, or for each session, or only once for a whole dataset.
 
-
 Example fif dataset:
 
 ```Text
@@ -96,7 +95,7 @@ sub-control01/
             sub-control01_ses-001_task-rest_run-01_channels.tsv
 ```
 
-# Sharing fif data *after* Maxwell filtering
+### Sharing fif data *after* Maxwell filtering
 
 After applying Maxwell filtering (e.g., by using the MaxFilter pre-processing tool),
 files should be renamed with the corresponding label (e.g., `proc-sss`)

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -63,7 +63,8 @@ sub-<label>[_ses-<label>]_task-<label>[_run-<index>]_meg.fif
 
 ### Cross-talk and fine-calibration files
 
-Raw FIFF files typically need to be processed using Maxwell filtering
+In case internal active shielding (IAS) was used during acquisition, raw FIFF
+files need to be processed using Maxwell filtering
 (signal-space separation, SSS) to make the data usable.
 To this end, two specific files are needed:
 The *cross-talk* file, and the *fine-calibration* file,
@@ -100,9 +101,9 @@ sub-control01/
             sub-control01_ses-001_task-rest_run-01_channels.tsv
 ```
 
-### Sharing FIFF data *after* Maxwell filtering
+### Sharing FIFF data after signal-space separation (SSS)
 
-After applying Maxwell filtering (e.g., by using the MaxFilter software),
+After applying SSS (e.g., by using the MaxFilter software),
 files should be renamed with the corresponding label (e.g., `proc-sss`)
 and placed in a `derivatives` subfolder.
 


### PR DESCRIPTION
This is a proposal on how cross-talk and fine-calibration files can be shared using BIDS.

Both files are necessary to make Neuromag/Elekta/MEGIN data usable, more information can be found in these threads:

1. https://github.com/mne-tools/mne-bids/issues/495 ... including a comprehensive discussion about implementation options
1. https://github.com/bids-standard/bids-examples/issues/56 ... basically pointing out the issue many months ago

The proposed solution would require validator adjustments:

1. `.dat` becomes a valid extension for MEG data ... but ONLY if `acq-crosstalk` is part of the file name
1. not sure if we need any adjustments for `*_acq-finecalibration_meg.fif`

Disclaimer: I never worked with Neuromag/Elekta/MEGIN data

Attention needed:

1. is what I am writing in the text correct? I basically took it from comments by @robertoostenveld @jasmainak and @hoechenberger 
1. is it fine to simply rename the dat and fif files without breaking any internal structures?
1. do you agree that this is a reasonable way to enable sharing of these apparently crucial files?

@bids-standard/raw-electrophys-meg @agramfort @larsoner @guiomar 