### PR TITLE
[FIX] Accidentally swapped Neuromag/Elekta/MEGIN cross-talk & fine-calibration filename extensions

### DIFF
--- a/src/99-appendices/01-contributors.md
+++ b/src/99-appendices/01-contributors.md
@@ -86,6 +86,7 @@ If you contributed to the BIDS ecosystem and your name is not listed, please add
 -   Peer Herholz 💬📖👀🔧✅📢
 -   Dora Hermes 📖💻✅🔍🤔
 -   Katja Heuer 🔧
+-   Richard Höchenberger 📖
 -   Chris Holdgraf 📖🤔
 -   Christopher J. Honey 📖
 -   Jean-Christophe Houde 📖

--- a/src/99-appendices/06-meg-file-formats.md
+++ b/src/99-appendices/06-meg-file-formats.md
@@ -74,10 +74,12 @@ Both files are thus specific to the site of recording and may change in the
 process of regular system maintenance.
 
 In BIDS, the cross-talk and fine-calibration files are shared unmodified,
-but with BIDS file naming convention and by using the `acq` entity.
+including their original extensions (`.fif` for cross-talk and `.dat` for
+fine-calibration), but with BIDS file naming convention and by using the `acq`
+entity.
 
--   cross-talk file template: `sub-<label>[_ses-<label>]_acq-crosstalk_meg.dat`
--   fine-calibration file template: `sub-<label>[_ses-<label>]_acq-calibration_meg.fif`
+-   cross-talk file template: `sub-<label>[_ses-<label>]_acq-crosstalk_meg.fif`
+-   fine-calibration file template: `sub-<label>[_ses-<label>]_acq-calibration_meg.dat`
 
 Note that cross-talk files MUST be denoted using `acq-crosstalk` and
 fine-calibration files MUST be denoted using `acq-calibration`.
@@ -94,16 +96,16 @@ sub-01/
         sub-01_task-rest_meg.fif
         sub-01_task-rest_meg.json
         sub-01_task-rest_channels.tsv
-        sub-01_acq-crosstalk_meg.dat
-        sub-01_acq-calibration_meg.fif
+        sub-01_acq-crosstalk_meg.fif
+        sub-01_acq-calibration_meg.dat
 sub-02/
     meg/
         sub-02_coordsystem.json
         sub-02_task-rest_meg.fif
         sub-02_task-rest_meg.json
         sub-02_task-rest_channels.tsv
-        sub-02_acq-crosstalk_meg.dat
-        sub-02_acq-calibration_meg.fif
+        sub-02_acq-crosstalk_meg.fif
+        sub-02_acq-calibration_meg.dat
 ```
 
 #### Example with multiple sessions
@@ -117,8 +119,8 @@ sub-01/
             sub-01_ses-01_task-rest_run-01_meg.fif
             sub-01_ses-01_task-rest_run-01_meg.json
             sub-01_ses-01_task-rest_run-01_channels.tsv
-            sub-01_ses-01_acq-crosstalk_meg.dat
-            sub-01_ses-01_acq-calibration_meg.fif
+            sub-01_ses-01_acq-crosstalk_meg.fif
+            sub-01_ses-01_acq-calibration_meg.dat
     ses-02/
         sub-01_ses-02_scans.tsv
         meg/
@@ -126,8 +128,8 @@ sub-01/
             sub-01_ses-02_task-rest_run-01_meg.fif
             sub-01_ses-02_task-rest_run-01_meg.json
             sub-01_ses-02_task-rest_run-01_channels.tsv
-            sub-01_ses-02_acq-crosstalk_meg.dat
-            sub-01_ses-02_acq-calibration_meg.fif
+            sub-01_ses-02_acq-crosstalk_meg.fif
+            sub-01_ses-02_acq-calibration_meg.dat
 ```
 
 ### Sharing FIFF data after signal-space separation (SSS)

--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/bids-standard/bids-specification/tree/HEAD)
 
--   \[FIX] Accidentally swapped Neuromag/Elekta/MEGIN cross-talk & fine-calib filename extensions [#621](https://github.com/bids-standard/bids-specification/pull/621) ([hoechenberger](https://github.com/hoechenberger))
+-   \[FIX] Accidentally swapped Neuromag/Elekta/MEGIN cross-talk & fine-calibration filename extensions [#621](https://github.com/bids-standard/bids-specification/pull/621) ([hoechenberger](https://github.com/hoechenberger))
 -   \[INFRA] Move MRI section headings up a level [#618](https://github.com/bids-standard/bids-specification/pull/618) ([tsalo](https://github.com/tsalo))
 -   \[FIX] Clarify data types and requirement levels for all JSON files [#605](https://github.com/bids-standard/bids-specification/pull/605) ([sappelhoff](https://github.com/sappelhoff))
 -   \[INFRA] downgrade github-changelog-generator to 1.14.3 due to issue with 1.15.2 [#600](https://github.com/bids-standard/bids-specification/pull/600) ([sappelhoff](https://github.com/sappelhoff))

--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/bids-standard/bids-specification/tree/HEAD)
 
+-   \[FIX] Accidentally swapped Neuromag/Elekta/MEGIN cross-talk & fine-calib filename extensions [#621](https://github.com/bids-standard/bids-specification/pull/621) ([hoechenberger](https://github.com/hoechenberger))
 -   \[INFRA] Move MRI section headings up a level [#618](https://github.com/bids-standard/bids-specification/pull/618) ([tsalo](https://github.com/tsalo))
 -   \[FIX] Clarify data types and requirement levels for all JSON files [#605](https://github.com/bids-standard/bids-specification/pull/605) ([sappelhoff](https://github.com/sappelhoff))
 -   \[INFRA] downgrade github-changelog-generator to 1.14.3 due to issue with 1.15.2 [#600](https://github.com/bids-standard/bids-specification/pull/600) ([sappelhoff](https://github.com/sappelhoff))

--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## [Unreleased](https://github.com/bids-standard/bids-specification/tree/HEAD)
 
--   \[FIX] Accidentally swapped Neuromag/Elekta/MEGIN cross-talk & fine-calibration filename extensions [#621](https://github.com/bids-standard/bids-specification/pull/621) ([hoechenberger](https://github.com/hoechenberger))
 -   \[INFRA] Move MRI section headings up a level [#618](https://github.com/bids-standard/bids-specification/pull/618) ([tsalo](https://github.com/tsalo))
 -   \[FIX] Clarify data types and requirement levels for all JSON files [#605](https://github.com/bids-standard/bids-specification/pull/605) ([sappelhoff](https://github.com/sappelhoff))
 -   \[INFRA] downgrade github-changelog-generator to 1.14.3 due to issue with 1.15.2 [#600](https://github.com/bids-standard/bids-specification/pull/600) ([sappelhoff](https://github.com/sappelhoff))


### PR DESCRIPTION
In GH-598 we accidentally swapped the extensions for fine-calibration and cross-talk files. This PR corrects this.

x-ref: bids-standard/bids-validator#1079
