### PR TITLE
[FIX] Change wrong text references from *CoordinateSystemUnits to *CoordinateUnits

### DIFF
--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -282,7 +282,7 @@ sub-<label>/
 
 File that gives the location of EEG electrodes. Note that coordinates are
 expected in cartesian coordinates according to the `EEGCoordinateSystem` and
-`EEGCoordinateSystemUnits` fields in `*_coordsystem.json`. **If an
+`EEGCoordinateUnits` fields in `*_coordsystem.json`. **If an
 `*_electrodes.tsv` file is specified, a [`*_coordsystem.json`](#coordinate-system-json-_coordsystemjson)
 file MUST be specified as well**. The order of the required columns in the
 `*_electrodes.tsv` file MUST be as listed below.

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -307,7 +307,7 @@ sub-<label>/
 
 File that gives the location, size and other properties of iEEG electrodes. Note
 that coordinates are expected in cartesian coordinates according to the
-`iEEGCoordinateSystem` and `iEEGCoordinateSystemUnits` fields in
+`iEEGCoordinateSystem` and `iEEGCoordinateUnits` fields in
 `*_coordsystem.json`. If an `*_electrodes.tsv` file is specified, a
 `*_coordsystem.json` file MUST be specified as well.
 

--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -48,7 +48,7 @@ Generally, across the MEG, EEG, and iEEG modalities, the first two pieces of
 information for a coordinate system (origin and orientation) are specified in
 `<datatype>CoordinateSystem`.
 The third piece of information for a coordinate system (units) are specified in
-`<datatype>CoordinateSystemUnits`.
+`<datatype>CoordinateUnits`.
 Here, `<datatype>` can be one of `MEG`, `EEG`, or `iEEG`, depending on the
 modality that is being used.
 
@@ -118,7 +118,7 @@ reference is described in `<datatype>CoordinateSystem`.
 Unless otherwise specified below, the origin is at the AC and the orientation of
 the axes is RAS.
 Unless specified explicitly in the sidecar file in the
-`<datatype>CoordinateSystemUnits` field, the units are assumed to be mm.
+`<datatype>CoordinateUnits` field, the units are assumed to be mm.
 
 ### Standard template identifiers
 


### PR DESCRIPTION
fixes a bug revealed by @rwblair in https://github.com/bids-standard/bids-validator/issues/1069#issuecomment-694568524

I remember that we used to have `*CoordinateSystemUnits` in the BEPs, but then decided to go for the shorter `*CoordinateUnits`. Apparently we forgot to carefully adjust the text after this change.

On the good hand, the tables describing the keys are all correct and the validator schemas are also all correct, so I consider this a bugfix, correcting wrong text references.

I am surprised for how long this bug remained undetected. Thanks @rwblair for finding it.