### PR TITLE
SCHEMA: Declare entities by concept names, add entity field for filename components

### DIFF
--- a/src/schema/entities.yaml
+++ b/src/schema/entities.yaml
@@ -1,11 +1,13 @@
 ---
 sub:
   name: Subject
+  pybids_name: subject
   description: |
     A person or animal participating in the study.
   format: label
 ses:
   name: Session
+  pybids_name: session
   description: |
     A logical grouping of neuroimaging and behavioral data consistent across
     subjects.
@@ -24,6 +26,7 @@ ses:
   format: label
 task:
   name: Task
+  pybids_name: task
   format: label
   description: |
     Each task has a unique label that MUST only consist of letters and/or
@@ -32,6 +35,7 @@ task:
     Those labels MUST be consistent across subjects and sessions.
 acq:
   name: Acquisition
+  pybids_name: acquisition
   description: |
     The `acq-<label>` key/value pair corresponds to a custom label the
     user MAY use to distinguish a different set of parameters used for
@@ -51,6 +55,7 @@ acq:
   format: label
 ce:
   name: Contrast Enhancing Agent
+  pybids_name: ceagent
   description: |
     The `ce-<label>` key/value can be used to distinguish
     sequences using different contrast enhanced images.
@@ -60,6 +65,7 @@ ce:
   format: label
 rec:
   name: Reconstruction
+  pybids_name: reconstruction
   description: |
     The `rec-<label>` key/value can be used to distinguish
     different reconstruction algorithms (for example ones using motion
@@ -67,12 +73,14 @@ rec:
   format: label
 dir:
   name: Phase-Encoding Direction
+  pybids_name: direction
   description: |
     The `dir-<label>` key/value can be used to distinguish
     different phase-encoding directions.
   format: label
 run:
   name: Run
+  pybids_name: run
   description: |
     If several scans of the same modality are acquired they MUST be indexed
     with a key-value pair: `_run-1`, `_run-2`, ..., `_run-<index>`
@@ -81,6 +89,7 @@ run:
   format: index
 mod:
   name: Corresponding Modality
+  pybids_name: modality
   description: |
     The `mod-<label>` key/value pair corresponds to modality label for defacing
     masks, e.g., T1w, inplaneT1, referenced by a defacemask image.
@@ -88,6 +97,7 @@ mod:
   format: label
 echo:
   name: Echo
+  pybids_name: echo
   description: |
     Multi-echo data MUST be split into one file per echo.
     Each file shares the same name with the exception of the `_echo-<index>`
@@ -98,6 +108,7 @@ echo:
   format: index
 recording:
   name: Recording
+  pybids_name: recording
   description: |
     More than one continuous recording file can be included (with different
     sampling frequencies).
@@ -106,6 +117,7 @@ recording:
   format: label
 proc:
   name: Processed (on device)
+  pybids_name: ''
   description: |
     The proc label is analogous to rec for MR and denotes a variant of a file
     that was a result of particular processing performed on the device.
@@ -116,6 +128,7 @@ proc:
   format: label
 space:
   name: Space
+  pybids_name: space
   description: |
     The space label (`*[_space-<label>]_electrodes.tsv`) can be used
     to indicate the way in which electrode positions are interpreted.
@@ -123,6 +136,7 @@ space:
   format: label
 split:
   name: Split
+  pybids_name: ''
   description: |
     In the case of long data recordings that exceed a file size of 2Gb, the
     .fif files are conventionally split into multiple parts.

--- a/src/schema/entities.yaml
+++ b/src/schema/entities.yaml
@@ -1,13 +1,13 @@
 ---
-sub:
+subject:
   name: Subject
-  altname: subject
+  entity: sub
   description: |
     A person or animal participating in the study.
   format: label
-ses:
+session:
   name: Session
-  altname: session
+  entity: ses
   description: |
     A logical grouping of neuroimaging and behavioral data consistent across
     subjects.
@@ -26,16 +26,16 @@ ses:
   format: label
 task:
   name: Task
-  altname: task
+  entity: task
   format: label
   description: |
     Each task has a unique label that MUST only consist of letters and/or
     numbers (other characters, including spaces and underscores, are not
     allowed).
     Those labels MUST be consistent across subjects and sessions.
-acq:
+acquisition:
   name: Acquisition
-  altname: acquisition
+  entity: acq
   description: |
     The `acq-<label>` key/value pair corresponds to a custom label the
     user MAY use to distinguish a different set of parameters used for
@@ -53,9 +53,9 @@ acq:
     FLASH, or between RARE, FLASH, and FLASHsubsampled) remains at the
     discretion of the researcher.
   format: label
