### PR TITLE
[FIX] document required column order MEG, EEG, iEEG, PET, and fix typo iEEG

### DIFF
--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -197,7 +197,7 @@ Missing values MUST be indicated with `n/a`.
 
 The columns of the Channels description table stored in `*_channels.tsv` are:
 
-MUST be present:
+MUST be present **in this specific order**:
 
 | **Column name** | **Requirement level** | **Description**                                                                                                                                                               |
 | --------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -221,8 +221,8 @@ SHOULD be present:
 Example:
 
 ```Text
-name type units description sampling_frequency  low_cutoff  high_cutoff notch software_filters status
-UDIO001 TRIG V analogue trigger 1200  0.1 300 0 n/a good
+name type units description sampling_frequency low_cutoff high_cutoff notch software_filters status
+UDIO001 TRIG V analogue trigger 1200 0.1 300 0 n/a good
 MLC11 MEGGRADAXIAL T sensor 1st-order grad 1200 0 n/a 50 SSS bad
 ```
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -188,8 +188,6 @@ Date time information MUST be expressed as indicated in [Units](../02-common-pri
 This file is RECOMMENDED as it provides easily searchable information across
 BIDS datasets for for example, general curation, response to queries or batch
 analysis.
-The required columns are channel `name`, `type` and `units` in this specific
-order.
 To avoid confusion, the channels SHOULD be listed in the order they
 appear in the EEG data file.
 Any number of additional columns may be added to provide additional information
@@ -205,7 +203,7 @@ See the examples for `*_channels.tsv` below, and for `*_electrodes.tsv` in
 
 The columns of the Channels description table stored in `*_channels.tsv` are:
 
-MUST be present:
+MUST be present **in this specific order**:
 
 | **Column name** | **Requirement level** | **Description**                                                                                                                                                               |
 | --------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -277,7 +275,7 @@ expected in cartesian coordinates according to the `EEGCoordinateSystem` and
 file MUST be specified as well**. The order of the required columns in the
 `*_electrodes.tsv` file MUST be as listed below.
 
-MUST be present:
+MUST be present **in this specific order**:
 
 | **Column name** | **Requirement level** | **Description**                     |
 | --------------- | --------------------- | ----------------------------------- |

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -203,7 +203,6 @@ Although this information can often be extracted from the iEEG recording,
 listing it in a simple `.tsv` document makes it easy to browse or search (for example,
 searching for recordings with a sampling frequency of >=1000 Hz).
 Hence, the channels.tsv is RECOMMENDED.
-The two required columns are channel `name` and `type`.
 Channels SHOULD appear in the table in the same order they do in the iEEG data
 file.
 Any number of additional columns may be provided to provide additional
@@ -213,7 +212,7 @@ Note that electrode positions SHOULD NOT be added to this file but to
 
 The columns of the Channels description table stored in `*_channels.tsv` are:
 
-MUST be present:
+MUST be present **in this specific order**:
 
 | **Column name** | **Requirement level** | **Description**                                                                                                                                                                                             |
 | --------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -275,7 +274,7 @@ Note that upper-case is REQUIRED:
 
 Example of free-form text for field `description`:
 
--   intracranial, stimulus, response, vertical EOG,  skin conductance
+-   intracranial, stimulus, response, vertical EOG, skin conductance
 
 ## Electrode description (`*_electrodes.tsv`)
 
@@ -315,7 +314,7 @@ For example:
 The order of the required columns in the `*_electrodes.tsv` file MUST be as
 listed below.
 
-MUST be present:
+MUST be present **in this specific order**:
 
 | **Column name** | **Requirement level** | **Description**                                                                                                                  |
 | --------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -332,7 +332,8 @@ The following metadata SHOULD or MUST be provided if corresponding flags are `tr
 | MetaboliteMethod                    | REQUIRED if `MetaboliteAvail` is `true` | [string][]    | Method used to measure metabolites.                                                                                                                                                                          |
 | MetaboliteRecoveryCorrectionApplied | REQUIRED if `MetaboliteAvail` is `true` | [boolean][]   | Metabolite recovery correction from the HPLC, for tracers where it changes with time postinjection. If `true`, the `hplc_recovery_fractions` column MUST be present in the corresponding `*_blood.tsv` file. |
 
-The following columns are defined for `_blood.tsv` files:
+The following columns are defined for `_blood.tsv` files.
+The `time` column MUST always be the first column.
 
 | **Column name**              | **Requirement level**                                       | **Description**                                                                   | **Units**                                                                           |
 | ---------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |


### PR DESCRIPTION
closes #817 

The EEG and iEEG specs had sentences like "columns X, Y, ... are required" before the table outlining the requirement levels. For the iEEG spec, this was furthermore inconsistent.

I removed these sentences before the tables as duplicate information, thereby also fixing the ieeg inconsistency.

I furthermore added a note to the tables where the order column is mandatory. This was not documented consistently before, and many people probably only found out about this by getting the validator error that is generated by these lines:

https://github.com/bids-standard/bids-validator/blob/c60daacf3dbb4cea5a07d5274947c366cf4c0e3a/bids-validator/validators/tsv/tsv.js#L243-L298


@dorahermes I saw your comment voting for making the column order of ieeg files consistent with those of EEG and MEG (only name, type, units, instead of additionally low and high cutoff). But that'd be a more invasive change that I don't think is necessary at this point (no complaints or issues have been raised about this). Let me know if you think otherwise.