### PR TITLE
[ENH] allow for _stim.{mp[34],mkv,avi} to provide stimuli files for func data

### DIFF
--- a/src/schema/datatypes/func.yaml
+++ b/src/schema/datatypes/func.yaml
@@ -54,10 +54,29 @@
 # Timeseries
 - suffixes:
     - physio
+  extensions:
+    - .tsv.gz
+    - .json
+  entities:
+    subject: required
+    session: optional
+    task: required
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    direction: optional
+    run: optional
+    recording: optional
+# Stimuli
+- suffixes:
     - stim
   extensions:
     - .tsv.gz
     - .json
+    - .mp3
+    - .mp4
+    - .mkv
+    - .avi
   entities:
     subject: required
     session: optional


### PR DESCRIPTION
The intention is to allow for BIDS to have not only "one for all" `stimuli/`
which is typically used for storing stimuli shared (selectively or overall)
across subjects, but also to allow for storing subject/session specific
audio-video stimulation.  Such stimulation could be

- pre-"rendered" audio or video clip presented to the subject
- recording of auditory input from some interactive sessions or
  hyperscanning (as received from another participant)
- VR feed presented to the subject 
- or, just simply audio/video recording for EVERY BIDS dataset/acqusition,
  as we are aiming to achieve with https://github.com/ReproNim/reprostim/
  (which was already handy to recover trial order randomization in the
  event of an overriden protocol file)

Note that we already had _stim.{tsv,json} reserved for similar cases in the
scope of
https://github.com/bids-standard/bids-specification/blob/HEAD/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md

And in this case ideally each .media (.mp3 etc) file SHOULD be accompanied by
.json.  I do see that aforementioned one making .json a MUST to have one one,
but I do not think it is necessary in the case of .media recordings since
ideally they should be perfectly aligned (thus StartTime=0), there would be no
Columns, and SamplingFrequency might be insufficient since might need to
be specified for different stimuli streams (video or audio).

WDYT?

TODOs
- [ ] do formalize the content of .json sidecar file
- [ ] add pertinent example(s) in the section for functional data?