### PR TITLE
[FIX] Amend note about *b*-vecs on DWI specs

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -548,8 +548,8 @@ Following the FSL format for the `[*_]dwi.bvec` specification, the coordinate sy
 the *b* vectors MUST be defined with respect to the coordinate system defined by
 the header of the corresponding `_dwi` NIfTI file and not the scanner's device
 coordinate system (see [Coordinate systems](../99-appendices/08-coordinate-systems.md)).
-The most relevant implication for this choice is that any rotations applied to the DWI data
-also need to be applied to the *b* vectors in the `[*_]dwi.bvec` file.
+The most relevant limitation imposed by this choice is that the gradient information cannot
+be directly stored in this format if the scanner generates *b*-vectors in *scanner coordinates*.
 
 Example of `[*_]dwi.bvec` file, with *N*=6, with two *b*=0 volumes in the beginning:
 


### PR DESCRIPTION
Although this note is true (and the b-vecs should be rotated through the head-motion parameters), it is describing some post-processing step.

The actual implication w.r.t. BIDS of the choice of this format is that, if the scanner generates (or better said, receives and forwards) b-vecs in "world coordinates", then they need to be converted into voxel coordinates before writing into BIDS.

BIDS should describe only how the data & metadata should/could be stored. AFAICT, it should not prescribe how to use them whenever possible.

Comes from https://github.com/mattcieslak/bids-specification/pull/1#discussion_r617477112