### PR TITLE
[INFRA] tiny speedup of building PDF by moving `re.compile()` outside of a loop

### DIFF
--- a/pdf_build_src/process_markdowns.py
+++ b/pdf_build_src/process_markdowns.py
@@ -434,6 +434,8 @@ def process_macros(duplicated_src_dir_path):
     delimiters ("{{" and "}}"). Therefore, those characters should not be used
     in the specification for any purposes other than running macros.
     """
+    re_code_snippets = re.compile("({{.*?}})", re.DOTALL)
+
     for root, dirs, files in os.walk(duplicated_src_dir_path):
         for name in files:
             # Only edit markdown files
@@ -445,7 +447,7 @@ def process_macros(duplicated_src_dir_path):
                 contents = fo.read()
 
             # Replace code snippets in the text with their outputs
-            matches = re.findall(re.compile("({{.*?}})", re.DOTALL), contents)
+            matches = re.findall(re_code_snippets, contents)
             for m in matches:
                 # Remove macro delimiters to get *just* the function call
                 function_string = m.strip("{} ")


### PR DESCRIPTION
5de7cfc8884babe4ae21c345805b5b1e2393bccf / #774 changed:
https://github.com/bids-standard/bids-specification/blob/b45d99e5eef734a751d13c0bd6ec6dfb03be9fef/pdf_build_src/process_markdowns.py#L447
into:
https://github.com/bids-standard/bids-specification/blob/5de7cfc8884babe4ae21c345805b5b1e2393bccf/pdf_build_src/process_markdowns.py#L448

If the intent was only to add `DOTALL`, I believe this would have been sufficient:
```python
            matches = re.findall("({{.*?}})", contents, re.DOTALL)
```

If the intent was to use `re.compile()` for efficiency, then `re.compile()` must be moved outside the loop.