### PR TITLE
[ENH] Add "multipart DWI" acquisitions and refactor DWI specifications

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -378,10 +378,10 @@ participant, task and run takes precedence.
 
 Currently supported image modalities include:
 
-| **Name**              | `modality_label` | **Description**                                                                                                                                     |
-|---------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| DWI                   | dwi              | Diffusion-weighted imaging contrast (specialized T2\* weighting)                                                                                     |
-| Single-Band Reference | sbref            | Single-band reference for one or more multi-band `dwi` images, only when no gradient informations needs to be stored (i.e., all volumes are *b = 0*) |
+| **Name**              | `modality_label` | **Description**                                                                                                                                       |
+|---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DWI                   | dwi              | Diffusion-weighted imaging contrast (specialized T2\* weighting).                                                                                     |
+| Single-Band Reference | sbref            | Single-band reference for one or more multi-band `dwi` images, only when no gradient informations needs to be stored (i.e., all volumes are *b = 0*). |
 
 Template:
 
@@ -450,7 +450,11 @@ bval example:
 and thus define those values for all sessions and/or subjects in one place (see
 Inheritance principle).
 
-## Multipart (split) DWI schemes
+As an exception to the [common principle](../02-common-principles.md#definitions)
+that parameters are constant across runs, the gradient table information (stored
+within the `.bval` and `.bvec` files) MAY change across DWI runs.
+
+### Multipart (split) DWI schemes
 
 Some MR schemes cannot be acquired directly by some scanner devices,
 requiring to generate several DWI runs that were originally meant to belong
@@ -459,9 +463,9 @@ For instance, some GE scanners cannot collect more than &asymp;160 volumes
 in a single run under fast-changing gradients, so acquiring *HCP-style*
 diffusion images will require splitting the DWI scheme in several runs.
 
-| **Key name**    | **Requirement level** | **Data type** | **Description**                                                                                                                                                                               |
-| --------------- | --------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MultipartID     | REQUIRED              | [string][]    | Unique identifier to prescribe DWI segments belonging in a single multipart run.                                                                                                              |
+| **Key name**    | **Requirement level** | **Data type** | **Description**                                                                                                                                                                                                      |
+| --------------- | --------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MultipartID     | REQUIRED              | [string][]    | Unique identifier (participant's level) to prescribe DWI segments belonging in a single dataset. Segments can be designated by any combination of `dir-<label>`, `acq-<label>` and/or `run-<index>` key/value pairs. |
 
 JSON example:
 
@@ -495,7 +499,7 @@ sub-<label>/[ses-<label>/]
        sub-<label>_dwi.json
 ```
 
-## Other RECOMMENDED metadata
+### Other RECOMMENDED metadata
 
 See [Common metadata fields](#common-metadata-fields) for a list of
 additional terms that can be included in the corresponding JSON file.

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -548,6 +548,9 @@ sub-<label>/[ses-<label>/]             # MultipartID
 
 ### Other RECOMMENDED metadata
 
+At minimum, the `PhaseEncodingDirection` and `TotalReadoutTime` metadata
+fields are RECOMMENDED to enable the correction of geometrical distortions
+with [fieldmap information](#fieldmap-data).
 See [Common metadata fields](#common-metadata-fields) for a list of
 additional terms that can be included in the corresponding JSON file.
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -415,7 +415,7 @@ distinguish different sets of phase-encoding directions.
 
 **Combining multi- and single-band acquisitions**.
 The single-band reference image MAY be stored with suffix `sbref` (for example,
-`dwi/sub-control01_sbref.nii[.gz]`,) as long as the image has no corresponding
+`dwi/sub-control01_sbref.nii[.gz]`) as long as the image has no corresponding
 [gradient information (`.bval` and `.bvec` sidecar files)](#required-gradient-orientation-information)
 to be stored.
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -413,11 +413,11 @@ The OPTIONAL [`dir-<label>`](../99-appendices/09-entities.md#dir)
 key/value pair corresponds to a custom label the user may use to
 distinguish different sets of phase-encoding directions.
 
-### Combining multi- and single-band acquisitions
-
-The single-band reference image MAY be stored as type `sbref` (e.g.,
+**Combining multi- and single-band acquisitions**.
+The single-band reference image MAY be stored with suffix `sbref` (e.g.,
 `dwi/sub-control01_sbref.nii[.gz]`,) as long as the image has no corresponding
-gradient information (`.bval` and `.bvec` sidecar files) to be stored.
+[gradient information (`.bval` and `.bvec` sidecar files)](#required-gradient-orientation-information)
+to be stored.
 
 Otherwise, if some gradient information is associated to the single-band diffusion
 image and a multi-band diffusion image also exists, the `acq-<label>` key/value pair
@@ -502,48 +502,48 @@ part of a unique multipart scan, then they will tag all four runs with the
 same `MultipartID` (shown at the right-hand side of the file listing):
 
 ```Text
-sub-<label>/[ses-<label>/]     # MultipartID
+sub-<label>/[ses-<label>/]         # MultipartID
   dwi/
-    sub-1_dir-AP_run-1.nii.gz  # dwi_1
-    sub-1_dir-AP_run-2.nii.gz  # dwi_1
-    sub-1_dir-PA_run-1.nii.gz  # dwi_1
-    sub-1_dir-PA_run-2.nii.gz  # dwi_1
+    sub-1_dir-AP_run-1_dwi.nii.gz  # dwi_1
+    sub-1_dir-AP_run-2_dwi.nii.gz  # dwi_1
+    sub-1_dir-PA_run-1_dwi.nii.gz  # dwi_1
+    sub-1_dir-PA_run-2_dwi.nii.gz  # dwi_1
 ```
 
 If, conversely, the resarcher wanted to store two multipart scans, one possibility
 is to combine matching phase-encoding directions:
 
 ```Text
-sub-<label>/[ses-<label>/]     # MultipartID
+sub-<label>/[ses-<label>/]         # MultipartID
   dwi/
-    sub-1_dir-AP_run-1.nii.gz  # dwi_1
-    sub-1_dir-AP_run-2.nii.gz  # dwi_1
-    sub-1_dir-PA_run-1.nii.gz  # dwi_2
-    sub-1_dir-PA_run-2.nii.gz  # dwi_2
+    sub-1_dir-AP_run-1_dwi.nii.gz  # dwi_1
+    sub-1_dir-AP_run-2_dwi.nii.gz  # dwi_1
+    sub-1_dir-PA_run-1_dwi.nii.gz  # dwi_2
+    sub-1_dir-PA_run-2_dwi.nii.gz  # dwi_2
 ```
 
 Alternatively, the researcher's intent could be combining opposed phase-encoding
 runs instead:
 
 ```Text
-sub-<label>/[ses-<label>/]     # MultipartID
+sub-<label>/[ses-<label>/]         # MultipartID
   dwi/
-    sub-1_dir-AP_run-1.nii.gz  # dwi_1
-    sub-1_dir-AP_run-2.nii.gz  # dwi_2
-    sub-1_dir-PA_run-1.nii.gz  # dwi_1
-    sub-1_dir-PA_run-2.nii.gz  # dwi_2
+    sub-1_dir-AP_run-1_dwi.nii.gz  # dwi_1
+    sub-1_dir-AP_run-2_dwi.nii.gz  # dwi_2
+    sub-1_dir-PA_run-1_dwi.nii.gz  # dwi_1
+    sub-1_dir-PA_run-2_dwi.nii.gz  # dwi_2
 ```
 
 The `MultipartID` metadata MAY be used with the
 [`acq-<label>`](../99-appendices/09-entities.md#acq) key/value pair, for example:
 
 ```Text
-sub-<label>/[ses-<label>/]         # MultipartID
+sub-<label>/[ses-<label>/]             # MultipartID
   dwi/
-    sub-1_acq-shell1_run-1.nii.gz  # dwi_1
-    sub-1_acq-shell1_run-2.nii.gz  # dwi_2
-    sub-1_acq-shell2_run-1.nii.gz  # dwi_1
-    sub-1_acq-shell2_run-2.nii.gz  # dwi_2
+    sub-1_acq-shell1_run-1_dwi.nii.gz  # dwi_1
+    sub-1_acq-shell1_run-2_dwi.nii.gz  # dwi_2
+    sub-1_acq-shell2_run-1_dwi.nii.gz  # dwi_1
+    sub-1_acq-shell2_run-2_dwi.nii.gz  # dwi_2
 ```
 
 ### Other RECOMMENDED metadata

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -376,12 +376,13 @@ participant, task and run takes precedence.
 
 ## Diffusion imaging data
 
+Diffusion-weighted imaging data acquired for a participant.
 Currently supported image modalities include:
 
-| **Name**              | `modality_label` | **Description**                                                                                                                                       |
-|---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| DWI                   | dwi              | Diffusion-weighted imaging contrast (specialized T2\* weighting).                                                                                     |
-| Single-Band Reference | sbref            | Single-band reference for one or more multi-band `dwi` images, only when no gradient informations needs to be stored (i.e., all volumes are *b = 0*). |
+| **Name**              | `modality_label` | **Description**                                                   |
+|---------------------- | ---------------- | ----------------------------------------------------------------- |
+| DWI                   | dwi              | Diffusion-weighted imaging contrast (specialized T2\* weighting). |
+| Single-Band Reference | sbref            | Single-band reference for one or more multi-band `dwi` images.    |
 
 Template:
 
@@ -396,20 +397,23 @@ sub-<label>/[ses-<label>/]
        sub-<label>[_ses-<label>][_acq-<label>][_dir-<label>][_run-<index>]_sbref.json
 ```
 
-Diffusion-weighted imaging data acquired for that participant.
-
 The OPTIONAL [`acq-<label>`](../99-appendices/09-entities.md#acq)
 key/value pair corresponds to a custom label the user may use to
 distinguish different sets of parameters.
-For example, this should be used when a study includes two diffusion
-images -- one single band and one multiband.
+
+### Combining multi- and single-band acquisitions
+
+The single-band reference image MAY be stored as type `sbref` (e.g.,
+`dwi/sub-control01_sbref.nii[.gz]`,) as long as the image has no corresponding
+gradient information (`.bval` and `.bvec` sidecar files) to be stored.
+
+Otherwise, if some gradient information is associated to the single-band diffusion
+image and a multi-band diffusion image also exists,  the `acq-<label>` key/value pair
+MUST be used to distinguish both images.
 In such case two files could have the following names:
 `sub-01_acq-singleband_dwi.nii.gz` and `sub-01_acq-multiband_dwi.nii.gz`,
 however the user is free to choose any other label than `singleband` and
 `multiband` as long as they are consistent across subjects and sessions.
-
-For multiband acquisitions, one can also save the single-band reference image as
-type `sbref` (e.g. `dwi/sub-control01_sbref.nii[.gz]`.)
 
 ### REQUIRED gradient orientation information
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -411,7 +411,6 @@ however the user is free to choose any other label than `singleband` and
 For multiband acquisitions, one can also save the single-band reference image as
 type `sbref` (e.g. `dwi/sub-control01_sbref.nii[.gz]`.)
 
-
 ### REQUIRED gradient orientation information
 
 The bvec and bval files are in the

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -377,12 +377,12 @@ participant, task and run takes precedence.
 ## Diffusion imaging data
 
 Diffusion-weighted imaging data acquired for a participant.
-Currently supported image modalities include:
+Currently supported image types include:
 
-| **Name**              | `modality_label` | **Description**                                                   |
-|---------------------- | ---------------- | ----------------------------------------------------------------- |
-| DWI                   | dwi              | Diffusion-weighted imaging contrast (specialized T2\* weighting). |
-| Single-Band Reference | sbref            | Single-band reference for one or more multi-band `dwi` images.    |
+| **Name**              | `suffix` | **Description**                                                   |
+|---------------------- | -------- | ----------------------------------------------------------------- |
+| DWI                   | dwi      | Diffusion-weighted imaging contrast (specialized T2\* weighting). |
+| Single-Band Reference | sbref    | Single-band reference for one or more multi-band `dwi` images.    |
 
 Template:
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -57,7 +57,7 @@ that a given scan was collected with the intended coil elements selected
 | **Key name**                   | **Requirement level** | **Data type** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 |--------------------------------|-----------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | NumberShots                    | RECOMMENDED           | [number][]    | The number of RF excitations need to reconstruct a slice or volume. Please mind that this is not the same as Echo Train Length which denotes the number of lines of k-space collected after an excitation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| ParallelReductionFactorInPlane | RECOMMENDED           | [number][]    | The parallel imaging (e.g, GRAPPA) factor. Use the denominator of the fraction of k-space encoded for each slice. For example, 2 means half of k-space is encoded. Corresponds to DICOM Tag 0018, 9069 `Parallel Reduction Factor In-plane`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ParallelReductionFactorInPlane | RECOMMENDED           | [number][]    | The parallel imaging (for instance, GRAPPA) factor. Use the denominator of the fraction of k-space encoded for each slice. For example, 2 means half of k-space is encoded. Corresponds to DICOM Tag 0018, 9069 `Parallel Reduction Factor In-plane`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ParallelAcquisitionTechnique   | RECOMMENDED           | [string][]    | The type of parallel imaging used (for example GRAPPA, SENSE). Corresponds to DICOM Tag 0018, 9078 `Parallel Acquisition Technique`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | PartialFourier                 | RECOMMENDED           | [number][]    | The fraction of partial Fourier information collected. Corresponds to DICOM Tag 0018, 9081 `Partial Fourier`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | PartialFourierDirection        | RECOMMENDED           | [string][]    | The direction where only partial Fourier information was collected. Corresponds to DICOM Tag 0018, 9036 `Partial Fourier Direction`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -399,7 +399,7 @@ sub-<label>/[ses-<label>/]
 
 If more than one run of the same acquisition and direction has been acquired, the
 [`run-<index>`](../99-appendices/09-entities.md#run) key/value pair MUST be used:
-`_run-1`, `_run-2`, `_run-3` etc.
+`_run-1`, `_run-2`, `_run-3` (and so forth.)
 When there is only one scan of a given acquisition and direction, the run key MAY be
 omitted.
 The [`run-<index>`](../99-appendices/09-entities.md#run) key/value pair is RECOMMENDED
@@ -414,7 +414,7 @@ key/value pair corresponds to a custom label the user may use to
 distinguish different sets of phase-encoding directions.
 
 **Combining multi- and single-band acquisitions**.
-The single-band reference image MAY be stored with suffix `sbref` (e.g.,
+The single-band reference image MAY be stored with suffix `sbref` (for example,
 `dwi/sub-control01_sbref.nii[.gz]`,) as long as the image has no corresponding
 [gradient information (`.bval` and `.bvec` sidecar files)](#required-gradient-orientation-information)
 to be stored.
@@ -439,7 +439,7 @@ As an exception to the [common principles](../02-common-principles.md#definition
 that parameters are constant across runs, the gradient table information (stored
 within the `.bval` and `.bvec` files) MAY change across DWI runs.
 
-**Gradient orientation file formats** The `.bvec` and `.bval` files MUST follow the
+**Gradient orientation file formats**. The `.bvec` and `.bval` files MUST follow the
 [FSL format](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#DTIFIT):
 The `.bvec` file contains 3 rows with *N* space-delimited floating-point numbers
 (corresponding to the *N* volumes in the corresponding NIfTI file.)
@@ -449,10 +449,10 @@ diffusion gradient, where the *i*-th elements in each row correspond together to
 the *i*-th volume, with `[0,0,0]` for *non-diffusion-weighted* (also called *b*=0 or *low-b*)
 volumes.
 Inherent to the FSL format for `.bvec` specification is the fact that the coordinate system of
-the bvecs is with respect to the participant (i.e., defined by the axes of the
-corresponding dwi.nii file) and not the magnet's coordinate system, which means
-that any rotations applied to the DWI data also need to be applied to the
-corresponding `.bvec` file.
+the bvecs is with respect to the participant (in other words, defined by the axes of the
+corresponding `_dwi` file) and not the magnet's coordinate system.
+The most relevant implication for this choice is that any rotations applied to the DWI data
+also need to be applied to the corresponding `.bvec` file.
 
 Example of `.bvec` file, with *N*=6, with two *b*=0 volumes in the beginning:
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -416,7 +416,7 @@ distinguish different sets of phase-encoding directions.
 **Combining multi- and single-band acquisitions**.
 The single-band reference image MAY be stored with suffix `sbref` (for example,
 `dwi/sub-control01_sbref.nii[.gz]`) as long as the image has no corresponding
-[gradient information (`.bval` and `.bvec` sidecar files)](#required-gradient-orientation-information)
+[gradient information (`[*_]dwi.bval` and `[*_]dwi.bvec` sidecar files)](#required-gradient-orientation-information)
 to be stored.
 
 Otherwise, if some gradient information is associated to the single-band diffusion
@@ -430,31 +430,32 @@ The user is free to choose any other label than `singleband` and
 ### REQUIRED gradient orientation information
 
 The REQUIRED gradient orientation information corresponding to a DWI acquisition
-MUST be stored using `.bval` and `.bvec` pairs of files.
-The `.bval` and `.bvec` files can be saved on any level of the directory structure
+MUST be stored using `[*_]dwi.bval` and `[*_]dwi.bvec` pairs of files.
+The `[*_]dwi.bval` and `[*_]dwi.bvec` files MAY be saved on any level of the directory structure
 and thus define those values for all sessions and/or subjects in one place (see
-Inheritance principle).
+[the inheritance principle](../02-common-principles.md#the-inheritance-principle)).
 
 As an exception to the [common principles](../02-common-principles.md#definitions)
 that parameters are constant across runs, the gradient table information (stored
-within the `.bval` and `.bvec` files) MAY change across DWI runs.
+within the `[*_]dwi.bval` and `[*_]dwi.bvec` files) MAY change across DWI runs.
 
-**Gradient orientation file formats**. The `.bvec` and `.bval` files MUST follow the
+**Gradient orientation file formats**.
+The `[*_]dwi.bval` and `[*_]dwi.bvec` files MUST follow the
 [FSL format](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#DTIFIT):
-The `.bvec` file contains 3 rows with *N* space-delimited floating-point numbers
+The `[*_]dwi.bvec` file contains 3 rows with *N* space-delimited floating-point numbers
 (corresponding to the *N* volumes in the corresponding NIfTI file.)
 The first row contains the *x* elements, the second row contains the *y* elements and
 the third row contains the *z* elements of a unit vector in the direction of the applied
 diffusion gradient, where the *i*-th elements in each row correspond together to
 the *i*-th volume, with `[0,0,0]` for *non-diffusion-weighted* (also called *b*=0 or *low-b*)
 volumes.
-Inherent to the FSL format for `.bvec` specification is the fact that the coordinate system of
-the bvecs is with respect to the participant (in other words, defined by the axes of the
-corresponding `_dwi` file) and not the magnet's coordinate system.
+Following the FSL format for the `[*_]dwi.bvec` specification, the coordinate system of
+the *b* vectors MUST be defined with respect to the participant (in other words, defined
+by the axes of the corresponding `_dwi` NIfTI file) and not the magnet's coordinate system.
 The most relevant implication for this choice is that any rotations applied to the DWI data
-also need to be applied to the corresponding `.bvec` file.
+also need to be applied to the *b* vectors in the `[*_]dwi.bvec` file.
 
-Example of `.bvec` file, with *N*=6, with two *b*=0 volumes in the beginning:
+Example of `[*_]dwi.bvec` file, with *N*=6, with two *b*=0 volumes in the beginning:
 
 ```Text
 0 0 0.021828 -0.015425 -0.70918 -0.2465
@@ -462,10 +463,10 @@ Example of `.bvec` file, with *N*=6, with two *b*=0 volumes in the beginning:
 0 0 -0.59636 0.97516 -0.70503 -0.96351
 ```
 
-The `.bval` file contains the *b*-values (in s/mm<sup>2</sup>) corresponding to the
+The `[*_]dwi.bval` file contains the *b*-values (in s/mm<sup>2</sup>) corresponding to the
 volumes in the relevant NIfTI file), with 0 designating *b*=0 volumes, space-delimited.
 
-Example of `.bval` file, corresponding to the previous `.bvec` example:
+Example of `[*_]dwi.bval` file, corresponding to the previous `[*_]dwi.bvec` example:
 
 ```Text
 0 0 2000 2000 1000 1000

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -510,7 +510,7 @@ sub-<label>/[ses-<label>/]         # MultipartID
     sub-1_dir-PA_run-2_dwi.nii.gz  # dwi_1
 ```
 
-If, conversely, the resarcher wanted to store two multipart scans, one possibility
+If, conversely, the researcher wanted to store two multipart scans, one possibility
 is to combine matching phase-encoding directions:
 
 ```Text

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -548,7 +548,7 @@ sub-<label>/[ses-<label>/]             # MultipartID
 
 ### Other RECOMMENDED metadata
 
-At minimum, the `PhaseEncodingDirection` and `TotalReadoutTime` metadata
+The `PhaseEncodingDirection` and `TotalReadoutTime` metadata
 fields are RECOMMENDED to enable the correction of geometrical distortions
 with [fieldmap information](#fieldmap-data).
 See [Common metadata fields](#common-metadata-fields) for a list of

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -450,8 +450,9 @@ diffusion gradient, where the *i*-th elements in each row correspond together to
 the *i*-th volume, with `[0,0,0]` for *non-diffusion-weighted* (also called *b*=0 or *low-b*)
 volumes.
 Following the FSL format for the `[*_]dwi.bvec` specification, the coordinate system of
-the *b* vectors MUST be defined with respect to the participant (in other words, defined
-by the axes of the corresponding `_dwi` NIfTI file) and not the magnet's coordinate system.
+the *b* vectors MUST be defined with respect to the coordinate system defined by
+the header of the corresponding `_dwi` NIfTI file and not the scanner's device
+coordinate system (see [Coordinate systems](../99-appendices/08-coordinate-systems.md)).
 The most relevant implication for this choice is that any rotations applied to the DWI data
 also need to be applied to the *b* vectors in the `[*_]dwi.bvec` file.
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -480,7 +480,7 @@ For instance, some GE scanners cannot collect more than &asymp;160 volumes
 in a single run under fast-changing gradients, so acquiring *HCP-style*
 diffusion images will require splitting the DWI scheme in several runs.
 Because researchers will generally optimize the data splits, these will likely
-not be directly concatenable anymore.
+not be able to be directly concatenated.
 BIDS permits defining arbitrary groupings of these multipart scans with the
 following metadata:
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -408,12 +408,12 @@ The single-band reference image MAY be stored as type `sbref` (e.g.,
 gradient information (`.bval` and `.bvec` sidecar files) to be stored.
 
 Otherwise, if some gradient information is associated to the single-band diffusion
-image and a multi-band diffusion image also exists,  the `acq-<label>` key/value pair
+image and a multi-band diffusion image also exists, the `acq-<label>` key/value pair
 MUST be used to distinguish both images.
-In such case two files could have the following names:
-`sub-01_acq-singleband_dwi.nii.gz` and `sub-01_acq-multiband_dwi.nii.gz`,
-however the user is free to choose any other label than `singleband` and
-`multiband` as long as they are consistent across subjects and sessions.
+In such a case, two files could have the following names:
+`sub-01_acq-singleband_dwi.nii.gz` and `sub-01_acq-multiband_dwi.nii.gz`.
+The user is free to choose any other label than `singleband` and
+`multiband`, as long as they are consistent across subjects and sessions.
 
 ### REQUIRED gradient orientation information
 


### PR DESCRIPTION
Addresses the use case of DWI sequences that need to be split into several runs because, e.g., the scanner would exceed temperature specifications due to fast gradient-switching.

This PR also refactors the text of DWIs to better accommodate the addition and make DWIs more consistent with the rest of the file.

The approach to solve this is similar to that of #622 for fieldmaps.

References: nipreps/dmriprep#43.