### PR TITLE
[FIX] Remove acq from PET filenames

### DIFF
--- a/src/schema/datatypes/pet.yaml
+++ b/src/schema/datatypes/pet.yaml
@@ -10,7 +10,6 @@
     subject: required
     session: optional
     task: optional
-    acquisition: optional
     tracer: optional
     reconstruction: optional
     run: optional
@@ -24,7 +23,6 @@
     subject: required
     session: optional
     task: optional
-    acquisition: optional
     tracer: optional
     reconstruction: optional
     run: optional


### PR DESCRIPTION
Closes #768.

Changes proposed:

- Remove the `acq` entity from `pet` and `blood` files.