### PR TITLE
FIX: Correct entity names in YAML files

### DIFF
--- a/src/schema/datatypes/anat.yaml
+++ b/src/schema/datatypes/anat.yaml
@@ -116,7 +116,7 @@
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    inv: required
+    inversion: required
     part: optional
 # Seventh group
 - suffixes:
@@ -134,7 +134,7 @@
     reconstruction: optional
     echo: optional
     flip: required
-    inv: required
+    inversion: required
     part: optional
 # Eighth group
 - suffixes:
@@ -153,7 +153,7 @@
     reconstruction: optional
     echo: optional
     flip: required
-    mt: required
+    mtransfer: required
     part: optional
 # Nineth group
 - suffixes:
@@ -169,5 +169,5 @@
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    mt: required
+    mtransfer: required
     part: optional


### PR DESCRIPTION
This corrects a problem with the CI identified in #719. In #610 we switched to using the entity names, rather than keys, in the datatype YAML files, while in #714 we changed those names for a couple of entities. As such, the old names are referenced in the datatype YAML files, which causes a conflict with the rendering code.