### PR TITLE
[FIX] run entity - "scans" -> "data samples"

### DIFF
--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -240,7 +240,7 @@ run:
   name: Run
   entity: run
   description: |
-    If several scans with the same acquisition parameters are acquired in the same session,
+    If several data samples (e.g., MRI scans) with the same acquisition parameters are acquired in the same session,
     they MUST be indexed with the [`run-<index>`](../99-appendices/09-entities.md#run) entity:
     `_run-1`, `_run-2`, `_run-3`, and so on (only nonnegative integers are allowed as
     run labels).

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -240,7 +240,7 @@ run:
   name: Run
   entity: run
   description: |
-    If several data samples (e.g., MRI scans) with the same acquisition parameters are acquired in the same session,
+    If several data acquisitions (for example, MRI scans or EEG recordings) with the same acquisition parameters are acquired in the same session,
     they MUST be indexed with the [`run-<index>`](../99-appendices/09-entities.md#run) entity:
     `_run-1`, `_run-2`, `_run-3`, and so on (only nonnegative integers are allowed as
     run labels).

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -240,7 +240,8 @@ run:
   name: Run
   entity: run
   description: |
-    If several data acquisitions (for example, MRI scans or EEG recordings) with the same acquisition parameters are acquired in the same session,
+    If several data acquisitions (for example, MRI scans or EEG recordings)
+    with the same acquisition parameters are acquired in the same session,
     they MUST be indexed with the [`run-<index>`](../99-appendices/09-entities.md#run) entity:
     `_run-1`, `_run-2`, `_run-3`, and so on (only nonnegative integers are allowed as
     run labels).


### PR DESCRIPTION
As we have now other modalities, such as EEG and MEG, "scan" is not really the
most appropriate term here.  Having said that we do use _scans etc for EEG and
MEG as well ATM, as it was the "forward compatible" with existing MRI-centric
BIDS back then.
