### PR TITLE
[MISC] make explicit that EDF+ (and for EEG: BDF+) are included in iEEG / EEG format requirements

### DIFF
--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -24,7 +24,8 @@ no single standard that all researchers agree on. For BIDS, EEG data MUST be
 stored in one of the following formats:
 
 -   [European data format](https://www.edfplus.info/)
-    (Each recording consisting of a `.edf` file)
+    (including [`edf+`](https://www.edfplus.info/specs/edfplus.html);
+    each recording consisting of a `.edf` file)
 
 -   [BrainVision Core Data Format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
     (Each recording consisting of a  `.vhdr`, `.vmrk`, `.eeg` file triplet)
@@ -33,7 +34,8 @@ stored in one of the following formats:
     (Each recording consisting of a `.set` file with an optional `.fdt` file)
 
 -   [Biosemi](https://www.biosemi.com/) data format
-    (Each recording consisting of a `.bdf` file)
+    (including [`bdf+`](https://www.teuniz.net/edfbrowser/bdfplus%20format%20description.html);
+    each recording consisting of a `.bdf` file)
 
 It is RECOMMENDED to use the European data format, or the BrainVision data
 format. It is furthermore discouraged to use the other accepted formats over

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -14,8 +14,9 @@ The iEEG community uses a variety of formats for storing raw data, and there is
 no single standard that all researchers agree on. For BIDS, iEEG data MUST be
 stored in one of the following formats:
 
--   [European Data Format](https://www.edfplus.info/)
-    (Each recording consisting of a `.edf` file)
+-   [European data format](https://www.edfplus.info/)
+    (including [`edf+`](https://www.edfplus.info/specs/edfplus.html);
+    each recording consisting of a `.edf` file)
 
 -   [BrainVision Core Data Format](https://www.brainproducts.com/productdetails.php?id=21&tab=5)
     (Each recording consisting of a  `.vhdr`, `.vmrk`, `.eeg` file triplet)


### PR DESCRIPTION
closes #821 

As proposed by @Aaronearlerichardson I here make explicit in the spec, that the EDF and BDF formats supported in EEG and iEEG also include EDF+ and BDF+.

Both EDF+ and BDF+ are backward compatible with EDF and BDF tools, the file extensions are the same, and technical, open accessible specifications of the formats are available and linked.

@CPernet and @robertoostenveld were not particularly enthusiastic, but also not against this change.

I personally deem this change more of a clarification and I assume that most of the BIDS `.edf` files that are "around" these days are actually EDF+ files anyhow (just my assumption though, I didn't check).