### PR TITLE
[MISC] Add Eric Earl as a Maintainer

### DIFF
--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -32,6 +32,7 @@ BIDS governance.
 | Taylor Salo ([@tsalo](https://github.com/tsalo))                               | 3h/week         | MRI                        |
 | Remi Gau ([@Remi-Gau](https://github.com/Remi-Gau))                            | 3h/week         | Community development, MRI |
 | Anthony Galassi  ([@bendhouseart](https://github.com/bendhouseart))            | 3h/week         | PET, Community development |
+| Eric Earl ([@ericearl](https://github.com/ericearl))                           | 2h/week         |                            |
 
 In addition to the [BIDS Governance](https://bids.neuroimaging.io/governance.html#bids-maintainers-group)
 classification of a maintainer, maintainers may declare a limited scope of responsibility.

--- a/src/99-appendices/01-contributors.md
+++ b/src/99-appendices/01-contributors.md
@@ -68,7 +68,7 @@ If you contributed to the BIDS ecosystem and your name is not listed, please add
 -   Erin W. Dickie 📖🤔👀📢💬
 -   Eugene P. Duff 📖
 -   Elizabeth DuPre 📖💡🔍🤔💬
--   Eric A. Earl 🤔
+-   Eric Earl 📖💬🐛🚧🔧🤔
 -   Anders Eklund 📖📢💻
 -   Oscar Esteban 📖🔧🤔💬💻
 -   Franklin W. Feingold 📋📝✅💬🤔🎨📢👀🚇🖋📆


### PR DESCRIPTION
- Add Eric Earl to the Maintainers Group in `DECISION-MAKING.md`.
- Add Eric Earl's missing contributions to `01-contributors.md`.