### PR TITLE
[INFRA] fixing "remove_internal_links" for PDF build

### DIFF
--- a/pdf_build_src/process_markdowns.py
+++ b/pdf_build_src/process_markdowns.py
@@ -112,10 +112,10 @@ def remove_internal_links(root_path, link_type):
     if link_type == 'cross':
         # regex that matches cross markdown links within a file
         # TODO: add more documentation explaining regex
-        primary_pattern = re.compile(r'\[((?!http).[\w\s.\(\)`*/–]+)\]\(((?!http).+(\.md|\.yml|\.md#[\w\-\w]+))\)')  # noqa: E501
+        primary_pattern = re.compile(r'\[((?!http).[\w\s.\(\)`*/–]+)\]\(((?!http).+(\.md|\.yml|\.md#[\w\-]+))\)')  # noqa: E501
     elif link_type == 'same':
         # regex that matches references sections within the same markdown
-        primary_pattern = re.compile(r'\[([\w\s.\(\)`*/–]+)\]\(([#\w\-._\w]+)\)')
+        primary_pattern = re.compile(r'\[([\w\s.\(\)`*/–]+)\]\(([#\w\-._]+)\)')
 
     for root, dirs, files in sorted(os.walk(root_path)):
         for file in files:

--- a/pdf_build_src/process_markdowns.py
+++ b/pdf_build_src/process_markdowns.py
@@ -112,10 +112,10 @@ def remove_internal_links(root_path, link_type):
     if link_type == 'cross':
         # regex that matches cross markdown links within a file
         # TODO: add more documentation explaining regex
-        primary_pattern = re.compile(r'\[((?!http).[\w\s.\(\)`*/–]+)\]\(((?!http).+(\.md|\.yml|\.md#[\w\-]+))\)')  # noqa: E501
+        primary_pattern = re.compile(r'\[((?!http).[\w\s\.\(\)`*/–]+)\]\(((?!http).+(\.md|\.yml|\.md#[\w\-]+))\)')  # noqa: E501
     elif link_type == 'same':
         # regex that matches references sections within the same markdown
-        primary_pattern = re.compile(r'\[([\w\s.\(\)`*/–]+)\]\(([#\w\-._]+)\)')
+        primary_pattern = re.compile(r'\[([\w\s\.\(\)`*/–]+)\]\(([#\w\-\._]+)\)')
 
     for root, dirs, files in sorted(os.walk(root_path)):
         for file in files:


### PR DESCRIPTION
This regular expression includes duplicate character `\w` in a set of characters.

Fixes #852.

Or at least attempts to fix that issue. This patch should not modify the current behaviour of the program. Yet, please review it carefully as the duplication might hide a conceptual error - but then I suppose such an error would have been detected by now!