### PR TITLE
[SCHEMA] Add MeasurementToolMetadata and Derivative metadata fields

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -573,6 +573,7 @@ using an object containing the following fields:
         "Units": "RECOMMENDED",
         "TermURL": "RECOMMENDED",
         "HED": "OPTIONAL",
+        "Derivative": "OPTIONAL",
    }
 ) }}
 

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -573,7 +573,6 @@ using an object containing the following fields:
         "Units": "RECOMMENDED",
         "TermURL": "RECOMMENDED",
         "HED": "OPTIONAL",
-        "Derivative": "OPTIONAL",
    }
 ) }}
 

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -363,12 +363,14 @@ in the BIDS dataset and `participants.tsv` file.
 As with all other tabular data, the additional phenotypic information files
 MAY be accompanied by a JSON file describing the columns in detail
 (see [Tabular files](02-common-principles.md#tabular-files)).
-In addition to the column description, a section describing the measurement tool
-(as a whole) MAY be added under the name `MeasurementToolMetadata`.
-This section consists of two keys:
 
--   `Description`: A free text description of the measurement tool
--   `TermURL`: A URL to an entity in an ontology corresponding to this tool.
+In addition to the column descriptions, the JSON file MAY contain the following fields:
+
+{{ MACROS___make_metadata_table(
+   {
+      "MeasurementToolMetadata": "OPTIONAL",
+   }
+) }}
 
 As an example, consider the contents of a file called
 `phenotype/acds_adult.json`:

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -369,6 +369,7 @@ In addition to the column descriptions, the JSON file MAY contain the following 
 {{ MACROS___make_metadata_table(
    {
       "MeasurementToolMetadata": "OPTIONAL",
+      "Derivative": "OPTIONAL",
    }
 ) }}
 

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -452,6 +452,13 @@ Density:
   - type: object
     additionalProperties:
       type: string
+Derivative:
+  name: Derivative
+  description: |
+    Indicates that values in the corresponding column are transformations of values
+    from other columns (for example a summary score based on a subset of items in a
+    questionnaire).
+  type: boolean
 Description:
   name: Description
   description: |
@@ -1549,6 +1556,20 @@ MaxMovement:
     as measured by the head localisation coils (for example, 4.8).
   type: number
   unit: mm
+MeasurementToolMetadata:
+  name: MeasurementToolMetadata
+  description: |
+    A description of the measurement tool as a whole.
+    Contains two fields: `"Description"` and `"TermURL"`.
+    `"Description"` is a free text description of the measurement tool.
+    `"TermURL"` is a URL to an entity in an ontology corresponding to this tool.
+  type: object
+  properties:
+    TermURL:
+      type: string
+      format: uri
+    Description:
+      type: string
 MetaboliteAvail:
   name: MetaboliteAvail
   description: |


### PR DESCRIPTION
Closes None, but adds fields that we previously missed.

Changes proposed:

- Add two new metadata fields that are described in the phenotypic data section of the spec.
- Add a metadata table for the MeasurementToolMetadata field.
- Add Derivative to the existing tabular data metadata table.