### PR TITLE
[FIX] schema for i/eeg coordsys+elecs: sub-ses-acq-space are allowed entities

### DIFF
--- a/src/schema/datatypes/eeg.yaml
+++ b/src/schema/datatypes/eeg.yaml
@@ -35,6 +35,7 @@
     subject: required
     session: optional
     acquisition: optional
+    space: optional
 - suffixes:
     - electrodes
   extensions:

--- a/src/schema/datatypes/ieeg.yaml
+++ b/src/schema/datatypes/ieeg.yaml
@@ -35,17 +35,18 @@
   entities:
     subject: required
     session: optional
+    acquisition: optional
     space: optional
 - suffixes:
     - electrodes
   extensions:
-    # No json, since electrodes.tsv uses coordsystem.json for metadata
+    - .json
     - .tsv
   entities:
     subject: required
     session: optional
-    space: optional
     acquisition: optional
+    space: optional
 - suffixes:
     - events
   extensions:


### PR DESCRIPTION
while opening https://github.com/bids-standard/bids-validator/issues/1198 I noticed some inconsistencies in our schema.


Q&A about the changes in this PR.

- Q: Why adding "space" to EEG coordsystem.json and "acq" to iEEG coordsystem.json?
    - A: coordsystem.json contains metadata for electrodes.tsv ... so it must support the same entities as electrodes.tsv
    - "space" is used to distinguish files from different "coordinate spaces"
    - "acq" is used for something like "coordinates digitized pre or post recording" -> acq-pre, acq-post
- Q: Why allow electrodes.json?
    - A: that file explains additional arbitrary columns in electrodes.tsv ... these are not added to coordsystem.json, which has a restricted set of metadata that can/must be specified
- And the remaining change is just for consistency, that space comes after acq in a file name.












---


I still have to rebuild the entitiy table, but I keep running into issues. @tsalo what's the current way to call the script (see also #696 )?

> ...:~/Desktop/bids/bids-specification$ python tools/schemacode/schema.py entities src/schema/ src/99-appendices/04-entity-table.md
Traceback (most recent call last):
  File "tools/schemacode/schema.py", line 12, in <module>
    from . import utils
