### PR TITLE
[INFRA] fix "CircleCI redirector" GH-action: remove the 2nd (sanity) check

### DIFF
--- a/.github/workflows/redirect_circleci_artifacts.yml
+++ b/.github/workflows/redirect_circleci_artifacts.yml
@@ -5,13 +5,9 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
-        id: step1
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/bids-spec.pdf
           circleci-jobs: build_docs_pdf
           job-title: Check the rendered PDF version here!
-      - name: Check the URL
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
Following the recommendation of @larsoner :
https://github.com/bids-standard/bids-specification/issues/941#issuecomment-982035117

Closes #941
