### PR TITLE
[INFRA] Fix linkchecker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,7 @@ jobs:
                 --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
                 --ignore-url 'https://github.com/[^/]*' \
                 --ignore-url 'https://doi.org/.*' \
-                --ignore-url 'https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html' \
-                --ignore-url 'https://bids-specification.readthedocs.io/en/stable/99-appendices/14-glossary.html' \
+                --ignore-url 'https://bids-specification.readthedocs.io/en/stable/.*' \
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             python -m pip install linkchecker
       - run:
           name: check links
-          # XXX: Remove --ignore-urls for stable spec after 1.7 release
+          # XXX: Remove --ignore-urls for bids-specification.readthedocs.io/en/stable after 1.7 release
           command: |
             git status
             if (! git log -1 --pretty=oneline | grep REL:) ; then
@@ -49,11 +49,12 @@ jobs:
               # failures for local file:/// -- yoh found no better way,
               linkchecker -t 1 --check-extern \
                 --ignore-url 'file:///.*' \
-                --ignore-url https://fonts.gstatic.com \
-                --ignore-url "https://github.com/bids-standard/bids-specification/(pull|tree)/.*" \
-                --ignore-url "https://github.com/[^/]*" \
-                --ignore-url "https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html" \
-                --ignore-url "https://bids-specification.readthedocs.io/en/stable/99-appendices/14-glossary.html"
+                --ignore-url 'https://fonts.gstatic.com' \
+                --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
+                --ignore-url 'https://github.com/[^/]*' \
+                --ignore-url 'https://doi.org/.*' \
+                --ignore-url 'https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html' \
+                --ignore-url 'https://bids-specification.readthedocs.io/en/stable/99-appendices/14-glossary.html' \
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
                 --ignore-url https://fonts.gstatic.com \
                 --ignore-url "https://github.com/bids-standard/bids-specification/(pull|tree)/.*" \
                 --ignore-url "https://github.com/[^/]*" \
+                --ignore-url "https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html"
+                --ignore-url "https://bids-specification.readthedocs.io/en/stable/99-appendices/14-glossary.html"
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
             python -m pip install linkchecker
       - run:
           name: check links
+          # XXX: Remove --ignore-urls for stable spec after 1.7 release
           command: |
             git status
             if (! git log -1 --pretty=oneline | grep REL:) ; then
@@ -51,7 +52,7 @@ jobs:
                 --ignore-url https://fonts.gstatic.com \
                 --ignore-url "https://github.com/bids-standard/bids-specification/(pull|tree)/.*" \
                 --ignore-url "https://github.com/[^/]*" \
-                --ignore-url "https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html"
+                --ignore-url "https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html" \
                 --ignore-url "https://bids-specification.readthedocs.io/en/stable/99-appendices/14-glossary.html"
                 ~/project/site/*html ~/project/site/*/*.html
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
             python -m pip install linkchecker
       - run:
           name: check links
-          # XXX: Remove --ignore-urls for bids-specification.readthedocs.io/en/stable after 1.7 release
           command: |
             git status
             if (! git log -1 --pretty=oneline | grep REL:) ; then


### PR DESCRIPTION
The problem with our linkchecker failing for weeks is the following:

- Mkdocs inserts an HTML header into each HTML site that it builds.
- That header contains a "canonical" URL
- For us, this canonical URL points to the "stable" website, see also: https://www.mkdocs.org/user-guide/configuration/#site_url
- This can be customized here: https://github.com/bids-standard/bids-specification/blob/4bf68b9d0bc09e61879e9196e2e48e1471e0fa2a/mkdocs.yml#L2


This is how it looks:
```html
<!doctype html>
<html lang="en" class="no-js">
  <head>
    
      <meta charset="utf-8">
      <meta name="viewport" content="width=device-width,initial-scale=1">
      
      
      
        <link rel="canonical" href="https://bids-specification.readthedocs.io/en/stable/01-introduction.html">
...
```

Whenever we add a new HTML page to the spec, like the glossary, or microscopy - but haven't done a release yet, linkchecker will fail because those HTML pages are not available in the stable (canonical) URL.

I think we can fix this by temporarily adding these files to the ignore list of the linkchecker, and then "cleaning up" that ignore list at release time.

WDYT?

EDIT: cc @tsalo who figured this out in the first place