### PR TITLE
[INFRA] install git in linkchecker job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,14 @@ jobs:
           # mkdocs build outputs will be in ~/project/site
           at: ~/project
       - run:
+          name: install git
+          command: |
+            apt update -y
+            apt install git-all -y
+      - run:
           name: check links
           command: |
+            git status
             if (! git log -1 --pretty=%b | grep REL:) ; then
               chmod a+rX -R ~
               linkchecker -t 1 ~/project/site/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           command: |
             cd ~/project/pdf_build_src
             bash build_pdf.sh
-            mv ~/project/pdf_build_src/bids-spec.pdf ./bids-spec.pdf
+            mv ~/project/pdf_build_src/bids-spec.pdf ~/project/bids-spec.pdf
       - store_artifacts:
           path: bids-spec.pdf
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
     docker:
       - image: yarikoptic/linkchecker:9.4.0.anchorfix1-1
     steps:
+      # checkout code to default ~/project
+      - checkout
       - attach_workspace:
           # mkdocs build outputs will be in ~/project/site
           at: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,9 @@ jobs:
           command: |
             cd ~/project/pdf_build_src
             bash build_pdf.sh
+            mv ~/project/pdf_build_src/bids-spec.pdf ./bids-spec.pdf
       - store_artifacts:
-          path: ~/project/pdf_build_src/bids-spec.pdf
+          path: bids-spec.pdf
 
   # Auto changelog collector
   github-changelog-generator:

--- a/pdf_build_src/pandoc_script.py
+++ b/pdf_build_src/pandoc_script.py
@@ -40,9 +40,21 @@ def build_pdf(filename):
         '--output={}'.format(filename),
     ]
 
+    # location of this file: This is also the working directory when
+    # the pdf is being built using `cd build_pdf_src` and then
+    # `bash build_pdf.sh`
+    root = pathlib.Path(__file__).parent.absolute()
+
+    # Resources are searched relative to the working directory, but
+    # we can add additional search paths using <path>:<another path>, ...
+    # When in one of the 99-appendices/ files there is a reference to
+    # "../04-modality-specific-files/images/...", then we need to use
+    # 99-appendices/ as a resource-path so that the relative files can
+    # be found.
+    cmd += [f'--resource-path=.:{str(root / "99-appendices")}']
+
     # Add input files to command
     # The filenames in `markdown_list` will ensure correct order when sorted
-    root = pathlib.Path(__file__).parent.absolute()
     cmd += [str(root / index_page)]
     cmd += [str(root / i) for i in sorted(markdown_list)]
 


### PR DESCRIPTION
closes #765 --> by installing `git` prior to the linkchecker job, ... so that we can properly evaluate the if/else logic

fixes the most crucial part of #766 --> by adding a resource path that allows pandoc to find previously missing image files