### PR TITLE
FIX: Make flip optional for MP2RAGE

### DIFF
--- a/src/schema/datatypes/anat.yaml
+++ b/src/schema/datatypes/anat.yaml
@@ -133,7 +133,7 @@
     ceagent: optional
     reconstruction: optional
     echo: optional
-    flip: required
+    flip: optional
     inversion: required
     part: optional
 # Eighth group


### PR DESCRIPTION
References #721.

Changes proposed:
- Make the `flip` entity optional for the MP2RAGE suffix.