### PR TITLE
BF?: use .url_output instead of .url

### DIFF
--- a/.github/workflows/redirect_circleci_artifacts.yml
+++ b/.github/workflows/redirect_circleci_artifacts.yml
@@ -14,4 +14,4 @@ jobs:
           job-title: Check the rendered PDF version here!
       - name: Check the URL
         run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA
+          curl --fail ${{ steps.step1.outputs.url_output }} | grep $GITHUB_SHA


### PR DESCRIPTION
Just blindly following an example on https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-10

If succeeds -- Closes #941
