### PR TITLE
[INFRA] set up github action to detect latin phrases

### DIFF
--- a/.github/workflows/no-bad-latin.yml
+++ b/.github/workflows/no-bad-latin.yml
@@ -1,0 +1,47 @@
+# Give your test a name!
+name: Check for Latin Phrases
+
+# Decide when to run the tests
+#
+# This configuration sets the test to run on pushes to master
+# and on pull requests that are opened to master
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+# Set up the Continuous Integration job
+jobs:
+  latin-phrases:
+    # Run on the latest Ubuntu distribution
+    runs-on: ubuntu-latest
+    # This section collects together the steps involved in running the test
+    steps:
+    # Checkout the repository. Relies on another GH-Action.
+    - uses: actions/checkout@v2
+    # Set up the Python version. Relies on another GH-Action.
+    - name: Setup Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    # Install Python dependencies
+    - name: Install dependencies
+      working-directory: ./tests
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+    # Run a Python script
+    - name: Run Python script to check for latin phrases - Master
+      working-directory: ./tests
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: |
+        python no-bad-latin.py
+
+    - name: Run Python script to check for latin phrases - Pull Request
+      working-directory: ./tests
+      if: github.event.pull_request
+      run: |
+        python no-bad-latin.py --pull-request ${{ github.event.pull_request.number }}

--- a/.github/workflows/no-bad-latin.yml
+++ b/.github/workflows/no-bad-latin.yml
@@ -1,4 +1,14 @@
-# Give your test a name!
+
+# This action initially adopted from The Turing Way from in October 2020.
+# doi:10.5281/zenodo.3233853
+# https://github.com/alan-turing-institute/the-turing-way/blob/af98c94/.github/workflows/no-bad-latin.yml
+# 
+# This action triggers the script tools/no-bad-latin.py to and will throw an error if any latin expression (like e.g. or i.e.) is detected:
+# 
+#  This action will be triggered
+# -   on a push to master
+# -   on a PR to the master branch and will only check files that were modified in src
+
 name: Check for Latin Phrases
 
 # Decide when to run the tests

--- a/.github/workflows/no-bad-latin.yml
+++ b/.github/workflows/no-bad-latin.yml
@@ -29,19 +29,19 @@ jobs:
         python-version: 3.7
     # Install Python dependencies
     - name: Install dependencies
-      working-directory: ./tests
+      working-directory: ./tools
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
     # Run a Python script
     - name: Run Python script to check for latin phrases - Master
-      working-directory: ./tests
+      working-directory: ./tools
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
         python no-bad-latin.py
 
     - name: Run Python script to check for latin phrases - Pull Request
-      working-directory: ./tests
+      working-directory: ./tools
       if: github.event.pull_request
       run: |
         python no-bad-latin.py --pull-request ${{ github.event.pull_request.number }}

--- a/tools/no-bad-latin.py
+++ b/tools/no-bad-latin.py
@@ -3,6 +3,7 @@
 # Detect Latin abbreviations that can be difficult for screenreaders and non-native English speakers
 #
 # This script initially adopted from The Turing Way from in October 2020.
+# doi:10.5281/zenodo.3233853
 # https://github.com/alan-turing-institute/the-turing-way/blob/af98c94/tests/no-bad-latin.py
 
 import os

