### PR TITLE
[DOC] add contributing guidelines to add figures in the specs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Jump to the following sections:
 -   [Understanding issues](#understanding-issues)
 -   [Writing in markdown](#writing-in-markdown)
 -   [Fixing Remark errors from Travis](#fixing-travis-remark-errors)
+-   [## Adding a figure to the specifications](#adding-a-figure-to-the-specifications)
 -   [Making a change with a pull request](#making-a-change-with-a-pull-request)
 -   [Example pull request](#example-pull-request)
 -   [Commenting on a pull request](#commenting-on-a-pull-request)
@@ -232,6 +233,29 @@ mv flagged_file_fixed.md flagged_file.md
 git add flagged_file.md
 git commit -m 'STY: Fixed Markdown style'
 ```
+
+## Adding a figure to the specifications
+
+> A figure is worth a 1000 words! 
+
+If you think that a figure or a picture can help summarize several aspects or notions of the 
+specifications, do not hesitate to make a suggestion by showing a draft in a Github issue.
+
+You can then submit your image in a pull request.
+
+Images should be added to an `images` folder that is at the same level as the Markdown file
+where your image will be added. For example if you want to add a figure `figure01.png` to 
+`src/05-derivatives/01-introduction.md` then your image should go 
+`src/05-derivatives/images/figure01.png`.
+
+Figures can be inserted in a Markdown like this:
+
+```markdown
+![ ](relative_path_to_file "alternative name")
+```
+
+If you are adding a figure (and not picture) make sure to also join a vector format 
+of that figure (ideally as an `.svg` file).
 
 ## Making a change with a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,14 +257,14 @@ Figures can be inserted in a Markdown like this (see also
 ```
 ### Recommendations for figures
 
-1. Try to keep the file size of your figure relatively small (inferior to 500 Ko) 
+1. Try to keep the file size of your figure relatively small (smaller than 500 Kb) 
 to keep the repository light and reduce the load time of the specs 
 for people who do not necessarily have broad-band internet.
 
-1. Figures in the main part of the specification should aim to be for very "comprehensive" 
+1. Figures in the main part of the specification should aim to be very "comprehensive" 
 but "smaller" figures can find their home in the appendices or the BIDS-starter-kit.
 
-1. If you are adding a figure (and not picture) make sure to also join a vector format 
+1. If you are adding a figure (and not picture) make sure to also supply a vector format 
 of that figure (ideally as an `.svg` file) as this makes it easier to edit it in the
 future.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,7 +240,6 @@ git commit -m 'STY: Fixed Markdown style'
 
 If you think that a figure or a picture can help summarize several aspects or notions of the 
 specifications, do not hesitate to make a suggestion by showing a draft in a Github issue.
-
 You can then submit your image in a pull request.
 
 Images should be added to an `images` folder that is at the same level as the Markdown file
@@ -254,8 +253,22 @@ Figures can be inserted in a Markdown like this:
 ![ ](relative_path_to_file "alternative name")
 ```
 
-If you are adding a figure (and not picture) make sure to also join a vector format 
-of that figure (ideally as an `.svg` file).
+### Recommendations for figures
+
+1. Try to keep the file size of your figure relatively small (inferior to 500 Ko) 
+to keep the repository light and reduce the load time of the specs 
+for people who do not necessarily have broad-band internet.
+
+1. Figures in the main part of the specification should aim to be for very "comprehensive" 
+but "smaller" figures can find their home in the appendices or the BIDS-starter-kit.
+
+1. If you are adding a figure (and not picture) make sure to also join a vector format 
+of that figure (ideally as an `.svg` file) as this makes it easier to edit it in the
+future.
+
+1. Try to include a README file that details where the figure / image came from 
+and how it can be reproduced. Preferably with a link to the file that generated the figure
+if relevant.
 
 ## Making a change with a pull request
 


### PR DESCRIPTION
The need for guidelines regarding figures in the specifications was mentioned in a meeting related to BEP005 and was also pointed in the PET BEP.

This is a PR to get some sort of guidelines started.

### Questions

- Do we want to have specific format recommendations for non-vector graphics? png?
- Maybe some size limits on the images too to avoid having people send us 15 Mo images. :-)

I might be overlooking some aspects with the pdf conversion process too that I don't know too well.