### PR TITLE
[ENH] add details for content of `*_beh.json`

### DIFF
--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -57,7 +57,7 @@ congruent	red	1.435	images/word-red_color-red.jpg
 incongruent	red	1.739	images/word-red_color-blue.jpg
 ```
 
-In the accompanying JSON sidecar, the `trial_type` column might look as follows:
+In the accompanying JSON sidecar, the `trial` column might be documented as follows:
 
 ```JSON
 {

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -29,10 +29,10 @@ stimulation turned on or off, the data files may be labelled
 
 In addition to the metadata that is either:
 
-- RECOMMENDED for side-car JSON files for [tabular data](../02-common-principles.md#tabular-data), or
+-   RECOMMENDED for side-car JSON files for [tabular data](../02-common-principles.md#tabular-data), or
 
-- REQUIRED for some data that can be found in the `beh` folder
-(for example `SamplingFrequency` and `StartTime` for `*_<physio|stim>.tsv.gz` files),
+-   REQUIRED for some data that can be found in the `beh` folder
+    (for example `SamplingFrequency` and `StartTime` for `*_<physio|stim>.tsv.gz` files),
 
 it is RECOMMENDED to add the following metadata to the JSON files of this folder:
 

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -27,9 +27,9 @@ stimulation turned on or off, the data files may be labelled
 
 ## RECOMMENDED metadata
 
-In addition of the metadata:
+In addition to the metadata that is either:
 
-- RECOMMENDED for side-car JSON files for [tabular data](../02-common-principles.md#tabular-data),
+- RECOMMENDED for side-car JSON files for [tabular data](../02-common-principles.md#tabular-data), or
 
 - REQUIRED for some data that can be found in the `beh` folder
 (for example `SamplingFrequency` and `StartTime` for `*_<physio|stim>.tsv.gz` files),
@@ -49,7 +49,7 @@ it is RECOMMENDED to add the following metadata to the JSON files of this folder
    }
 ) }}
 
-Example of the content of a `_beh.tsv` and its `_beh.json` file:
+Example of the content of a `_beh.tsv` and its accompanying `_beh.json` sidecar file:
 
 ```Text
 trial	response	response_time	stim_file

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -29,7 +29,7 @@ stimulation turned on or off, the data files may be labelled
 
 In addition to the metadata that is either:
 
--   RECOMMENDED for side-car JSON files for [tabular data](../02-common-principles.md#tabular-data), or
+-   RECOMMENDED for sidecar JSON files for [tabular data](../02-common-principles.md#tabular-data), or
 
 -   REQUIRED for some data that can be found in the `beh` folder
     (for example `SamplingFrequency` and `StartTime` for `*_<physio|stim>.tsv.gz` files),

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -66,8 +66,8 @@ In the accompanying JSON sidecar, the `trial_type` column might look as follows:
       "LongName": "Trial name",
       "Description": "Indicator of the type of trial",
       "Levels": {
-         "congruent": "Word and color font are congruent.",
-         "incongruent": "Word and color font are not congruent."
+         "congruent": "Word and font color match.",
+         "incongruent": "Word and font color do not match."
       }
    }
 }

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -27,9 +27,14 @@ stimulation turned on or off, the data files may be labelled
 
 ## RECOMMENDED metadata
 
-In addition of the metadata REQUIRED for some data that can be found in the `beh` folder
+In addition of the metadata:
+
+- RECOMMENDED for side-car JSON files for [tabular data](../02-common-principles.md#tabular-data),
+
+- REQUIRED for some data that can be found in the `beh` folder
 (for example `SamplingFrequency` and `StartTime` for `*_<physio|stim>.tsv.gz` files),
-it is RECOMMENDED to add the following metadata to the JSON files of this folder.
+
+it is RECOMMENDED to add the following metadata to the JSON files of this folder:
 
 {{ MACROS___make_metadata_table(
    {
@@ -43,3 +48,27 @@ it is RECOMMENDED to add the following metadata to the JSON files of this folder
       "InstitutionalDepartmentName": "RECOMMENDED",
    }
 ) }}
+
+Example of the content of a `_beh.tsv` and its `_beh.json` file:
+
+```Text
+trial	response	response_time	stim_file
+congruent	red	1.435	images/word-red_color-red.jpg
+incongruent	red	1.739	images/word-red_color-blue.jpg
+```
+
+In the accompanying JSON sidecar, the `trial_type` column might look as follows:
+
+```JSON
+{
+   "TaskName": "Stroop",
+   "trial": {
+      "LongName": "Trial name",
+      "Description": "Indicator of the type of trial",
+      "Levels": {
+         "congruent": "Word and color font are congruent.",
+         "incongruent": "Word and color font are not congruent.",
+      }
+   }
+}
+```

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -67,7 +67,7 @@ In the accompanying JSON sidecar, the `trial_type` column might look as follows:
       "Description": "Indicator of the type of trial",
       "Levels": {
          "congruent": "Word and color font are congruent.",
-         "incongruent": "Word and color font are not congruent.",
+         "incongruent": "Word and color font are not congruent."
       }
    }
 }


### PR DESCRIPTION
Add more info and an example concerning for `beh.tsv` an `beh.json`

Related to this issue in the BIDS validator: 
https://github.com/bids-standard/bids-validator/issues/1364