--- a/tools/no-bad-latin.py
+++ b/tools/no-bad-latin.py
@@ -86,7 +86,10 @@ def read_and_check_files(files):
 				  containing the offending line.
 	"""
     failing_files = {}
-    bad_latin = ["i.e.", "e.g.", "e.t.c.", " etc", " ie ", "et cetera"]
+    bad_latin = [
+        "i.e.", "i.e ", " ie ", 
+        "e.g.", "e.g ",  
+        "e.t.c.", " etc", "et cetera"]
 
     for filename in files:
         if os.path.basename(filename) in IGNORE_LIST:

--- a/tools/no-bad-latin.py
+++ b/tools/no-bad-latin.py
@@ -117,7 +117,7 @@ def read_and_check_files(files):
 
 
 def get_all_files(directory=os.path.join(ABSOLUTE_HERE, "src")):
-    """Get a list of files to be checked. Ignores image files.
+    """Get a list of files to be checked. Ignores image, javacript, css files.
 
 	Keyword Arguments:
 		directory {string} -- The directory containing the files to check

--- a/tools/no-bad-latin.py
+++ b/tools/no-bad-latin.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# 
+# Detect Latin abbreviations that can be difficult for screenreaders and non-native English speakers
+#
+# This script initially adopted from The Turing Way from in October 2020.
+# https://github.com/alan-turing-institute/the-turing-way/blob/af98c94/tests/no-bad-latin.py
+
 import os
 import re
 import argparse

--- a/tools/no-bad-latin.py
+++ b/tools/no-bad-latin.py
@@ -1,0 +1,153 @@
+import os
+import re
+import argparse
+from pull_files import filter_files
+
+HERE = os.getcwd()
+ABSOLUTE_HERE = os.path.dirname(HERE)
+IGNORE_LIST = [ "_config.yml", "style.md", "contributors-record.md"]
+
+
+def parse_args():
+    """Construct command line interface for parsing Pull Request number"""
+    DESCRIPTION = "Script to check for latin phrases in Markdown files"
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+
+    parser.add_argument(
+        "--pull-request",
+        type=str,
+        default=None,
+        help="If the script is being run on a Pull Request, parse the PR number",
+    )
+
+    return parser.parse_args()
+
+
+def remove_comments(text_string):
+    """Function to omit  html comment identifiers in a text string using
+	regular expression matches
+
+	Arguments:
+		text_string {string} -- The text to be matched
+
+	Returns:
+		{string} -- The input text string with html comments removed
+	"""
+    p = re.sub("(?s)<!--(.*?)-->", "", text_string)
+    return p
+
+
+def get_lines(text_string, sub_string):
+    """Get individual lines in a text file
+
+	Arguments:
+		text_string {string} -- The text string to test
+		sub_string {string} -- The conditional string to perform splitting on
+
+	Returns:
+		{list} -- A list of split strings
+	"""
+    lines = [line for line in text_string.split("\n") if sub_string in line]
+    return lines
+
+
+def construct_error_message(files_dict):
+    """Function to construct an error message pointing out where bad latin
+	phrases appear in lines of text
+
+	Arguments:
+		files_dict {dictionary} -- Dictionary of failing files containing the
+		                           bad latin phrases and offending lines
+
+	Returns:
+		{string} -- The error message to be raised
+	"""
+    error_message = ["Bad latin found in the following files:\n"]
+
+    for file in files_dict.keys():
+        error_message.append(
+            f"{file}:\t{files_dict[file]['latin_type']}\tfound in line\t[{files_dict[file]['line']}]\n"
+        )
+
+    return "\n".join(error_message)
+
+
+def read_and_check_files(files):
+    """Function to read in files, remove html comments and check for bad latin
+	phrases
+
+	Arguments:
+		files {list} -- List of filenames to be checked
+
+	Returns:
+		{dict} -- Dictionary: Top level keys are absolute filepaths to files
+		          that failed the check. Each of these has two keys:
+				  'latin_type' containing the unwanted latin phrase, and 'line'
+				  containing the offending line.
+	"""
+    failing_files = {}
+    bad_latin = ["i.e.", "e.g.", "e.t.c.", " etc", " ie ", "et cetera"]
+
+    for filename in files:
+        if os.path.basename(filename) in IGNORE_LIST:
+            pass
+        else:
+            try:
+                with open(
+                os.path.join(ABSOLUTE_HERE, filename), encoding="utf8",
+                errors="ignore") as f:
+                    text = f.read()
+                    text = remove_comments(text)
+
+                    for latin_type in bad_latin:
+                        if latin_type in text.lower():
+                            lines = get_lines(text.lower(), latin_type)
+                            for line in lines:
+                                failing_files[os.path.abspath(filename)] = {
+                                    "latin_type": latin_type,
+                                    "line": line,
+                                }
+            except FileNotFoundError:
+                pass
+
+    return failing_files
+
+
+def get_all_files(directory=os.path.join(ABSOLUTE_HERE, "src")):
+    """Get a list of files to be checked. Ignores image files.
+
+	Keyword Arguments:
+		directory {string} -- The directory containing the files to check
+
+	Returns:
+		{list} -- List of files to check
+	"""
+    files = []
+    filetypes_to_ignore = (".png", ".jpg", ".js", ".css")
+
+    for rootdir, _, filenames in os.walk(directory):
+        for filename in filenames:
+            if not filename.endswith(filetypes_to_ignore):
+                files.append(os.path.join(rootdir, filename))
+
+    return files
+
+
+def main():
+    """Main function"""
+    args = parse_args()
+
+    if args.pull_request is not None:
+        files = filter_files(args.pull_request)
+    else:
+        files = get_all_files()
+
+    failing_files = read_and_check_files(files)
+
+    if bool(failing_files):
+        error_message = construct_error_message(failing_files)
+        raise Exception(error_message)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pull_files.py
+++ b/tools/pull_files.py
@@ -1,0 +1,69 @@
+"""
+Script to pull changed files in a Pull Request using a GET resquest to the
+GitHub API.
+"""
+import requests
+import argparse
+
+
+def parse_args():
+    """Construct the command line interface for the script"""
+    DESCRIPTION = "Script to check for occurences of 'Lorem Ipsum' in Markdown files"
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+
+    parser.add_argument(
+        "--pull-request",
+        type=str,
+        default=None,
+        help="If the script is be run on files changed by a pull request, parse the PR number",
+    )
+
+    return parser.parse_args()
+
+
+def get_files_from_pr(pr_num):
+    """Return a list of changed files from a GitHub Pull Request
+
+    Arguments:
+        pr_num {str} -- Pull Request number to get modified files from
+
+    Returns:
+        {list} -- List of modified filenames
+    """
+    files = []
+    pr_url = f"https://api.github.com/repos/alan-turing-institute/the-turing-way/pulls/{pr_num}/files"
+    resp = requests.get(pr_url)
+
+    for item in resp.json():
+        files.append(item["filename"])
+
+    return files
+
+
+def filter_files(pr_num, start_phrase="book/website"):
+    """Filter modified files from a Pull Request by a start phrase
+
+    Arguments:
+        pr_num {str} -- Number of the Pull Request to get modified files from
+
+    Keyword Arguments:
+        start_phrase {str} -- Start phrase to filter changed files by
+                              (default: {"book/website"})
+
+    Returns:
+        {list} -- List of filenames that begin with the desired start phrase
+    """
+    files = get_files_from_pr(pr_num)
+    filtered_files = []
+
+    for filename in files:
+        if filename.startswith(start_phrase):
+            filtered_files.append(filename)
+
+    return filtered_files
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    changed_files = filter_files(args.pull_request)
+    print(changed_files)

--- a/tools/pull_files.py
+++ b/tools/pull_files.py
@@ -1,6 +1,11 @@
 """
