### PR TITLE
[INFRA] downgrade github-changelog-generator to 1.14.3 due to issue with 1.15.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
   github-changelog-generator:
     working_directory: ~/build
     docker:
-      - image: ferrarimarco/github-changelog-generator:1.15.2
+      - image: ferrarimarco/github-changelog-generator:1.14.3
     steps:
       - setup_remote_docker:
            version: 18.06.0-ce


### PR DESCRIPTION
Due to `--since-tag` issue.

- See: https://github.com/bids-standard/bids-specification/pull/594#issuecomment-688709082
- And investigation here: https://gitter.im/github-changelog-generator/chat?at=5f57456cec534f584fedf00d

This param gets automatically set when using `--base` (which we do), because the "base" file gets parsed for versions.
In our case, the latest version in "base" (pregh-changes.md) happens to be `1.1.1`,
and then `--since-tag` is automatically set to `1.1.1` and that tag
cannot be found in the repository, because we never tagged such a
version in git.

Alternative options next to downgrading github-changelog-generator
are:

- to make a PR against github-changelog-generator and add
an option that allows explicitly setting `--since-tag` to None, or
- tagging the first commit of the bids-specification repository
as `1.1.1`, however the latter would be a weird hack.