-ce:
+ceagent:
   name: Contrast Enhancing Agent
-  altname: ceagent
+  entity: ce
   description: |
     The `ce-<label>` key/value can be used to distinguish
     sequences using different contrast enhanced images.
@@ -63,33 +63,33 @@ ce:
     The key `ContrastBolusIngredient` MAY be also be added in the JSON file,
     with the same label.
   format: label
-rec:
+reconstruction:
   name: Reconstruction
-  altname: reconstruction
+  entity: rec
   description: |
     The `rec-<label>` key/value can be used to distinguish
     different reconstruction algorithms (for example ones using motion
     correction).
   format: label
-dir:
+direction:
   name: Phase-Encoding Direction
-  altname: direction
+  entity: dir
   description: |
     The `dir-<label>` key/value can be used to distinguish
     different phase-encoding directions.
   format: label
 run:
   name: Run
-  altname: run
+  entity: run
   description: |
     If several scans of the same modality are acquired they MUST be indexed
     with a key-value pair: `_run-1`, `_run-2`, ..., `_run-<index>`
     (only nonnegative integers are allowed for the `<index>`).
     When there is only one scan of a given type the run key MAY be omitted.
   format: index
-mod:
+modality:
   name: Corresponding Modality
-  altname: modality
+  entity: mod
   description: |
     The `mod-<label>` key/value pair corresponds to modality label for defacing
     masks, e.g., T1w, inplaneT1, referenced by a defacemask image.
@@ -97,7 +97,7 @@ mod:
   format: label
 echo:
   name: Echo
-  altname: echo
+  entity: echo
   description: |
     Multi-echo data MUST be split into one file per echo.
     Each file shares the same name with the exception of the `_echo-<index>`
@@ -108,16 +108,16 @@ echo:
   format: index
 recording:
   name: Recording
-  altname: recording
+  entity: recording
   description: |
     More than one continuous recording file can be included (with different
     sampling frequencies).
     In such case use different labels.
     For example: `_recording-contrast`, `_recording-saturation`.
   format: label
-proc:
+processing:
   name: Processed (on device)
-  altname: ''
+  entity: proc
   description: |
     The proc label is analogous to rec for MR and denotes a variant of a file
     that was a result of particular processing performed on the device.
@@ -128,7 +128,7 @@ proc:
   format: label
 space:
   name: Space
-  altname: space
+  entity: space
   description: |
     The space label (`*[_space-<label>]_electrodes.tsv`) can be used
     to indicate the way in which electrode positions are interpreted.
@@ -136,7 +136,7 @@ space:
   format: label
 split:
   name: Split
-  altname: ''
+  entity: split
   description: |
     In the case of long data recordings that exceed a file size of 2Gb, the
     .fif files are conventionally split into multiple parts.

--- a/src/schema/entities.yaml
+++ b/src/schema/entities.yaml
@@ -1,13 +1,13 @@
 ---
 sub:
   name: Subject
-  pybids_name: subject
+  altname: subject
   description: |
     A person or animal participating in the study.
   format: label
 ses:
   name: Session
-  pybids_name: session
+  altname: session
   description: |
     A logical grouping of neuroimaging and behavioral data consistent across
     subjects.
@@ -26,7 +26,7 @@ ses:
   format: label
 task:
   name: Task
-  pybids_name: task
+  altname: task
   format: label
   description: |
     Each task has a unique label that MUST only consist of letters and/or
@@ -35,7 +35,7 @@ task:
     Those labels MUST be consistent across subjects and sessions.
 acq:
   name: Acquisition
-  pybids_name: acquisition
+  altname: acquisition
   description: |
     The `acq-<label>` key/value pair corresponds to a custom label the
     user MAY use to distinguish a different set of parameters used for
