### PR TITLE
[MISC] add link to guide on how to write a good README

### DIFF
--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -123,9 +123,10 @@ That is, in a directory `<dataset>/derivatives/<pipeline>[-<variant>]/`, the fir
 
 ### `README`
 
-In addition a free form text file (`README`) describing the dataset in more
-details SHOULD be provided.
+Every BIDS dataset SHOULD come with a free form text file (`README`) describing the dataset in more detail.
 The `README` file MUST be either in ASCII or UTF-8 encoding.
+A guideline for creating a good `README` file can be found in the
+[bids-starter-kit](https://github.com/bids-standard/bids-starter-kit/blob/master/templates/README).
 
 ### `CHANGES`
 


### PR DESCRIPTION
closes #662 

On top of this I plan to add a feature in bids-validator that warns about "suspiciously small READMEs", as discussed in #662.

- bids-validator progress: https://github.com/bids-standard/bids-validator/issues/1279