### PR TITLE
[ENH] BEP031 - New columns to participants.tsv file

### DIFF
--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -162,16 +162,20 @@ participants.json
 ```
 
 The purpose of this RECOMMENDED file is to describe properties of participants
-such as age, sex, handedness.
+such as age, sex, handedness, species, strain, strain_rrid, diagnosis.
 If this file exists, it MUST contain the column `participant_id`,
 which MUST consist of `sub-<label>` values identifying one row for each participant,
 followed by a list of optional columns describing participants.
 Each participant MUST be described by one and only one row.
 
-Commonly used *optional* columns in `participant.tsv` files are `age`, `sex`,
-and `handedness`. We RECOMMEND to make use of these columns, and
-in case that you do use them, we RECOMMEND to use the following values
-for them:
+When different from `homo sapiens`, `participants.tsv` SHOULD include a `species`
+column, and the value MUST be the string of the binomial species name from
+[NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi).
+
+Commonly used *optional* columns in `participants.tsv` files are `age`, `sex`,
+`handedness`, `strain`, `strain_rrid` and `diagnosis`. We RECOMMEND to make use
+of these columns, and in case that you do use them, we RECOMMEND to use the
+following values for them:
 
 -   `age`: numeric value in years (float or integer value)
 
@@ -197,6 +201,15 @@ for them:
     -   for "ambidextrous", use one of these values: `ambidextrous`, `a`, `A`,
         `AMBIDEXTROUS`, `Ambidextrous`
 
+-   `strain`: string value indicating the strain of the species
+
+-   `strain_rrid`: research resource identifier ([RRID](https://scicrunch.org/resources/Organisms/search))
+    of the strain of the species
+
+-   `diagnosis`: string value describing the diagnosis of the participant.
+    The diagnosis MAY instead be specified in [Sessions files](06-longitudinal-and-multi-site-studies.md#sessions-file)
+    in case it changes over time.
+
 Throughout BIDS you can indicate missing values with `n/a` (for "not
 available").
 
@@ -213,9 +226,9 @@ It is RECOMMENDED to accompany each `participants.tsv` file with a sidecar
 `participants.json` file to describe the TSV column names and properties of their values (see also
 the [section on tabular files](02-common-principles.md#tabular-files)).
 Such sidecar files are needed to interpret the data, especially so when
-optional columns are defined beyond `age`, `sex`, and `handedness`, such as
-`group` in this example, or when a different age unit is needed
-(for example, gestational weeks).
+optional columns are defined beyond `age`, `sex`, `handedness`, `species`, `strain`,
+`strain_rrid` and `diagnosis`, such as `group` in this example, or when a different
+age unit is needed (for example, gestational weeks).
 If no `units` is provided for age, it will be assumed to be in years relative
 to date of birth.
 


### PR DESCRIPTION
Dear BIDS community,

### Context

As part of the development of the Microscopy BEP ([BEP031](https://bids.neuroimaging.io/bep031) @mariehbourget, @jcohenadad) and Animal Ephys BEP ([BEP032](https://bids.neuroimaging.io/bep032) @SylvainTakerkart, @JuliaSprenger), the “sample” entity was introduced along with a `samples.tsv` file describing properties of the samples in PR #812.

To better describe animal participants, new properties of the subjects also need to be included in `participants.tsv`.

### Contribution

The purpose of this PR is to add new recommended column (`species`) and optional columns (`strain`, `strain_rrid` and `diagnosis`) to the participants.tsv file.

See issue #779 for related discussions on this topic.