### PR TITLE
[MISC] use RFC 2119 language in legend of the "volume timing" table

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -381,9 +381,9 @@ sparse sequences.
 
 **Legend**
 
--   \[ X ] --> has to be filled
--   \[   \] --> has to be left empty
--   empty cell --> can be specified but not required
+-   \[ X ] --> MUST be defined
+-   \[  \] --> MUST NOT be defined
+-   empty cell --> MAY be specified
 
 #### fMRI task information
 


### PR DESCRIPTION
Small update to be consistent with the incoming legend on BEP005.