### PR TITLE
[INFRA] LGTM warning: Variable defined multiple times

### DIFF
--- a/pdf_build_src/process_markdowns.py
+++ b/pdf_build_src/process_markdowns.py
@@ -444,7 +444,6 @@ def process_macros(duplicated_src_dir_path):
                 contents = fo.read()
 
             # Replace code snippets in the text with their outputs
-            matches = re.findall("({{.*?}})", contents)
             matches = re.findall(re.compile("({{.*?}})", re.DOTALL), contents)
             for m in matches:
                 # Remove macro delimiters to get *just* the function call


### PR DESCRIPTION
This assignment to 'matches' is unnecessary as it is redefined here before
this value is used.

https://lgtm.com/rules/1800095/

This change is rather obvious. Remaining issues (including false positives?) can be found here:
https://lgtm.com/projects/g/bids-standard/bids-specification/