### PR TITLE
[ENH] BEP034 Computational modelling

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
         - Behavioral experiments (with no neural recordings): 04-modality-specific-files/07-behavioral-experiments.md
         - Genetic Descriptor: 04-modality-specific-files/08-genetic-descriptor.md
         - Positron Emission Tomography: 04-modality-specific-files/09-positron-emission-tomography.md
+        - Computational models: 04-modality-specific-files/10-computational-models.md
       - Derivatives:
         - BIDS Derivatives: 05-derivatives/01-introduction.md
         - Common data types and metadata: 05-derivatives/02-common-data-types.md

--- a/src/04-modality-specific-files/10-computational-models.md
+++ b/src/04-modality-specific-files/10-computational-models.md
@@ -1,0 +1,143 @@
+# Computational Models
+
+Support for the modality `comp` was developed as a
+[BIDS Extension Proposal](https://docs.google.com/document/d/1NT1ERdL41oz3NibIFRyVQ2iR8xH-dKY-lRCB4eyVeRo/edit#heading=h.mqkmyp254xh6).
+
+BIDS Computational Model files store the mathematical and computational descriptions of
+computational models as well as simulation results.
+To ensure that computational modelling results are reproducible it is necessary to store
+for every simulation result the used
+
+-   mathematical model equations (including all state variables and generic parameters),
+-   specific parameter settings (for example, for a certain `sub`, `ses`, `task`, ...)
+-   structural connectivity
+-   source code
+-   and machine code.
+
+Therefore, every file that contains computational model simulation results **MUST**
+reference these files in a JSON sidecar file.
+
+To store code either the modality agnostic datatype `code` or publicly accessible
+long-term repositories can be used. To store models the datatype `model` **MUST** be
+used.
+
+**Caveat**: To store structural connectivity the datatype `connectivity` developed in
+[BEP017](https://docs.google.com/document/d/1ugBdUF6dhElXdj3u9vw0iWjE6f_Bibsro3ah7sRV0GA/edit#)
+is planned to be used.
+To store simulation results a new datatype for storing time series will be needed.
+The need for such a BIDS-wide datatype to store time series was
+[identified](https://github.com/bids-standard/bids-specification/issues/713).
+
+The following filetree exemplifies the directory structure.
+
+{{ MACROS___make_filetree_example(
+
+{
+    	"comp": {
+    		"model": {
+    			"desc-Generic2dOscillator_eq.xml": "                     generic equations for all subjects",
+    			"desc-JansenRit_eq.xml": "",
+    			"desc-JansenRit-healthy_param.xml": "                    generic parameters for all subjects",
+    			"desc-Generic2dOscillator-healthy_param.xml": "",
+    		},
+    		"code": {
+    			"desc-Generic2dOscillator-script.py": "                  generic machine code for all subjects",
+    			"desc-JansenRit.img": "",
+    			"desc-JansenRit-Dockerfile.txt": "                       generic source code for all subjects"
+    		},
+    		"sub-01": {
+    			"model": {
+    				"sub-01_desc-JansenRit-stroke_param.xml": "           subject-specific parameters only for sub-01",
+    				"sub-01_desc-Generic2dOscillator-stroke_param.xml": ""
+    			},
+    			"code": {
+    				"sub-01_desc-preproc.py": "                           subject-specific code only for sub-01"
+    			},
+    			"timeseries": {
+    				"sub-01_desc-testsim.tsv": "                          Datatype timeseries not yet existing, but needed: <https://github.com/bids-standard/bids-specification/issues/713>",
+    				"sub-01_desc-testsim.json": "                         every simulation result has a JSON sidecar that references the used model, code and connectivity",
+    				"sub-01_task-motor.tsv": "",
+    				"sub-01_task-motor.json": "",
+    				"sub-01_task-motor_desc-burnin.tsv": "",
+    				"sub-01_task-motor_desc-burnin.json": ""
+    			},
+    			"connectivity": {
+    				"sub-01_conndata-network_connectivity.tsv": "         as per BEP017: connectivity data schema",
+    				"sub-01_conndata-network_connectivity.json": ""
+    			}
+    		}
+    	}
+}
+
+) }}
+
+## Datatype: `model`
+
+{{ MACROS___make_filename_template(datatypes=["model"], suffixes=["eq", "param"]) }}
+
+Equations and parameters **MUST** be specified using the XML-based
+[**L**ow **E**ntropy **M**odel **S**pecification (LEMS)](http://lems.github.io/LEMS)
+format.
+LEMS provides a compact, minimally redundant, human-readable, human-writable, declarative
+way of expressing models of physical systems.
+[PyLEMS](https://github.com/LEMS/pylems) is a Python implementation of the LEMS language
+that can both parse and simulate existing LEMS models and provides an API in Python for
+reading, modifying and writing LEMS files.
+See the
+[original publication introducing LEMS](https://pubmed.ncbi.nlm.nih.gov/25309419/),
+and its [repository](http://lems.github.io/LEMS) with examples for more information.
+A basic principle of LEMS is to separate equations and parameter settings such that the
+equations need only be stated once and can then be reused with different
+parameterizations.
+
+### Entity: model equations (suffix: `"_eq.xml"`)
+
+Every simulation result MUST link to the used equations in LEMS-formatted `*_eq.xml` files
+using the metadata keyword `"ModelEq"`.
+
+### Entity: model parameters (suffix: `"_param.xml"`)
+
+Every simulation result MUST link to the used parameter settings in LEMS-formatted
+`*_param.xml` files using the keyword `"ModelParam"`.
+
+## Datatype: `code`
+
+Code involves
+
+-   "source code" (human-readable standard programming language)
+
+-   and "machine code" (executable program; in the case of an interpreted language like
+    Python, machine code and source code may be identical).
+
+Every BIDS dataset that contains simulation results **MUST** either directly store the
+**source code** and the **executable machine code** that was used to produce the result in
+the
+[modality agnostic folder code](https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html#code)
+or in a publicly accessible long-term repository.
+Every BIDS file that contains a simulation result **MUST** have a JSON sidecar file that
+links to the location of the used codes (either using URIs or relative file paths in the
+BIDS data set) using the metadata keys `"SourceCodeRepository"` and
+`"MachineCodeRepository"`.
+
+It is preferred that machine code exist in the form of self-contained container images
+(including the entire necessary computational environment).
+
+## Metadata
+
+**Note**: currently there is no datatype for simulation results in BIDS. There are
+however efforts towards a datatype to store
+[time series](https://github.com/bids-standard/bids-specification/issues/713),
+which may then be accompanied by JSON sidecar files with the entities below.
+Furthermore, connectivity information must be referenced using the entity
+`"Connectivity"`, support for which is currently developed in
+[BEP017](https://docs.google.com/document/d/1ugBdUF6dhElXdj3u9vw0iWjE6f_Bibsro3ah7sRV0GA/edit#)
+
+{{ MACROS___make_metadata_table(
+{
+"SourceCodeRepository": "REQUIRED",
+"MachineCodeRepository": "REQUIRED",
+"ModelEq": "REQUIRED",
+"ModelParam": "REQUIRED",
+"Connectivity": "REQUIRED"
+}
+) }}

--- a/src/schema/objects/datatypes.yaml
+++ b/src/schema/objects/datatypes.yaml
@@ -31,6 +31,10 @@ ieeg:
 meg:
   name: Magnetoencephalography
   description: Magnetoencephalography
+model:
+  name: Computational models
+  description: |
+    Mathematical equations and parameter settings in [LEMS](http://lems.github.io/LEMS) format.
 perf:
   name: Perfusion imaging
   description: |

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -365,6 +365,18 @@ Columns:
   type: array
   items:
     type: string
+Connectivity:
+  name: Connectivity
+  description: |
+    Reference to one or more `_conndata-network_connectivity.tsv` file(s) where the 
+    structural connectivity used to produce a simulation result is specified.
+  anyOf:
+  - type: array
+    items:
+      type: string
+      format: dataset_relative
+  - type: string
+    format: dataset_relative
 ContinuousHeadLocalization:
   name: ContinuousHeadLocalization
   description: |
@@ -1520,6 +1532,21 @@ MTState:
     Boolean stating whether the magnetization transfer pulse is applied.
     Corresponds to DICOM Tag 0018, 9020 `Magnetization Transfer`.
   type: boolean
+MachineCodeRepository:
+  name: MachineCodeRepository
+  description: |
+    Either reference to modality agnostic folder "code" or 
+    [URI](/02-common-principles.html#uniform-resource-indicator) to a publicly
+    accessible repository where the machine code used to produce the simulation result is 
+    provided.
+  anyOf:
+  - type: array
+    items:
+      type: string
+  - type: string
+    format: dataset_relative
+  - type: string
+    format: uri
 MagneticFieldStrength:
   name: MagneticFieldStrength
   description: |
@@ -1614,6 +1641,30 @@ ModeOfAdministration:
     Mode of administration of the injection
     (for example, `"bolus"`, `"infusion"`, or `"bolus-infusion"`).
   type: string
+ModelEq:
+  name: ModelEq
+  description: |
+    Reference to one or more `_eq.xml` file(s) where the computational model used to
+    produce a simulation result is specified in [LEMS](http://lems.github.io/LEMS) format.
+  anyOf:
+  - type: array
+    items:
+      type: string
+      format: dataset_relative
+  - type: string
+    format: dataset_relative
+ModelParam:
+  name: ModelParam
+  description: |
+    Reference to one or more `_param.xml` file(s) where the parameter setting used to
+    produce a simulation result is specified in [LEMS](http://lems.github.io/LEMS) format.
+  anyOf:
+  - type: array
+    items:
+      type: string
+      format: dataset_relative
+  - type: string
+    format: dataset_relative
 MolarActivity:
   name: MolarActivity
   description: |
@@ -2286,6 +2337,21 @@ SoftwareVersions:
     Manufacturer's designation of software version of the equipment that produced
     the measurements.
   type: string
+SourceCodeRepository:
+  name: SourceCodeRepository
+  description: |
+    Either reference to modality agnostic folder "code" or 
+    [URI](/02-common-principles.html#uniform-resource-indicator) to a publicly
+    accessible repository where the source code used to produce the simulation result is 
+    provided.
+  anyOf:
+  - type: array
+    items:
+      type: string
+  - type: string
+    format: dataset_relative
+  - type: string
+    format: uri
 SourceDatasets:
   name: SourceDatasets
   description: |

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -368,7 +368,7 @@ Columns:
 Connectivity:
   name: Connectivity
   description: |
-    Reference to one or more `_conndata-network_connectivity.tsv` file(s) where the 
+    Reference to one or more `_conndata-network_connectivity.tsv` file(s) where the
     structural connectivity used to produce a simulation result is specified.
   anyOf:
   - type: array
@@ -1535,9 +1535,9 @@ MTState:
 MachineCodeRepository:
   name: MachineCodeRepository
   description: |
-    Either reference to modality agnostic folder "code" or 
+    Either reference to modality agnostic folder "code" or
     [URI](/02-common-principles.html#uniform-resource-indicator) to a publicly
-    accessible repository where the machine code used to produce the simulation result is 
+    accessible repository where the machine code used to produce the simulation result is
     provided.
   anyOf:
   - type: array
@@ -2340,9 +2340,9 @@ SoftwareVersions:
 SourceCodeRepository:
   name: SourceCodeRepository
   description: |
-    Either reference to modality agnostic folder "code" or 
+    Either reference to modality agnostic folder "code" or
     [URI](/02-common-principles.html#uniform-resource-indicator) to a publicly
-    accessible repository where the source code used to produce the simulation result is 
+    accessible repository where the source code used to produce the simulation result is
     provided.
   anyOf:
   - type: array

--- a/src/schema/objects/modalities.yaml
+++ b/src/schema/objects/modalities.yaml
@@ -24,3 +24,7 @@ pet:
   name: Positron Emission Tomography
   description: |
     Data acquired with PET.
+comp:
+  name: Computational Modelling
+  description: |
+    Computational models and data simulated with computational models.

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -441,6 +441,10 @@ epi:
     The phase-encoding polarity (PEpolar) technique combines two or more Spin Echo
     EPI scans with different phase encoding directions to estimate the underlying
     inhomogeneity/deformation map.
+eq:
+  name: Equations
+  description: |
+    Mathematical equations in [LEMS](http://lems.github.io/LEMS) format.
 events:
   name: Events
   description: |
@@ -505,6 +509,10 @@ meg:
   description: |
     Unprocessed MEG data stored in the native file format of the MEG instrument
     with which the data was collected.
+param:
+  name: Parameters
+  description: |
+    Parameters in [LEMS](http://lems.github.io/LEMS) format.
 pet:
   name: Positron Emission Tomography
   description: |

--- a/src/schema/rules/datatypes/model.yaml
+++ b/src/schema/rules/datatypes/model.yaml
@@ -13,4 +13,3 @@
     run: optional
     resolution: optional
     description: optional
-    

--- a/src/schema/rules/datatypes/model.yaml
+++ b/src/schema/rules/datatypes/model.yaml
@@ -1,0 +1,16 @@
+---
+- suffixes:
+  - eq
+  - param
+  extensions:
+  - .xml
+  entities:
+    subject: optional
+    session: optional
+    task: optional
+    acquisition: optional
+    reconstruction: optional
+    run: optional
+    resolution: optional
+    description: optional
+    

--- a/src/schema/rules/modalities.yaml
+++ b/src/schema/rules/modalities.yaml
@@ -22,3 +22,7 @@ beh:
 pet:
   datatypes:
   - pet
+comp:
+  datatypes:
+    - model
+    - code

--- a/src/schema/rules/modalities.yaml
+++ b/src/schema/rules/modalities.yaml
@@ -24,5 +24,5 @@ pet:
   - pet
 comp:
   datatypes:
-    - model
-    - code
+  - model
+  - code


### PR DESCRIPTION
Dear BIDS community,

this PR replaces [#850](https://github.com/bids-standard/bids-specification/pull/850) on BEP034 Computational modelling.

Briefly, in the original PR the new modality `comp` with datatypes
1.   time series (and their derivatives)
2.   connectivities
3.   model descriptions (equations and parameters)
4.   coordinates
5.   code

was proposed.

In this new PR we address feedback from the maintainer meeting:

-    We now removed the datatype "time series" from the PR and instead will join efforts with the group around [issue 713 "Convergence on time series and events"](https://github.com/bids-standard/bids-specification/issues/713) towards making "time series" a BIDS-wide datatype that can also be used in other modalities. 
-    Furthermore, we will join efforts with [BEP017 Generic BIDS connectivity data schema](https://docs.google.com/document/d/1ugBdUF6dhElXdj3u9vw0iWjE6f_Bibsro3ah7sRV0GA/edit#heading=h.mqkmyp254xh6) and add the use case "structural connectivity for computational model simulation" to BEP017 to achieve a BIDS-wide connectivity datatype that can be used for different modalities.  
-   Instead, this new PR now introduces only one new data type "model" with the filename suffixes "_eq" and "_param" and the file extension ".xml" to store the equations and parameters of computational models in [LEMS](http://lems.github.io/LEMS) format.
-    Lastly, we propose to store the source codes and the machine codes that were used to create computational results in the modality agnostic folder `code`.

The new PR will be discussed **on Jan 11 at 17 CET** in the [NFDI-Neuro Webinar](https://nfdi-neuro.de/event/nfdi-neuro-webinar-ritter-et-al-bids/), please join the discussion.