### PR TITLE
FIX: Correct schema irregularities for func datatype

### DIFF
--- a/src/schema/datatypes/dwi.yaml
+++ b/src/schema/datatypes/dwi.yaml
@@ -1,5 +1,5 @@
 ---
-# First group
+# DWI
 - suffixes:
     - dwi
   extensions:
@@ -15,7 +15,7 @@
     direction: optional
     run: optional
     part: optional
-# Second group
+# Single-band reference images
 - suffixes:
     - sbref
   extensions:

--- a/src/schema/datatypes/func.yaml
+++ b/src/schema/datatypes/func.yaml
@@ -1,5 +1,5 @@
 ---
-# First group
+# Func
 - suffixes:
     - bold
     - cbv
@@ -19,9 +19,9 @@
     run: optional
     echo: optional
     part: optional
-# Second group
+# Phase (deprecated)
 - suffixes:
-    - phase
+    - phase  # deprecated
   extensions:
     - .nii.gz
     - .nii
@@ -36,7 +36,7 @@
     direction: optional
     run: optional
     echo: optional
-# Third group
+# Events
 - suffixes:
     - events
   extensions:
@@ -51,7 +51,7 @@
     reconstruction: optional
     direction: optional
     run: optional
-# Fourth group
+# Timeseries
 - suffixes:
     - physio
     - stim

--- a/src/schema/datatypes/func.yaml
+++ b/src/schema/datatypes/func.yaml
@@ -51,7 +51,6 @@
     reconstruction: optional
     direction: optional
     run: optional
-    echo: optional
 # Fourth group
 - suffixes:
     - physio

--- a/src/schema/datatypes/func.yaml
+++ b/src/schema/datatypes/func.yaml
@@ -63,6 +63,8 @@
     session: optional
     task: required
     acquisition: optional
+    ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     recording: optional


### PR DESCRIPTION
Closes None, but stems (in part) from https://github.com/bids-standard/bids-validator/pull/1125#discussion_r571177984.

Changes proposed:

- Prohibit combination of `echo` entity and `_events` suffix. The echo entity delineates files _within_ an imaging run, so it shouldn't be used for associated files that apply to the whole run.
- Allow `ce` and `dir` entities with `func/` continuous data (the `_physio` and `_stim` suffixes). These entities distinguish imaging runs, so they are required to link the continuous data to the imaging scan.
    - For example, we currently could have `sub-X_task-Y_dir-AP_bold.nii.gz`, `sub-X_task-Y_dir-PA_bold.nii.gz`, and `sub-X_task-Y_physio.tsv.gz`, and there would be no way to know which BOLD scan the physio is associated with.