### PR TITLE
[FIX] Common principles: Add "entity" to list of definitions

### DIFF
--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -105,6 +105,9 @@ misunderstanding we clarify them here.
     The modality may overlap with, but should not be confused with
     the **data type**.
 
+1.  **Entity** - a portion of a file name, consisting of a **key** and corresponding
+    **value** separated by a hyphen.
+
 1.  **`<index>`** - a nonnegative integer, possibly prefixed with arbitrary number of
     0s for consistent indentation, for example, it is `01` in `run-01` following
     `run-<index>` specification.


### PR DESCRIPTION
Just realised why the "entity" terminology when referring to key-values in file names hadn't clicked for me: it's missing from the list of definitions!

While this is a relatively trivial addition, I am nevertheless listing as a draft PR. I have noticed that in subsequent text, both "entity / entities" and "key-value(s) / key-value pairs" are used interchangeably. If the definition of "entity" is presented unambiguously in the specification, then it is worth considering the prospect of enforcing this nomenclature throughout the specification, and I think this is an appropriate location for that discussion.