### PR TITLE
[INFRA] In PDF, color every other row in table in light gray fill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ site/
 venvs
 
 pdf_build_src/bids-spec.pdf
+pdf_build_src/src_copy
 
 # JS/NPM
 package-lock.json

--- a/pdf_build_src/README.md
+++ b/pdf_build_src/README.md
@@ -32,6 +32,8 @@ additional tex files are used with options offered by pandoc.
 
 ### Formatting files
 
+- `metadata.yml` - Contains formatting options for the PDF.
+
 - `header_setup.tex` -  This file sets up the packages to suit our needs.
 
 - `cover.tex` - BIDS Logo is used as a cover page for the document. `cover.tex` is used with the option `--include-before-body`

--- a/pdf_build_src/build_pdf.sh
+++ b/pdf_build_src/build_pdf.sh
@@ -10,11 +10,9 @@ python3 process_markdowns.py
 cp pandoc_script.py header.tex cover.tex header_setup.tex src_copy/src
 
 # run pandoc_script from src_copy directory
-(
 cd src_copy/src
 python3 pandoc_script.py
 mv bids-spec.pdf ../..
-)
 
 # delete the duplicated src directory
 rm -rf src_copy

--- a/pdf_build_src/header_setup.tex
+++ b/pdf_build_src/header_setup.tex
@@ -1,6 +1,3 @@
-\usepackage{xcolor}
-\usepackage{graphicx}
-
 \usepackage{fontspec}
 \setmainfont{Symbola}
 
@@ -27,3 +24,5 @@
 }
 
 \usepackage[a4paper,margin=0.75in,landscape]{geometry}
+
+\rowcolors{2}{gray!10}{white}

--- a/pdf_build_src/header_setup.tex
+++ b/pdf_build_src/header_setup.tex
@@ -1,28 +1,6 @@
 \usepackage{fontspec}
 \setmainfont{Symbola}
 
-\lstset{
-    basicstyle=\ttfamily,
-    numbers=left,
-    keywordstyle=\color[rgb]{0.13,0.29,0.53}\bfseries,
-    stringstyle=\color[rgb]{0.31,0.60,0.02},
-    commentstyle=\color[rgb]{0.56,0.35,0.01}\itshape,
-    numberstyle=\footnotesize,
-    stepnumber=1,
-    numbersep=5pt,
-    backgroundcolor=\color[RGB]{248,248,248},
-    showspaces=false,
-    showstringspaces=false,
-    showtabs=false,
-    tabsize=2,
-    captionpos=b,
-    breaklines=true,
-    breakautoindent=true,
-    escapeinside={\%*}{*)},
-    linewidth=\textwidth,
-    basewidth=0.5em
-}
-
 \usepackage[a4paper,margin=0.75in,landscape]{geometry}
 
-\rowcolors{2}{gray!10}{white}
+\rowcolors{1}{}{gray!10}

--- a/pdf_build_src/metadata.yml
+++ b/pdf_build_src/metadata.yml
@@ -1,0 +1,8 @@
+---
+documentclass: report
+classoption: table
+colorlinks: true
+linkcolor: blue
+toc: true
+listings: true
+---

--- a/pdf_build_src/pandoc_script.py
+++ b/pdf_build_src/pandoc_script.py
@@ -28,14 +28,10 @@ def build_pdf(filename):
     # Prepare the command options
     cmd = [
         'pandoc',
-        '--from=markdown_github',
+        '--from=markdown_github+yaml_metadata_block',
         '--include-before-body=./cover.tex',
-        '--toc',
-        '--listings',
         '--include-in-header=./header.tex',
         '--include-in-header=./header_setup.tex',
-        '-V documentclass=report',
-        '-V linkcolor:blue',
         '--pdf-engine=xelatex',
         '--output={}'.format(filename),
     ]
@@ -56,7 +52,7 @@ def build_pdf(filename):
     # Add input files to command
     # The filenames in `markdown_list` will ensure correct order when sorted
     cmd += [str(root / index_page)]
-    cmd += [str(root / i) for i in sorted(markdown_list)]
+    cmd += [str(root / i) for i in ["../../metadata.yml"] + sorted(markdown_list)]
 
     # print and run
     print('running: \n\n' + '\n'.join(cmd))

--- a/pdf_build_src/pandoc_script.py
+++ b/pdf_build_src/pandoc_script.py
@@ -16,14 +16,19 @@ def build_pdf(filename):
         Name of the output file.
 
     """
+    # Files that are not supposed to be built into the PDF
+    EXCLUDE = ["./index.md", "./schema/README.md", "./pregh-changes.md"]
+
     # Get all input files
     markdown_list = []
     for root, dirs, files in os.walk('.'):
         for file in files:
-            if file.endswith(".md") and file != 'index.md':
-                markdown_list.append(os.path.join(root, file))
-            elif file == 'index.md':
-                index_page = os.path.join(root, file)
+            fpath = os.path.join(root, file)
+            if fpath.endswith(".md") and fpath not in EXCLUDE:
+                markdown_list.append(fpath)
+            elif fpath.endswith('index.md'):
+                # Special role for index.md
+                index_page = fpath
 
     # Prepare the command options
     cmd = [


### PR DESCRIPTION
closes #659 

This took me way longer than it should have ... there are many challenges with our pdf generation code, but I think I fixed more than I destroyed. Some of the options we were passing previously were never actually passed, and I still need to figure out why.

Anyhow, this is a start:

- [x] table rows have alternating colors ... BUT the setting that "start at row 1 and color every even one light gray" does not work fully --> no idea why, but it's not too bad visually. (an improvement over status quo, I think)
- [x] several options that we were previously passing (including color of links) were somehow swallowed without any alarms raised --> this is now fixed, which also results in slightly changed formatting of code sections (improved, IMHO)
- [x] we started to accidentally include non-spec MD files in the PDF version of the spec, such as the raw pre-github changelog, or the README of the schema sub-folder (intended for development docs, not spec content) --> this is now fixed.

From my side, this is ready to be merged - but a lot remains to be done in the future.