### PR TITLE
[ENH] Describe arbitrary units in Common Principles

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -544,7 +544,7 @@ For additional rules, see below:
 
 -   Frequency SHOULD be expressed in Hertz.
 
--   Arbitrary/unitless units SHOULD be represented with the format `arbitrary`.
+-   Arbitrary units SHOULD be indicated with the string `"arbitrary"`.
 
 Describing dates and timestamps:
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -544,6 +544,8 @@ For additional rules, see below:
 
 -   Frequency SHOULD be expressed in Hertz.
 
+-   Arbitrary/unitless units SHOULD be represented with the format `arbitrary`.
+
 Describing dates and timestamps:
 
 -   Date time information MUST be expressed in the following format


### PR DESCRIPTION
Closes #580. Although I considered adding something to Appendix 5 (Units), it didn't seem to fit well with the contents of the Appendix, so I've limited this change to a single list item in Common Principles#Units.

Changes proposed:

- Add an item to the additional rules list in Common Principes#Units describing how arbitrary units/unitless data should be handled.