### PR TITLE
[ENH] Add links to example datasets for each modality

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -6,7 +6,7 @@ MR Data described in the following sections share the following RECOMMENDED meta
 fields (stored in sidecar JSON files). MRI acquisition parameters are divided
 into several categories based on
 ["A checklist for fMRI acquisition methods reporting in the literature"](https://thewinnower.com/papers/977-a-checklist-for-fmri-acquisition-methods-reporting-in-the-literature)
-by Ben Inglis:
+by Ben Inglis.
 
 ### Scanner Hardware
 
@@ -743,6 +743,16 @@ JSON example:
 ```
 
 ## Arterial Spin Labeling perfusion data
+
+Several [example ASL datasets](https://github.com/bids-standard/bids-examples) 
+have been formatted using this specification
+and can be used for practical guidance when curating a new dataset:
+
+- [`asl001`](https://github.com/bids-standard/bids-examples/tree/master/asl001)
+- [`asl002`](https://github.com/bids-standard/bids-examples/tree/master/asl002)
+- [`asl003`](https://github.com/bids-standard/bids-examples/tree/master/asl003)
+- [`asl004`](https://github.com/bids-standard/bids-examples/tree/master/asl004)
+- [`asl005`](https://github.com/bids-standard/bids-examples/tree/master/asl005)
 
 {{ MACROS___make_filename_template(datatypes=["perf"]) }}
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -993,6 +993,13 @@ For example:
 
 #### Case 1: Phase-difference map and at least one magnitude image
 
+[Example datasets](https://github.com/bids-standard/bids-examples) 
+containing that type of fieldmap can be found here:
+
+- [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)
+- [`genetics_ukbb`](https://github.com/bids-standard/bids-examples/tree/master/genetics_ukbb)
+- [`ds000117`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
+
 {{ MACROS___make_filename_template(datatypes=["fmap"], suffixes=["phasediff", "magnitude1", "magnitude2"]) }}
 
 where
@@ -1081,6 +1088,11 @@ See [Using `IntendedFor` metadata](#using-intendedfor-metadata)
 for details on the `IntendedFor` field.
 
 #### Case 4: Multiple phase encoded directions ("pepolar")
+
+An [example dataset](https://github.com/bids-standard/bids-examples) 
+containing that type of fieldmap can be found here:
+
+- [`ieeg_visual_multimodal`](https://github.com/bids-standard/bids-examples/tree/master/ieeg_visual_multimodal)
 
 The phase-encoding polarity (PEpolar) technique combines two or more Spin Echo
 EPI scans with different phase encoding directions to estimate the distortion

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -558,14 +558,14 @@ participant, task and run takes precedence.
 
 ## Diffusion imaging data
 
-Several [example datasets](https://github.com/bids-standard/bids-examples) 
+Several [example datasets](https://github.com/bids-standard/bids-examples)
 contain diffusion imaging data formatted using this specification
 and that can be used for practical guidance when curating a new dataset:
 
-- [`genetics_ukbb`](https://github.com/bids-standard/bids-examples/tree/master/genetics_ukbb)
-- [`eeg_rest_fmri`](https://github.com/bids-standard/bids-examples/tree/master/eeg_rest_fmri)
-- [`ds114`](https://github.com/bids-standard/bids-examples/tree/master/ds114)
-- [`ds000117`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
+-   [`genetics_ukbb`](https://github.com/bids-standard/bids-examples/tree/master/genetics_ukbb)
+-   [`eeg_rest_fmri`](https://github.com/bids-standard/bids-examples/tree/master/eeg_rest_fmri)
+-   [`ds114`](https://github.com/bids-standard/bids-examples/tree/master/ds114)
+-   [`ds000117`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
 
 Diffusion-weighted imaging data acquired for a participant.
 Currently supported image types include:
@@ -753,7 +753,7 @@ JSON example:
 
 ## Arterial Spin Labeling perfusion data
 
-Several [example ASL datasets](https://github.com/bids-standard/bids-examples#asl-datasets) 
+Several [example ASL datasets](https://github.com/bids-standard/bids-examples#asl-datasets)
 have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
 
@@ -987,12 +987,12 @@ For example:
 
 #### Case 1: Phase-difference map and at least one magnitude image
 
-[Example datasets](https://github.com/bids-standard/bids-examples) 
+[Example datasets](https://github.com/bids-standard/bids-examples)
 containing that type of fieldmap can be found here:
 
-- [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)
-- [`genetics_ukbb`](https://github.com/bids-standard/bids-examples/tree/master/genetics_ukbb)
-- [`ds000117`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
+-   [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)
+-   [`genetics_ukbb`](https://github.com/bids-standard/bids-examples/tree/master/genetics_ukbb)
+-   [`ds000117`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
 
 {{ MACROS___make_filename_template(datatypes=["fmap"], suffixes=["phasediff", "magnitude1", "magnitude2"]) }}
 
@@ -1083,10 +1083,10 @@ for details on the `IntendedFor` field.
 
 #### Case 4: Multiple phase encoded directions ("pepolar")
 
-An [example dataset](https://github.com/bids-standard/bids-examples) 
+An [example dataset](https://github.com/bids-standard/bids-examples)
 containing that type of fieldmap can be found here:
 
-- [`ieeg_visual_multimodal`](https://github.com/bids-standard/bids-examples/tree/master/ieeg_visual_multimodal)
+-   [`ieeg_visual_multimodal`](https://github.com/bids-standard/bids-examples/tree/master/ieeg_visual_multimodal)
 
 The phase-encoding polarity (PEpolar) technique combines two or more Spin Echo
 EPI scans with different phase encoding directions to estimate the distortion

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -558,6 +558,15 @@ participant, task and run takes precedence.
 
 ## Diffusion imaging data
 
+Several [example datasets](https://github.com/bids-standard/bids-examples) 
+contain diffusion imaging data formatted using this specification
+and that can be used for practical guidance when curating a new dataset:
+
+- [`genetics_ukbb`](https://github.com/bids-standard/bids-examples/tree/master/genetics_ukbb)
+- [`eeg_rest_fmri`](https://github.com/bids-standard/bids-examples/tree/master/eeg_rest_fmri)
+- [`ds114`](https://github.com/bids-standard/bids-examples/tree/master/ds114)
+- [`ds000117`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
+
 Diffusion-weighted imaging data acquired for a participant.
 Currently supported image types include:
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -753,15 +753,9 @@ JSON example:
 
 ## Arterial Spin Labeling perfusion data
 
-Several [example ASL datasets](https://github.com/bids-standard/bids-examples) 
+Several [example ASL datasets](https://github.com/bids-standard/bids-examples#asl-datasets) 
 have been formatted using this specification
-and can be used for practical guidance when curating a new dataset:
-
-- [`asl001`](https://github.com/bids-standard/bids-examples/tree/master/asl001)
-- [`asl002`](https://github.com/bids-standard/bids-examples/tree/master/asl002)
-- [`asl003`](https://github.com/bids-standard/bids-examples/tree/master/asl003)
-- [`asl004`](https://github.com/bids-standard/bids-examples/tree/master/asl004)
-- [`asl005`](https://github.com/bids-standard/bids-examples/tree/master/asl005)
+and can be used for practical guidance when curating a new dataset.
 
 {{ MACROS___make_filename_template(datatypes=["perf"]) }}
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -9,11 +9,10 @@ context of the academic literature.
 The following example MEG datasets have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
 
-- [`multimodal MEG and MRI`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
+-   [`multimodal MEG and MRI`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
 
-Further datasets are available from 
+Further datasets are available from
 the [BIDS examples repository](https://github.com/bids-standard/bids-examples).
-
 
 ## MEG recording data
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -6,6 +6,15 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
+The following example MEG datasets have been formatted using this specification
+and can be used for practical guidance when curating a new dataset.
+
+- [`multimodal MEG and MRI`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
+
+Further datasets are available from 
+the [BIDS examples repository](https://github.com/bids-standard/bids-examples).
+
+
 ## MEG recording data
 
 {{ MACROS___make_filename_template(datatypes=["meg"], suffixes=["meg", "markers", "events"]) }}

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -10,7 +10,7 @@ The following example EEG datasets have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
 
 -   Single session per subject: [`eeg_matchingpennies`](https://doi.org/10.17605/OSF.IO/CJ2DR)
--   Multiple sessions per subject: [`eeg_rishikesh`](https://doi.org/10.5281/zenodo.1490922)
+-   Multiple sessions per subject: [`eeg_rishikesh`](https://github.com/bids-standard/bids-examples/tree/master/eeg_rishikesh)
 -   Combined with fMRI: [`eeg_rest_fmri`](https://osf.io/94c5t/files/)
 
 Further datasets are available from 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -13,7 +13,8 @@ and can be used for practical guidance when curating a new dataset.
 -   Multiple sessions per subject: [`eeg_rishikesh`](https://doi.org/10.5281/zenodo.1490922)
 -   Combined with fMRI: [`eeg_rest_fmri`](https://osf.io/94c5t/files/)
 
-Further datasets are available from the [BIDS examples repository](https://github.com/bids-standard/bids-examples).
+Further datasets are available from 
+the [BIDS examples repository](https://github.com/bids-standard/bids-examples#eeg-datasets).
 
 ## EEG recording data
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -6,7 +6,7 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
-Several [example EEG datasets](https://github.com/bids-standard/bids-examples#eeg-datasets) 
+Several [example EEG datasets](https://github.com/bids-standard/bids-examples#eeg-datasets)
 have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -9,7 +9,7 @@ context of the academic literature.
 The following example EEG datasets have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
 
--   Single session per subject: [`eeg_matchingpennies`](https://doi.org/10.17605/OSF.IO/CJ2DR)
+-   Single session per subject: [`eeg_matchingpennies`](https://github.com/bids-standard/bids-examples/tree/master/eeg_matchingpennies)
 -   Multiple sessions per subject: [`eeg_rishikesh`](https://github.com/bids-standard/bids-examples/tree/master/eeg_rishikesh)
 -   Combined with fMRI: [`eeg_rest_fmri`](https://osf.io/94c5t/files/)
 

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -6,15 +6,9 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
-The following example EEG datasets have been formatted using this specification
+Several [example EEG datasets](https://github.com/bids-standard/bids-examples#eeg-datasets) 
+have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
-
--   Single session per subject: [`eeg_matchingpennies`](https://github.com/bids-standard/bids-examples/tree/master/eeg_matchingpennies)
--   Multiple sessions per subject: [`eeg_rishikesh`](https://github.com/bids-standard/bids-examples/tree/master/eeg_rishikesh)
--   Combined with fMRI: [`eeg_rest_fmri`](https://osf.io/94c5t/files/)
-
-Further datasets are available from 
-the [BIDS examples repository](https://github.com/bids-standard/bids-examples#eeg-datasets).
 
 ## EEG recording data
 

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -6,16 +6,9 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
-The following example iEEG datasets have been formatted using this specification
+Several [example iEEG datasets](https://github.com/bids-standard/bids-examples#ieeg-datasets) 
+have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
-
--   iEEG: 
-[`ieeg visual`](https://github.com/bids-standard/bids-examples/tree/master/ieeg_visual)
--   multimodal iEEG and functional MRI: 
-[`ieeg visual multimodal`](https://github.com/bids-standard/bids-examples/tree/master/ieeg_visual_multimodal)
-
-Further datasets are available from 
-the [BIDS examples repository](https://github.com/bids-standard/bids-examples#ieeg-datasets).
 
 
 ## iEEG recording data

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -6,6 +6,18 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
+The following example iEEG datasets have been formatted using this specification
+and can be used for practical guidance when curating a new dataset.
+
+-   iEEG: 
+[`ieeg visual`](https://github.com/bids-standard/bids-examples/tree/master/ieeg_visual)
+-   multimodal iEEG and functional MRI: 
+[`ieeg visual multimodal`](https://github.com/bids-standard/bids-examples/tree/master/ieeg_visual_multimodal)
+
+Further datasets are available from 
+the [BIDS examples repository](https://github.com/bids-standard/bids-examples#ieeg-datasets).
+
+
 ## iEEG recording data
 
 {{ MACROS___make_filename_template(datatypes=["ieeg"], suffixes=["ieeg", "events"]) }}

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -6,10 +6,9 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
-Several [example iEEG datasets](https://github.com/bids-standard/bids-examples#ieeg-datasets) 
+Several [example iEEG datasets](https://github.com/bids-standard/bids-examples#ieeg-datasets)
 have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
-
 
 ## iEEG recording data
 

--- a/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
+++ b/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
@@ -1,5 +1,12 @@
 # Physiological and other continuous recordings
 
+[Example datasets](https://github.com/bids-standard/bids-examples) 
+with physiological data have been formatted using this specification
+and can be used for practical guidance when curating a new dataset:
+
+- [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)
+- [`ds210`](https://github.com/bids-standard/bids-examples/tree/master/ds210)
+
 Template:
 
 ```Text

--- a/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
+++ b/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
@@ -1,11 +1,11 @@
 # Physiological and other continuous recordings
 
-[Example datasets](https://github.com/bids-standard/bids-examples) 
+[Example datasets](https://github.com/bids-standard/bids-examples)
 with physiological data have been formatted using this specification
 and can be used for practical guidance when curating a new dataset:
 
-- [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)
-- [`ds210`](https://github.com/bids-standard/bids-examples/tree/master/ds210)
+-   [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)
+-   [`ds210`](https://github.com/bids-standard/bids-examples/tree/master/ds210)
 
 Template:
 

--- a/src/04-modality-specific-files/08-genetic-descriptor.md
+++ b/src/04-modality-specific-files/08-genetic-descriptor.md
@@ -12,6 +12,11 @@ A genetic descriptor links a BIDS dataset to associated genetic data,
 potentially in a separate repository,
 with details of where to find the genetic data and the type of data available.
 
+The following example dataset with genetics data have been formatted using this specification
+and can be used for practical guidance when curating a new dataset.
+
+-   [`UK biobank`](https://github.com/bids-standard/bids-examples/tree/master/genetics_ukbb)
+
 ## Dataset Description
 
 Genetic descriptors are encoded as an additional, OPTIONAL entry in the

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -6,8 +6,15 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
-Several [example PET datasets](https://github.com/bids-standard/bids-examples) have been formatted using this specification
-and can be used for practical guidance when curating a new dataset.
+Several [example PET datasets](https://github.com/bids-standard/bids-examples) 
+have been formatted using this specification
+and can be used for practical guidance when curating a new dataset:
+
+- [`pet001`](https://github.com/bids-standard/bids-examples/tree/master/pet001)
+- [`pet002`](https://github.com/bids-standard/bids-examples/tree/master/pet002)
+- [`pet003`](https://github.com/bids-standard/bids-examples/tree/master/pet003)
+- [`pet004`](https://github.com/bids-standard/bids-examples/tree/master/pet004)
+- [`pet005`](https://github.com/bids-standard/bids-examples/tree/master/pet005)
 
 Further PET datasets are available from [OpenNeuro](https://openneuro.org).
 

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -6,15 +6,9 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
-Several [example PET datasets](https://github.com/bids-standard/bids-examples) 
+Several [example PET datasets](https://github.com/bids-standard/bids-examples#pet-datasets) 
 have been formatted using this specification
-and can be used for practical guidance when curating a new dataset:
-
-- [`pet001`](https://github.com/bids-standard/bids-examples/tree/master/pet001)
-- [`pet002`](https://github.com/bids-standard/bids-examples/tree/master/pet002)
-- [`pet003`](https://github.com/bids-standard/bids-examples/tree/master/pet003)
-- [`pet004`](https://github.com/bids-standard/bids-examples/tree/master/pet004)
-- [`pet005`](https://github.com/bids-standard/bids-examples/tree/master/pet005)
+and can be used for practical guidance when curating a new dataset.
 
 Further PET datasets are available from [OpenNeuro](https://openneuro.org).
 

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -6,7 +6,7 @@ Please see [Citing BIDS](../01-introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the
 context of the academic literature.
 
-Several [example PET datasets](https://github.com/bids-standard/bids-examples#pet-datasets) 
+Several [example PET datasets](https://github.com/bids-standard/bids-examples#pet-datasets)
 have been formatted using this specification
 and can be used for practical guidance when curating a new dataset.
 

--- a/src/99-appendices/11-qmri.md
+++ b/src/99-appendices/11-qmri.md
@@ -113,7 +113,7 @@ It is RECOMMENDED to share them along with the vendor outputs, whenever possible
 
 ### Example datasets
 
-You can find example file collections and qMRI maps organized according to BIDS 
+You can find example file collections and qMRI maps organized according to BIDS
 in the [BIDS examples](https://github.com/bids-standard/bids-examples#qmri-datasets).
 
 ## Metadata requirements for qMRI data

--- a/src/99-appendices/11-qmri.md
+++ b/src/99-appendices/11-qmri.md
@@ -114,19 +114,7 @@ It is RECOMMENDED to share them along with the vendor outputs, whenever possible
 ### Example datasets
 
 You can find example file collections and qMRI maps organized according to BIDS 
-in the [BIDS examples](https://github.com/bids-standard/bids-examples):
-
-- [qmri_megre](https://github.com/bids-standard/bids-examples/tree/master/qmri_megre)
-- [qmri_mpm](https://github.com/bids-standard/bids-examples/tree/master/qmri_mpm)
-- [qmri_vfa](https://github.com/bids-standard/bids-examples/tree/master/qmri_vfa)
-- [qmri_mp2rageme](https://github.com/bids-standard/bids-examples/tree/master/qmri_mp2rageme)
-- [qmri_mtsat](https://github.com/bids-standard/bids-examples/tree/master/qmri_mtsat)
-- [qmri_mp2rage](https://github.com/bids-standard/bids-examples/tree/master/qmri_mp2rage)
-- [qmri_irt1](https://github.com/bids-standard/bids-examples/tree/master/qmri_irt1)
-- [qmri_qsm](https://github.com/bids-standard/bids-examples/tree/master/qmri_qsm)
-- [qmri_mese](https://github.com/bids-standard/bids-examples/tree/master/qmri_mese
-- [qmri_sa2rage](https://github.com/bids-standard/bids-examples/tree/master/qmri_sa2rage)
-- [qmri_tb1tfl](https://github.com/bids-standard/bids-examples/tree/master/qmri_tb1tfl)
+in the [BIDS examples](https://github.com/bids-standard/bids-examples#qmri-datasets).
 
 ## Metadata requirements for qMRI data
 

--- a/src/99-appendices/11-qmri.md
+++ b/src/99-appendices/11-qmri.md
@@ -113,7 +113,20 @@ It is RECOMMENDED to share them along with the vendor outputs, whenever possible
 
 ### Example datasets
 
-You can find example file collections and qMRI maps organized according to BIDS at [https://osf.io/k4bs5/](https://osf.io/k4bs5/).
+You can find example file collections and qMRI maps organized according to BIDS 
+in the [BIDS examples](https://github.com/bids-standard/bids-examples):
+
+- [qmri_megre](https://github.com/bids-standard/bids-examples/tree/master/qmri_megre)
+- [qmri_mpm](https://github.com/bids-standard/bids-examples/tree/master/qmri_mpm)
+- [qmri_vfa](https://github.com/bids-standard/bids-examples/tree/master/qmri_vfa)
+- [qmri_mp2rageme](https://github.com/bids-standard/bids-examples/tree/master/qmri_mp2rageme)
+- [qmri_mtsat](https://github.com/bids-standard/bids-examples/tree/master/qmri_mtsat)
+- [qmri_mp2rage](https://github.com/bids-standard/bids-examples/tree/master/qmri_mp2rage)
+- [qmri_irt1](https://github.com/bids-standard/bids-examples/tree/master/qmri_irt1)
+- [qmri_qsm](https://github.com/bids-standard/bids-examples/tree/master/qmri_qsm)
+- [qmri_mese](https://github.com/bids-standard/bids-examples/tree/master/qmri_mese
+- [qmri_sa2rage](https://github.com/bids-standard/bids-examples/tree/master/qmri_sa2rage)
+- [qmri_tb1tfl](https://github.com/bids-standard/bids-examples/tree/master/qmri_tb1tfl)
 
 ## Metadata requirements for qMRI data
 


### PR DESCRIPTION
Fixes #842 

Add links to example from the BIDS example repo in the following section:

- [x] MEG
- [x] iEEG
- [x] genetics
- [x] PET
- [ ] MRI
  - [ ] anat
  - [ ] func
  - [x] dwi
  - [x] fmap
  - [x] asl
  - [x] qmri
- [ ] behavior ?
- [x] physio