### PR TITLE
[FIX] Clarify shifting dates RECOMMENDED, add example EDF

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -734,8 +734,11 @@ Describing dates and timestamps:
 
 -   Dates can be shifted by a random number of days for privacy protection
     reasons.
-    To distinguish real dates from shifted dates, always use year 1925
-    or earlier when including shifted years.
+    To distinguish real dates from shifted dates,
+    is is RECOMMENDED to set shifted dates to the year 1925 or earlier.
+    Note that some data formats do not support arbitrary recording dates.
+    For example, the [EDF](https://www.edfplus.info/)
+    data format can only contain recording dates after 1985.
     For longitudinal studies dates MUST be shifted by the same number of days
     within each subject to maintain the interval information.
     For example: `1867-06-15T13:45:30`

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -431,6 +431,9 @@ This way relative timing would be preserved, but chances of identifying a
 person based on the date and time of their scan would be decreased.
 Dates that are shifted for anonymization purposes SHOULD be set to the year 1925
 or earlier to clearly distinguish them from unmodified data.
+Note that some data formats do not support arbitrary recording dates.
+For example, the [EDF](https://www.edfplus.info/)
+data format can only contain recording dates after 1985.
 Shifting dates is RECOMMENDED, but not required.
 
 Additional fields can include external behavioral measures relevant to the


### PR DESCRIPTION
closes #698 

While browsing #698, I realized that in the spec we are slightly inconsistent: In the modality agnostic files section, we RECOMMEND that shifted dates are in the year 1925 or earlier, and emphasize that shifting is RECOMMENDED, not required.

Yet in the Common Principles section, we write:

> To distinguish real dates from shifted dates, always use year 1925
    or earlier when including shifted years.
    
In this PR I propose to rephrase what we have in Common Principles and clarify that shifting dates is RECOMMENDED (not required) and preferably done to or prior to 1925 (but again, not required).

I think that makes the spec both more consistent, and avoids nonsensical situations were we have a data format like EDF which cannot technically contain recording dates prior to 1985, but which BIDS REQUIRES to have a date prior to 1925.