### PR TITLE
ENH: Update B0Field metadata to accommodate single-blip fieldmaps

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -174,30 +174,33 @@ B0FieldIdentifier:
   description: |
     The presence of this key states that this particular 3D or 4D image MAY be
     used for fieldmap estimation purposes.
-    The `B0FieldIdentifier` MUST be a unique string within one participant's tree,
+    Each `B0FieldIdentifier` MUST be a unique string within one participant's tree,
     shared only by the images meant to be used as inputs for the estimation of a
     particular instance of the *B<sub>0</sub> field* estimation.
     It is RECOMMENDED to derive this identifier from DICOM Tags, for example,
     DICOM tag 0018, 1030 `Protocol Name`, or DICOM tag 0018, 0024 `Sequence Name`
     when the former is not defined (for example, in GE devices.)
-  type: string
-  format: participant_relative
+  anyOf:
+  - type: string
+  - type: array
+    items:
+      type: string
 B0FieldSource:
   name: B0FieldSource
   description: |
-    At least one existing `B0FieldIdentifier` defined by other images in the
+    At least one existing `B0FieldIdentifier` defined by images in the
     participant's tree.
     This field states the *B<sub>0</sub> field* estimation designated by the
     `B0FieldIdentifier` that may be used to correct the dataset for distortions
     caused by B<sub>0</sub> inhomogeneities.
-    `B0FieldSource` and `B0FieldIdentifier` are mutually exclusive.
+    `B0FieldSource` and `B0FieldIdentifier` MAY both be present for images that
+    are used to estimate their own B<sub>0</sub> field, for example, in "pepolar"
+    acquisitions.
   anyOf:
   - type: string
-    format: participant_relative
   - type: array
     items:
       type: string
-      format: participant_relative
 BIDSVersion:
   name: BIDSVersion
   description: |


### PR DESCRIPTION
Follow-up to #622. We realized that as currently worded, there are unresolvable ambiguities for pepolar schemes. Consider the case where you have two BOLD series and one reverse-PE EPI fieldmap. The inputs to estimate the fieldmap could be one or both BOLD files (along with the reverse-PE EPI), and the estimated fieldmap could then apply to one or both.

This allows files to be listed as part of multiple identifiers, and for a BOLD file to be part of an `B0FieldIdentifier` AND have a `B0FieldSource`.