### PR TITLE
[FIX] Adjust index definition to be nonnegative integer

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -57,7 +57,7 @@ misunderstanding we clarify them here.
     due to different subject response or randomized nature of the stimuli). Run
     is a synonym of a data acquisition.
 
-1.  **`<index>`** - a numeric value, possibly prefixed with arbitrary number of
+1.  **`<index>`** - a nonnegative integer, possibly prefixed with arbitrary number of
     0s for consistent indentation, e.g., it is `01` in `run-01` following
     `run-<index>` specification.
 


### PR DESCRIPTION
Micro PR, making the edit suggested in #589, finishing work started in #535, updating definition of `<index>` to clarify that it is a nonnegative integer.

closes #589 