### PR TITLE
[WIP; ENH] Storage of iEEG electrodes in subject-specific FreeSurfer space

### DIFF
--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -151,6 +151,11 @@ Restricted keywords for the `<CoordSysType>CoordinateSystem` field in the
     [ACPC site](https://www.fieldtriptoolbox.org/faq/acpc/) on the FieldTrip
     toolbox wiki.
 
+-   `fsnative`: The origin of the coordinate system is at the center of
+    isotropic 1 mm 256x256x256 volume in RAS orientation. This corresponds
+    to electrode coordinates localized on the subject-specific ``T1.mgz``
+    FreeSurfer file.
+
 -   Any keyword from the list of
     [Standard template identifiers](#standard-template-identifiers)
 


### PR DESCRIPTION
Closes: #747 

Currently, this is a draft to demonstrate exactly what would fix issues discussed in #747 .

What I'm not sure of is how to modify the following:

```
### Nonstandard coordinate system identifiers

The following template identifiers are RECOMMENDED for individual- and study-specific reference
spaces.
In order for these spaces to be interpretable, `SpatialReference` metadata MUST be provided, as
described in [Common file level metadata fields][common file level metadata fields].

In the case of multiple study templates, additional names may need to be defined.

| Coordinate System | Description                                                                                                                                                                                                                                                           |
| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| individual        | Participant specific anatomical space (for example derived from T1w and/or T2w images). This coordinate system requires specifying an additional, participant-specific file to be fully defined. In context of surfaces this space has been refered to as `fsnative`. |
| study             | Custom space defined using a group/study-specific template. This coordinate system requires specifying an additional file to be fully defined.                                                                                                                        |
```

Since I'm not sure what exactly the `individual` coordinate system is used for. It seems like an umbrella term that also encompasses `fsnative`.