### PR TITLE
[FIX] Add angio suffix to the non-parametric aMRI suffix table

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -206,6 +206,7 @@ non-parametric structural MR images include:
          "inplaneT2",
          "PDT2",
          "UNIT1",
+         "angio",
       ]
    )
 }}


### PR DESCRIPTION
Closes #830.

Changes proposed:

- Add the `angio` suffix to the table describing non-parametric anatomical MRI suffixes in the specification.