### PR TITLE
[FIX] Fixing template string on electrodes for eeg and ieeg.

### DIFF
--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -279,7 +279,7 @@ Template:
 sub-<label>/
     [ses-<label>]/
       eeg/
-        [sub-<label>[_ses-<label>][_acq-<label>][_run-<index>]_electrodes.tsv]
+        sub-<label>[_ses-<label>][_acq-<label>][_space-<label>]_electrodes.tsv]
 ```
 
 File that gives the location of EEG electrodes. Note that coordinates are

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -279,7 +279,7 @@ Template:
 sub-<label>/
     [ses-<label>]/
       eeg/
-        sub-<label>[_ses-<label>][_acq-<label>][_space-<label>]_electrodes.tsv]
+        sub-<label>[_ses-<label>][_acq-<label>][_space-<label>]_electrodes.tsv
 ```
 
 File that gives the location of EEG electrodes. Note that coordinates are

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -300,7 +300,7 @@ Template:
 sub-<label>/
     [ses-<label>]/
       ieeg/
-         sub-<label>[_ses-<label>][_space-<label>]_electrodes.tsv
+         sub-<label>[_ses-<label>][_acq-<label>][_space-<label>]_electrodes.tsv
 ```
 
 File that gives the location, size and other properties of iEEG electrodes. Note


### PR DESCRIPTION
# Summary

Closes: #649 

Fixes the template strings in the modality-specific spec to match that of https://bids-specification.readthedocs.io/en/stable/99-appendices/04-entity-table.html#encephalography-eeg-ieeg-and-meg
