### PR TITLE
[FIX] Spelling errors in appendices

### DIFF
--- a/src/99-appendices/03-hed.md
+++ b/src/99-appendices/03-hed.md
@@ -40,7 +40,7 @@ automatically generated.
 Usually annotations that appear in the `HED` column are specific to each individual event.
 Information that is common to groups of events can be annotated by category.
 Numerical values associated with each event can be annotated by value type.
-Annotating by category and by valuegreatly reduces the effort required to HED tag
+Annotating by category and by value greatly reduces the effort required to HED tag
 data and improves the clarity for data users.
 
 ## Annotating events by categories

--- a/src/99-appendices/11-qmri.md
+++ b/src/99-appendices/11-qmri.md
@@ -349,7 +349,7 @@ required metadata field (second column).
 
 A derived qMRI application becomes available if all the optional metadata fields
 listed for the respective file collection suffix are provided for the data. In addition,
-conditional rules based on the value of a given required metada field can be set
+conditional rules based on the value of a given required metadata field can be set
 for the description of a derived qMRI application. Note that the value of this
 required metadata is fixed across constituent images of a file collection and defined
 in [Method-specific priority levels for qMRI file collections](#method-specific-priority-levels-for-qmri-file-collections).


### PR DESCRIPTION
Two minor spelling errors spotted in the process of generating Lestropie/bids-specification#1, itself an offshoot of #947 (though the errors are unrelated).