@@ -55,7 +55,7 @@ acq:
   format: label
 ce:
   name: Contrast Enhancing Agent
-  pybids_name: ceagent
+  altname: ceagent
   description: |
     The `ce-<label>` key/value can be used to distinguish
     sequences using different contrast enhanced images.
@@ -65,7 +65,7 @@ ce:
   format: label
 rec:
   name: Reconstruction
-  pybids_name: reconstruction
+  altname: reconstruction
   description: |
     The `rec-<label>` key/value can be used to distinguish
     different reconstruction algorithms (for example ones using motion
@@ -73,14 +73,14 @@ rec:
   format: label
 dir:
   name: Phase-Encoding Direction
-  pybids_name: direction
+  altname: direction
   description: |
     The `dir-<label>` key/value can be used to distinguish
     different phase-encoding directions.
   format: label
 run:
   name: Run
-  pybids_name: run
+  altname: run
   description: |
     If several scans of the same modality are acquired they MUST be indexed
     with a key-value pair: `_run-1`, `_run-2`, ..., `_run-<index>`
@@ -89,7 +89,7 @@ run:
   format: index
 mod:
   name: Corresponding Modality
-  pybids_name: modality
+  altname: modality
   description: |
     The `mod-<label>` key/value pair corresponds to modality label for defacing
     masks, e.g., T1w, inplaneT1, referenced by a defacemask image.
@@ -97,7 +97,7 @@ mod:
   format: label
 echo:
   name: Echo
-  pybids_name: echo
+  altname: echo
   description: |
     Multi-echo data MUST be split into one file per echo.
     Each file shares the same name with the exception of the `_echo-<index>`
@@ -108,7 +108,7 @@ echo:
   format: index
 recording:
   name: Recording
-  pybids_name: recording
+  altname: recording
   description: |
     More than one continuous recording file can be included (with different
     sampling frequencies).
@@ -117,7 +117,7 @@ recording:
   format: label
 proc:
   name: Processed (on device)
-  pybids_name: ''
+  altname: ''
   description: |
     The proc label is analogous to rec for MR and denotes a variant of a file
     that was a result of particular processing performed on the device.
@@ -128,7 +128,7 @@ proc:
   format: label
 space:
   name: Space
-  pybids_name: space
+  altname: space
   description: |
     The space label (`*[_space-<label>]_electrodes.tsv`) can be used
     to indicate the way in which electrode positions are interpreted.
@@ -136,7 +136,7 @@ space:
   format: label
 split:
   name: Split
-  pybids_name: ''
+  altname: ''
   description: |
     In the case of long data recordings that exceed a file size of 2Gb, the
     .fif files are conventionally split into multiple parts.

--- a/tools/bids_schema.py
+++ b/tools/bids_schema.py
@@ -220,7 +220,7 @@ each is given in the [Entity Table](04-entity-table.md).
         fo.write(intro_text)
         for entity, entity_info in entities.items():
             fo.write('\n')
-            fo.write('## {}'.format(entity))
+            fo.write('## {}'.format(entity_info['entity']))
             fo.write('\n\n')
             fo.write('Full name: {}'.format(entity_info['name']))
             fo.write('\n\n')
@@ -284,9 +284,9 @@ def make_entity_table(schema_path, entities_file='09-entities.md'):
     # Compose header and formats first
     for i, (entity, spec) in enumerate(schema['entities'].items()):
         header.append(spec["name"])
-        formats.append(f'[`{entity}-<{spec["format"]}>`]'
-                       f'({entities_file}#{entity})')
-        entity_to_col[entity] = i + 1
+        formats.append(f'[`{spec["entity"]}-<{spec["format"]}>`]'
+                       f'({entities_file}#{spec["entity"]})')
+        entity_to_col[spec["entity"]] = i + 1
 
     # Go through data types
     for dtype, specs in chain(schema['datatypes'].items(),


### PR DESCRIPTION
As proposed in https://github.com/bids-standard/bids-specification/pull/588#discussion_r487266873, roughly agreed on, and not (yet) argued against.

This uses the names settled on in https://github.com/bids-standard/pybids/issues/489#issuecomment-531381408 to allow pybids to query in a somewhat consistent manner.

Closes #585.
Closes #588.