### PR TITLE
[FIX] Clarify case collision intolerance as a file naming principle

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -111,7 +111,8 @@ misunderstanding we clarify them here.
 
 1.  **`<label>`** - an alphanumeric value, possibly prefixed with arbitrary
     number of 0s for consistent indentation, for example, it is `rest` in `task-rest`
-    following `task-<label>` specification.
+    following `task-<label>` specification. See [Participant names and other labels](#participant-names-and-other-labels)
+    for additional information.
 
 1.  **`suffix`** - an alphanumeric value, located after the `key-value_` pairs (thus after
     the final `_`), right before the **File extension**, for example, it is `eeg` in

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -111,9 +111,7 @@ misunderstanding we clarify them here.
 
 1.  **`<label>`** - an alphanumeric value, possibly prefixed with arbitrary
     number of 0s for consistent indentation, for example, it is `rest` in `task-rest`
-    following `task-<label>` specification. **Note:** value is case sensitive, but
-    values for the same entity MUST NOT be identical if casing is ignored, for example,
-    it is not allowed to have `sub-S1` and `sub-s1`.
+    following `task-<label>` specification.
 
 1.  **`suffix`** - an alphanumeric value, located after the `key-value_` pairs (thus after
     the final `_`), right before the **File extension**, for example, it is `eeg` in
@@ -632,6 +630,11 @@ Please note that a given label or index is distinct from the "prefix"
 it refers to. For example `sub-01` refers to the `sub` entity (a
 subject) with the label `01`. The `sub-` prefix is not part of the subject
 label, but must be included in file names (similarly to other key names).
+
+### Case collision intolerance
+
+`<label>` values are sensitive, but values for the same entity MUST NOT be identical across files if casing is ignored.
+For example, it is not allowed to have `sub-S1` and `sub-s1`.
 
 ## Uniform Resource Indicator
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -111,8 +111,8 @@ misunderstanding we clarify them here.
 
 1.  **`<label>`** - an alphanumeric value, possibly prefixed with arbitrary
     number of 0s for consistent indentation, for example, it is `rest` in `task-rest`
-    following `task-<label>` specification. See [Participant names and other labels](#participant-names-and-other-labels)
-    for additional information.
+    following `task-<label>` specification. Note that labels MUST not collide when
+    casing is ignored (see [Case collision intolerance](#case-collision-intolerance)).
 
 1.  **`suffix`** - an alphanumeric value, located after the `key-value_` pairs (thus after
     the final `_`), right before the **File extension**, for example, it is `eeg` in
@@ -218,6 +218,15 @@ although certain suffixes are exclusive for this purpose (for example, `MP2RAGE`
 Use cases concerning this convention are compiled in the
 [file collections](./99-appendices/10-file-collections.md) appendix.
 This convention is mainly intended for but not limited to MRI modalities.
+
+### Case collision intolerance
+
+File name components are case sensitive,
+but collisions MUST be avoided when casing is ignored.
+For example, a dataset cannot contain both `sub-s1` and `sub-S1`,
+as the labels would collide on a case-insensitive filesystem.
+Additionally, because the suffix `eeg` is defined,
+then the suffix `EEG` will not be added to future versions of the standard.
 
 ## Source vs. raw vs. derived data
 
@@ -631,11 +640,6 @@ Please note that a given label or index is distinct from the "prefix"
 it refers to. For example `sub-01` refers to the `sub` entity (a
 subject) with the label `01`. The `sub-` prefix is not part of the subject
 label, but must be included in file names (similarly to other key names).
-
-### Case collision intolerance
-
-`<label>` values are sensitive, but values for the same entity MUST NOT be identical across files if casing is ignored.
-For example, it is not allowed to have `sub-S1` and `sub-s1`.
 
 ## Uniform Resource Indicator
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -111,7 +111,9 @@ misunderstanding we clarify them here.
 
 1.  **`<label>`** - an alphanumeric value, possibly prefixed with arbitrary
     number of 0s for consistent indentation, for example, it is `rest` in `task-rest`
-    following `task-<label>` specification.
+    following `task-<label>` specification. **Note:** value is case sensitive, but
+    values for the same entity MUST NOT be identical if casing is ignored, for example,
+    it is not allowed to have `sub-S1` and `sub-s1`.
 
 1.  **`suffix`** - an alphanumeric value, located after the `key-value_` pairs (thus after
     the final `_`), right before the **File extension**, for example, it is `eeg` in


### PR DESCRIPTION
Closes #857 

An alternative could be to establish a new section, like "Case sensitivity" in the same document, which would allow to generalize the rule to cover the entire file path, and then just refer to it from `<label>`.  But was not sure if it would not just get lost among already a good number of sections there, and where to place it.  Sounds like a foundational aspect to me and should be close on top but "what is not as important" there? ;)

- [x] Whenever this PR is merged in some form or shape, an issue should be filed in bids-validator to have validation for this implemented.

edit 1: is there a term to describe such desired behavior?  it is neither "case sensitive" nor "case insensitive" .  "case collision intolerant"?