### PR TITLE
[MISC] Add mini entity tables after filename templates

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -138,6 +138,8 @@ whenever possible. See also
 
 {{ MACROS___make_filename_template(datatypes=["anat"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["anat"]) }}
+
 Anatomical (structural) data acquired for that participant. Currently supported
 non-parametric structural MR images include:
 
@@ -300,6 +302,8 @@ Currently supported image contrasts include:
 | Phase    | phase    | [DEPRECATED](../02-common-principles.md#definitions). Phase information associated with magnitude information stored in BOLD contrast. This suffix should be replaced by the [`part-phase`](../99-appendices/09-entities.md#part) in conjunction with the `bold` suffix. |
 
 {{ MACROS___make_filename_template(datatypes=["func"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["func"]) }}
 
 Functional imaging consists of techniques that support rapid temporal repetition.
 This includes but is not limited to task based fMRI
@@ -492,6 +496,8 @@ Currently supported image types include:
 
 {{ MACROS___make_filename_template(datatypes=["dwi"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["dwi"]) }}
+
 If more than one run of the same acquisition and direction has been acquired, the
 [`run-<index>`](../99-appendices/09-entities.md#run) key/value pair MUST be used:
 `_run-1`, `_run-2`, `_run-3` (and so forth.)
@@ -664,6 +670,8 @@ JSON example:
 
 {{ MACROS___make_filename_template(datatypes=["perf"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["perf"]) }}
+
 The complete ASL time series should be stored as a 4D NIfTI file in the original acquisition order,
 accompanied by two ancillary files: `*_asl.json` and `*_aslcontext.tsv`.
 
@@ -834,6 +842,8 @@ are allowed across all the four scenarios:
 
 {{ MACROS___make_filename_template(datatypes=["fmap"], suffixes=["phasediff", "magnitude1", "magnitude2"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["fmap"], suffixes=["phasediff", "magnitude1", "magnitude2"]) }}
+
 where
 the REQUIRED `_phasediff` image corresponds to the phase-drift map between echo times,
 the REQUIRED `_magnitude1` image corresponds to the shorter echo time, and
@@ -867,6 +877,8 @@ second echos are available.
 
 {{ MACROS___make_filename_template(datatypes=["fmap"], suffixes=["phase1", "phase2", "magnitude1", "magnitude2"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["fmap"], suffixes=["phase1", "phase2", "magnitude1", "magnitude2"]) }}
+
 Required fields:
 
 | **Key name** | **Requirement level** | **Data type** | **Description**                                                                   |
@@ -887,6 +899,8 @@ In some cases (for example GE), the scanner software will directly reconstruct a
 *B<sub>0</sub>* field map along with a magnitude image used for anatomical reference.
 
 {{ MACROS___make_filename_template(datatypes=["fmap"], suffixes=["fieldmap", "magnitude"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["fmap"], suffixes=["fieldmap", "magnitude"]) }}
 
 Required fields:
 
@@ -917,6 +931,8 @@ Examples of software tools using these kinds of images are FSL TOPUP,
 AFNI `3dqwarp`, and SPM.
 
 {{ MACROS___make_filename_template(datatypes=["fmap"], suffixes=["epi"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["fmap"], suffixes=["epi"]) }}
 
 The [`dir-<label>`](../99-appendices/09-entities.md#dir) entity is REQUIRED
 for these files.

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -10,6 +10,8 @@ context of the academic literature.
 
 {{ MACROS___make_filename_template(datatypes=["meg"], suffixes=["meg", "markers", "events"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["meg"], suffixes=["meg", "markers", "events"]) }}
+
 Unprocessed MEG data MUST be stored in the native file format of the MEG
 instrument with which the data was collected.
 With the MEG specification of BIDS, we wish to promote the adoption of good
@@ -188,6 +190,8 @@ Date time information MUST be expressed as indicated in [Units](../02-common-pri
 
 {{ MACROS___make_filename_template(datatypes=["meg"], suffixes=["channels"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["meg"], suffixes=["channels"]) }}
+
 This file is RECOMMENDED as it provides easily searchable information across
 BIDS datasets for for example, general curation, response to queries or batch
 analysis.
@@ -279,6 +283,8 @@ UADC001 AUDIO V envelope of audio signal presented to participant
 
 {{ MACROS___make_filename_template(datatypes=["meg"], suffixes=["coordsystem"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["meg"], suffixes=["coordsystem"]) }}
+
 OPTIONAL. A JSON document specifying the coordinate system(s) used for the MEG,
 EEG, head localization coils, and anatomical landmarks.
 
@@ -363,6 +369,8 @@ Photos of the anatomical landmarks and/or head localization coils
 
 {{ MACROS___make_filename_template(datatypes=["meg"], suffixes=["photo"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["meg"], suffixes=["photo"]) }}
+
 Photos of the anatomical landmarks and/or head localization coils on the
 subject’s head are RECOMMENDED. If the coils are not placed at the location of
 actual anatomical landmarks, these latter may be marked with a piece of felt-tip
@@ -382,6 +390,8 @@ actual anatomical nasion: `sub-0001_ses-001_acq-NAS_photo.jpg`
 ## Head shape and electrode description (`*_headshape.<ext>`)
 
 {{ MACROS___make_filename_template(datatypes=["meg"], suffixes=["headshape"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["meg"], suffixes=["headshape"]) }}
 
 This file is RECOMMENDED.
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -19,6 +19,8 @@ Further datasets are available from the [BIDS examples repository](https://githu
 
 {{ MACROS___make_filename_template(datatypes=["eeg"], suffixes=["eeg", "events"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["eeg"], suffixes=["eeg", "events"]) }}
+
 The EEG community uses a variety of formats for storing raw data, and there is
 no single standard that all researchers agree on. For BIDS, EEG data MUST be
 stored in one of the following formats:
@@ -185,6 +187,8 @@ Date time information MUST be expressed as indicated in [Units](../02-common-pri
 
 {{ MACROS___make_filename_template(datatypes=["eeg"], suffixes=["channels"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["eeg"], suffixes=["channels"]) }}
+
 This file is RECOMMENDED as it provides easily searchable information across
 BIDS datasets for for example, general curation, response to queries or batch
 analysis.
@@ -270,6 +274,8 @@ UADC001  MISC  n/a    envelope of audio signal        n/a           good    n/a
 
 {{ MACROS___make_filename_template(datatypes=["eeg"], suffixes=["electrodes"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["eeg"], suffixes=["electrodes"]) }}
+
 File that gives the location of EEG electrodes. Note that coordinates are
 expected in cartesian coordinates according to the `EEGCoordinateSystem` and
 `EEGCoordinateUnits` fields in `*_coordsystem.json`. **If an
@@ -317,6 +323,8 @@ the recording.
 ## Coordinate System JSON (`*_coordsystem.json`)
 
 {{ MACROS___make_filename_template(datatypes=["eeg"], suffixes=["coordsystem"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["eeg"], suffixes=["coordsystem"]) }}
 
 A `*_coordsystem.json` file is used to specify the fiducials, the location of
 anatomical landmarks, and the coordinate system and units in which the position
@@ -413,6 +421,8 @@ Example:
 Photos of the anatomical landmarks and/or fiducials.
 
 {{ MACROS___make_filename_template(datatypes=["eeg"], suffixes=["photo"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["eeg"], suffixes=["photo"]) }}
 
 Photos of the anatomical landmarks and/or fiducials are OPTIONAL.
 Please note that the photos may need to be cropped or blurred to conceal

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -10,6 +10,8 @@ context of the academic literature.
 
 {{ MACROS___make_filename_template(datatypes=["ieeg"], suffixes=["ieeg", "events"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["ieeg"], suffixes=["ieeg", "events"]) }}
+
 The iEEG community uses a variety of formats for storing raw data, and there is
 no single standard that all researchers agree on. For BIDS, iEEG data MUST be
 stored in one of the following formats:
@@ -197,6 +199,8 @@ Date time information MUST be expressed as indicated in [Units](../02-common-pri
 
 {{ MACROS___make_filename_template(datatypes=["ieeg"], suffixes=["channels"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["ieeg"], suffixes=["channels"]) }}
+
 A channel represents one time series recorded with the recording system (for
 example, there can be a bipolar channel, recorded from two electrodes or contact
 points on the tissue).
@@ -282,6 +286,8 @@ Example of free-form text for field `description`:
 
 {{ MACROS___make_filename_template(datatypes=["ieeg"], suffixes=["electrodes"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["ieeg"], suffixes=["electrodes"]) }}
+
 File that gives the location, size and other properties of iEEG electrodes. Note
 that coordinates are expected in cartesian coordinates according to the
 `iEEGCoordinateSystem` and `iEEGCoordinateUnits` fields in
@@ -356,6 +362,8 @@ H01   27  -42  -21  5      AdTech
 
 {{ MACROS___make_filename_template(datatypes=["ieeg"], suffixes=["coordsystem"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["ieeg"], suffixes=["coordsystem"]) }}
+
 This `_coordsystem.json` file contains the coordinate system in which electrode
 positions are expressed. The associated MRI, CT, X-Ray, or operative photo can
 also be specified.
@@ -420,6 +428,8 @@ Example:
 ## Photos of the electrode positions (`*_photo.jpg`)
 
 {{ MACROS___make_filename_template(datatypes=["ieeg"], suffixes=["photo"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["ieeg"], suffixes=["photo"]) }}
 
 These can include photos of the electrodes on the brain surface, photos of
 anatomical features or landmarks (such as sulcal structure), and fiducials. Photos

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -2,6 +2,8 @@
 
 {{ MACROS___make_filename_template(datatypes=["beh"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["beh"]) }}
+
 In addition to logs from behavioral experiments performed alongside imaging data
 acquisitions, one can also include data from experiments performed with no neural
 recordings.

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -62,6 +62,8 @@ In this example, tracer injection coincides with scan start.
 
 {{ MACROS___make_filename_template(datatypes=["pet"], suffixes=["pet", "events"]) }}
 
+{{ MACROS___make_entity_table(datatypes=["pet"], suffixes=["pet", "events"]) }}
+
 PET data MUST be stored in the `pet` directory.
 PET imaging data SHOULD be stored in 4D (or 3D, if only one volume was acquired)
 NIfTI files with the `_pet` suffix.
@@ -291,6 +293,8 @@ ses-02 59
 ## Blood recording data
 
 {{ MACROS___make_filename_template(datatypes=["pet"], suffixes=["blood"]) }}
+
+{{ MACROS___make_entity_table(datatypes=["pet"], suffixes=["blood"]) }}
 
 If collected, blood measurements of radioactivity are be stored in
 [Tabular files](../02-common-principles.md#tabular-files) and located in


### PR DESCRIPTION
This implements a proposal of @Remi-Gau's to make it easier for readers to link to relevant entity definitions.

Changes proposed:
- Call `MACROS___make_entity_table` after each call of `MACROS___make_filename_template` to generate a limited entity table for the suffixes/data types in the filename template.