### PR TITLE
[INFRA] fix circleci: adding apt keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,13 @@ jobs:
           at: ~/project
       - run:
           name: install git
+          # `apt-key adv` calls added 2021-10-27, no idea why they are needed now.
           command: |
+            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DCC9EFBF77E11517
+            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9
+            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 54404762BBB6E853
+            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 112695A0E562B32A
+            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
             apt update -y
             apt install git-all -y
       - run:


### PR DESCRIPTION
This PR is intended to fix the CircleCI continuous integration service step. I debugged it when logged into the session via ssh, and this was the fix. I don't know why adding the keys is now needed. It might be a temporary thing. In any case, I don't think it hurts.

- https://chrisjean.com/fix-apt-get-update-the-following-signatures-couldnt-be-verified-because-the-public-key-is-not-available/
- https://unix.stackexchange.com/questions/75807/no-public-key-available-on-apt-get-update