### PR TITLE
[INFRA] Add .lgtm.yml file for better usage of LGTM CI tool

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,8 @@
+---
+# This file contains configuration for the LGTM tool: https://lgtm.com/
+# The bids-specification repository is continuously scanned by the LGTM tool
+# for any security and/or code vulnerabilities. You can find the alert here:
+# https://lgtm.com/projects/g/bids-standard/bids-specification/
+queries:
+  # https://lgtm.com/rules/6770079/
+  - exclude: py/unused-import

--- a/pdf_build_src/process_markdowns.py
+++ b/pdf_build_src/process_markdowns.py
@@ -16,7 +16,8 @@ from datetime import datetime
 import numpy as np
 
 sys.path.append("../tools/")
-from mkdocs_macros_bids import macros  # noqa   (used in "eval" call later on)
+# functions from module macros are called by eval() later on
+from mkdocs_macros_bids import macros  # noqa: F401
 
 
 def run_shell_cmd(command):


### PR DESCRIPTION
Previous commit bb6065a from #853 does not work around the LGTM alert.

We attempt to silence the LGTM alert using an [`lgtm.yml`](https://lgtm.com/help/lgtm/lgtm.yml-configuration-file) file, and use standard Flake8 `noqa` suppression comments to document the issue at hand.

Fixes #864.

Links:
* https://lgtm.com/projects/g/bids-standard/bids-specification/snapshot/56824aa6b869bcbec1fb14c50e3771cfc0358af5/files/pdf_build_src/process_markdowns.py?sort=name&dir=ASC&mode=heatmap#xea83c650d9db5491:1
* https://github.com/github/codeql/issues/6517
