### PR TITLE
[INFRA] fix draft rendering css on mobile or when browser window is narrow

### DIFF
--- a/src/css/watermark.css
+++ b/src/css/watermark.css
@@ -1,15 +1,12 @@
-.md-nav__title[for=__drawer] {
-    background-color: #ff0000;
-}
-
-.md-header {
-    background-color: #ff0000;
-}
-
 .md-main__inner {
     background-image: url(../images/draft_watermark.png);
     background-repeat: no-repeat;
     background-attachment: fixed;
     background-size: contain, cover;
     background-position: center;
+}
+
+ /* See: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#custom-color-schemes */
+:root {
+    --md-primary-fg-color: #ff0000;
 }

--- a/src/css/watermark.css
+++ b/src/css/watermark.css
@@ -1,12 +1,17 @@
+@media screen and (max-width: 76.1875em) {
+    .md-nav__title[for=__drawer] {
+        background-color: #ff0000 !important;
+    }
+    }
+
+.md-header {
+    background-color: #ff0000;
+}
+
 .md-main__inner {
     background-image: url(../images/draft_watermark.png);
     background-repeat: no-repeat;
     background-attachment: fixed;
     background-size: contain, cover;
     background-position: center;
-}
-
- /* See: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#custom-color-schemes */
-:root {
-    --md-primary-fg-color: #ff0000;
 }

--- a/src/css/watermark.css
+++ b/src/css/watermark.css
@@ -1,4 +1,4 @@
-.md-sidebar {
+.md-nav__title {
     background-color: #ff0000;
 }
 

--- a/src/css/watermark.css
+++ b/src/css/watermark.css
@@ -1,4 +1,4 @@
-.md-nav__title {
+.md-nav__title[for=__drawer] {
     background-color: #ff0000;
 }
 

--- a/src/css/watermark.css
+++ b/src/css/watermark.css
@@ -1,3 +1,7 @@
+.md-nav__list {
+    background-color: #ff0000;
+}
+
 .md-header {
     background-color: #ff0000;
 }

--- a/src/css/watermark.css
+++ b/src/css/watermark.css
@@ -1,8 +1,9 @@
+/* 76.1875em are based on stylesheets: https://github.com/squidfunk/mkdocs-material/tree/master/material/assets/stylesheets */
 @media screen and (max-width: 76.1875em) {
     .md-nav__title[for=__drawer] {
         background-color: #ff0000 !important;
     }
-    }
+}
 
 .md-header {
     background-color: #ff0000;

--- a/src/css/watermark.css
+++ b/src/css/watermark.css
@@ -1,4 +1,4 @@
-.md-nav__list {
+.md-sidebar {
     background-color: #ff0000;
 }
 


### PR DESCRIPTION
fixes #491 

it's probably (I think) the `nav__title` element's background that needs to be changed --> BUT ONLY when the width of the browser is of a certain width or below, see screenshot from browser console (in Chrome):

![image](https://user-images.githubusercontent.com/9084751/135713618-62a45613-975a-4e82-a5d8-ec7488146eeb.png)


I applied red color to `nav__title` but:

1. this results in unwanted coloring on **wide** screens, see screenshot: 
![image](https://user-images.githubusercontent.com/9084751/135713644-927277ab-1a44-404a-a187-747dd9a056f8.png)

1. this gets **overridden** when the screen is narrow (or the browser window is made narrow), see the "strike-through" CSS from the first screenshot in this thread, ... and then what we want to be red is blue again.

So we somehow need to edit/customize the logic that kicks in for narrow browser windows --> and to have that add the red color.

EDIT: tried that via https://stackoverflow.com/questions/13979443/if-screen-resolution-is-less-than-x-append-css/13979463 in https://github.com/bids-standard/bids-specification/pull/889/commits/fc1f272c0c39bf1fd5d703529aa85d3e6256ad70 ... will revert if it doesn't work.

---

An alternative might be to set the colors via `:root {}`, see: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#custom-colors
