### PR TITLE
[MISC] add brief note that TSV example in the spec may currently use either tab or space characters

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -455,6 +455,7 @@ are occasionally formatted using space characters instead of tabs to improve
 human readability.
 Directly copying and then pasting these examples from the specification
 for use in new BIDS datasets can lead to errors and is discouraged.
+
 Tabular files MAY be optionally accompanied by a simple data dictionary
 in the form of a JSON [object](https://www.json.org/json-en.html)
 within a JSON file.

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -446,8 +446,8 @@ exponent. TSV files MUST be in UTF-8 encoding.
 Example:
 
 ```Text
-onset duration  response_time correct stop_trial  go_trial
-200 200 0 n/a n/a n/a
+onset	duration	response_time	correct	stop_trial	go_trial
+200	200	0	n/a	n/a	n/a
 ```
 
 Tabular files MAY be optionally accompanied by a simple data dictionary

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -450,10 +450,11 @@ onset	duration	response_time	correct	stop_trial	go_trial
 200	200	0	n/a	n/a	n/a
 ```
 
-**Note**: TSV examples in the document can be re-formatted using
-spaces instead of tabs for human readability, and have tabs replaced
-with spaces by used for rendering HTML or PDF.
-
+**Note**: The TSV examples in this document (like the one above this note)
+are occasionally formatted using space characters instead of tabs to improve
+human readability.
+Directly copying and then pasting these examples from the specification
+for use in new BIDS datasets can lead to errors and is discouraged.
 Tabular files MAY be optionally accompanied by a simple data dictionary
 in the form of a JSON [object](https://www.json.org/json-en.html)
 within a JSON file.

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -450,6 +450,10 @@ onset	duration	response_time	correct	stop_trial	go_trial
 200	200	0	n/a	n/a	n/a
 ```
 
+**Note**: TSV examples in the document can be re-formatted using
+spaces instead of tabs for human readability, and have tabs replaced
+with spaces by used for rendering HTML or PDF.
+
 Tabular files MAY be optionally accompanied by a simple data dictionary
 in the form of a JSON [object](https://www.json.org/json-en.html)
 within a JSON file.


### PR DESCRIPTION
Inspired by realization while discussing now merged https://github.com/bids-standard/bids-specification/pull/619 

See individual commits description for more information.  A satellite issue on harmonization of tsv examples ~~will be filed shortly~~ #644