-Script to pull changed files in a Pull Request using a GET resquest to the
+Script to pull changed files in a Pull Request using a GET request to the
 GitHub API.
+
+This script initially adopted from The Turing Way from in October 2020.
+doi:10.5281/zenodo.3233853
+https://github.com/alan-turing-institute/the-turing-way/blob/af98c94/tests/pull_files.py
+
 """
 import requests
 import argparse

--- a/tools/pull_files.py
+++ b/tools/pull_files.py
@@ -8,7 +8,7 @@ import argparse
 
 def parse_args():
     """Construct the command line interface for the script"""
-    DESCRIPTION = "Script to check for occurences of 'Lorem Ipsum' in Markdown files"
+    DESCRIPTION = "Script to pull changed files in a Pull Request using a GET resquest to the GitHub API."
     parser = argparse.ArgumentParser(description=DESCRIPTION)
 
     parser.add_argument(
@@ -31,7 +31,7 @@ def get_files_from_pr(pr_num):
         {list} -- List of modified filenames
     """
     files = []
-    pr_url = f"https://api.github.com/repos/alan-turing-institute/the-turing-way/pulls/{pr_num}/files"
+    pr_url = f"https://api.github.com/repos/bids-standard/bids-specification/pulls/{pr_num}/files"
     resp = requests.get(pr_url)
 
     for item in resp.json():
@@ -40,7 +40,7 @@ def get_files_from_pr(pr_num):
     return files
 
 
-def filter_files(pr_num, start_phrase="book/website"):
+def filter_files(pr_num, start_phrase="src"):
     """Filter modified files from a Pull Request by a start phrase
 
     Arguments:
@@ -48,7 +48,7 @@ def filter_files(pr_num, start_phrase="book/website"):
 
     Keyword Arguments:
         start_phrase {str} -- Start phrase to filter changed files by
-                              (default: {"book/website"})
+                              (default: {"src"})
 
     Returns:
         {list} -- List of filenames that begin with the desired start phrase

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
This relates to the issue #635 .
fixes #635 

TODO
- [x] import and adapt script 
- [x] test script locally
- [x] credit the turing-way
- [x] test the github action

Adapting the code from the Turing way was actually easier than anticipated.

## script

The way this is set up, this should look through the files in the `src` folder ignoring the files with extensions listed in `get_all_files` and look for lines that contain the expressions listed in `read_and_check_files`.

Comments lines are skipped. 

Files added to the `src` folder in a PR are also checked

## github action
It will trigger the script : 
- on a push to master 
- on a PR to the master branch and will only check files that were modified in `src`

## for reviewers

My python is far from fluent so a cross check would be good. :pray: 

~~Any suggestions on how to smartly test a github action? Should I merge into this onto my own master to give this a go.~~
This seems to be set up directly even in this PR. Never mind.