### PR TITLE
[ENH] make "Institutional department name" available for all datatypes

### DIFF
--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -286,7 +286,7 @@ you do use them, we RECOMMEND to use the following values for them:
 
 -   `pathology`: string value describing the pathology of the sample or type of control.
     When different from `healthy`, pathology SHOULD be specified in `samples.tsv`.
-    The pathology MAY instead be specified in [Sessions files](06-longitudinal-and-multi-site-studies.md#sessions-file)
+    The pathology MAY instead be specified in [Sessions files](./03-modality-agnostic-files.md#sessions-file)
     in case it changes over time.
 
 -   `derived_from`: `sample-<label>` key/value pair from which a sample is derived from,

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -179,7 +179,7 @@ fieldmap estimation using the following metadata:
    {
       "InstitutionName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0080 `InstitutionName`."),
       "InstitutionAddress": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`."),
-      "InstitutionalDepartmentName": "RECOMMENDED",
+      "InstitutionalDepartmentName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.")
    }
 ) }}
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -94,6 +94,7 @@ Whenever possible, please avoid using ad-hoc wording.
    {
       "InstitutionName": "RECOMMENDED",
       "InstitutionAddress": "RECOMMENDED",
+      "InstitutionalDepartmentName": "RECOMMENDED",
       "Manufacturer": (
          "RECOMMENDED",
          "For MEG scanners, this must be one of: "

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -100,6 +100,7 @@ Whenever possible, please avoid using ad hoc wording.
    {
       "InstitutionName": "RECOMMENDED",
       "InstitutionAddress": "RECOMMENDED",
+      "InstitutionalDepartmentName": "RECOMMENDED",
       "Manufacturer": "RECOMMENDED",
       "ManufacturersModelName": "RECOMMENDED",
       "SoftwareVersions": "RECOMMENDED",

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -108,6 +108,7 @@ Whenever possible, please avoid using ad hoc wording.
    {
       "InstitutionName": "RECOMMENDED",
       "InstitutionAddress": "RECOMMENDED",
+      "InstitutionalDepartmentName": "RECOMMENDED",
       "Manufacturer": ("RECOMMENDED", 'For example, `"TDT"`, `"Blackrock"`.'),
       "ManufacturersModelName": "RECOMMENDED",
       "SoftwareVersions": "RECOMMENDED",

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -40,5 +40,6 @@ it is RECOMMENDED to add the following metadata to the JSON files of this folder
       "CogPOID": "RECOMMENDED",
       "InstitutionName": "RECOMMENDED",
       "InstitutionAddress": "RECOMMENDED",
+      "InstitutionalDepartmentName": "RECOMMENDED",
    }
 ) }}

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -141,7 +141,7 @@ which we divide into several categories:
       ),
       "InstitutionName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0080 `InstitutionName`."),
       "InstitutionAddress": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`."),
-      "InstitutionalDepartmentName": "RECOMMENDED",
+      "InstitutionalDepartmentName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`."),
       "BodyPart": "RECOMMENDED",
    }
 ) }}

--- a/src/schema/metadata/InstitutionalDepartmentName.yaml
+++ b/src/schema/metadata/InstitutionalDepartmentName.yaml
@@ -3,5 +3,4 @@ name: InstitutionalDepartmentName
 description: |
   The department in the institution in charge of the equipment that produced
   the measurements.
-  Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
 type: string


### PR DESCRIPTION
This PR is to keep in synch with changes on the validator and *explicitly* makes "Institutional department name" available for all modalities: it was included in the EEG and MEG json schema of the validator but not in the specs.

https://github.com/bids-standard/bids-validator/pull/1312

- [x] simplify base definition of Institutional department name
- [x] update MRI and PET definitions in macro calls
- [x] add as metadata for EEG, MEG, iEEG
- [x] add to behavior metadata (once #804 is merged)