### PR TITLE
[FIX]: Add missing closing parenthesis in 02-common-principle.md

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -352,7 +352,7 @@ then Case 1 will be assumed for clarity in templates and examples, but removing
 Case 2.
 In both cases, every derivatives dataset is considered a BIDS dataset and must
 include a `dataset_description.json` file at the root level (see
-[Dataset description][dataset-description].
+[Dataset description][dataset-description]).
 Consequently, files should be organized to comply with BIDS to the full extent
 possible (that is, unless explicitly contradicted for derivatives).
 Any subject-specific derivatives should be housed within each subject’s directory;


### PR DESCRIPTION
Add missing closing parenthesis in "Storage of derived datasets" section.
