### PR TITLE
[FIX] update definition acq_time for sessions.tsv

### DIFF
--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -401,7 +401,7 @@ Such recordings MUST be documented with one row per file.
 {{ MACROS___make_columns_table(
    {
       "filename": ("REQUIRED", "There MUST be exactly one row for each file."),
-      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point in each run was acquired. Furthermore, if this header is provided, the acquisition times of all files that to a recording MUST be identical.")
+      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point in each run was acquired. Furthermore, if this header is provided, the acquisition times of all files that to a recording MUST be identical."),
    }
 ) }}
 
@@ -444,7 +444,7 @@ Column names in `sessions.tsv` files MUST be different from group level particip
 {{ MACROS___make_columns_table(
    {
       "session_id": ("REQUIRED", "There MUST be exactly one row for each session."),
-      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point of the first run was acquired.")
+      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point of the first run was acquired."),
       "pathology": "RECOMMENDED",
    }
 ) }}

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -401,7 +401,7 @@ Such recordings MUST be documented with one row per file.
 {{ MACROS___make_columns_table(
    {
       "filename": ("REQUIRED", "There MUST be exactly one row for each file."),
-      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point in each run was acquired. Furthermore, if this header is provided, the acquisition times of all files that to a recording MUST be identical."),
+      "acq_time__scans": ("OPTIONAL"),
    }
 ) }}
 
@@ -444,7 +444,7 @@ Column names in `sessions.tsv` files MUST be different from group level particip
 {{ MACROS___make_columns_table(
    {
       "session_id": ("REQUIRED", "There MUST be exactly one row for each session."),
-      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point of the first run was acquired."),
+      "acq_time__sessions": ("OPTIONAL"),
       "pathology": "RECOMMENDED",
    }
 ) }}

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -401,7 +401,7 @@ Such recordings MUST be documented with one row per file.
 {{ MACROS___make_columns_table(
    {
       "filename": ("REQUIRED", "There MUST be exactly one row for each file."),
-      "acq_time": "OPTIONAL",
+      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point in each run was acquired. Furthermore, if this header is provided, the acquisition times of all files that to a recording MUST be identical.")
    }
 ) }}
 
@@ -444,7 +444,7 @@ Column names in `sessions.tsv` files MUST be different from group level particip
 {{ MACROS___make_columns_table(
    {
       "session_id": ("REQUIRED", "There MUST be exactly one row for each session."),
-      "acq_time": "OPTIONAL",
+      "acq_time": ("OPTIONAL", "Acquisition time refers to when the first data point of the first run was acquired.")
       "pathology": "RECOMMENDED",
    }
 ) }}

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -17,18 +17,8 @@ acq_time:
     Furthermore, if this header is provided, the acquisition times of all files that
     belong to a recording MUST be identical.
 
-    Datetime should be expressed as described in [Units](/02-common-principles.html#units).
+    Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
 
-    For anonymization purposes all dates within one subject should be shifted by a randomly
-    chosen (but consistent across all recordings) number of days.
-    This way relative timing would be preserved, but chances of identifying a person based
-    on the date and time of their scan would be decreased.
-    Dates that are shifted for anonymization purposes SHOULD be set to the year 1925 or earlier
-    to clearly distinguish them from unmodified data.
-    Note that some data formats do not support arbitrary recording dates.
-    For example, the [EDF](https://www.edfplus.info/)
-    data format can only contain recording dates after 1985.
-    Shifting dates is RECOMMENDED, but not required.
   type: string
   format: datetime
 age:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -10,9 +10,20 @@ abbreviation:
   description: |
     The unique label abbreviation
   type: string
-acq_time:
+acq_time__scans:
   name: acq_time
-  description: Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
+  description: |
+    Acquisition time refers to when the first data point in each run was acquired.
+    Furthermore, if this header is provided, the acquisition times of all files
+    from the same recording MUST be identical.
+    Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
+  type: string
+  format: datetime
+acq_time__sessions:
+  name: acq_time
+  description: |
+    Acquisition time refers to when the first data point of the first run was acquired.
+    Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
   type: string
   format: datetime
 age:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -12,13 +12,7 @@ abbreviation:
   type: string
 acq_time:
   name: acq_time
-  description: |
-    Acquisition time refers to when the first data point in each run was acquired.
-    Furthermore, if this header is provided, the acquisition times of all files that
-    belong to a recording MUST be identical.
-
-    Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
-
+  description: Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
   type: string
   format: datetime
 age:


### PR DESCRIPTION
fixes #948 

- [x] simplify `acq_time` definition by removing sections that are redundant with the Unit section
- [x] give different restrictions for scans.tsv and sessions.tsv