### PR TITLE
[SCHEMA, FIX] Remove mentions of auxdatatypes

### DIFF
--- a/src/99-appendices/04-entity-table.md
+++ b/src/99-appendices/04-entity-table.md
@@ -20,7 +20,7 @@ while entity definitions are in [Appendix IX](09-entities.md).
 
 ## Magnetic Resonance Imaging
 
-{{ MACROS___make_entity_table(datatypes=["anat", "dwi", "func", "fmap", "perf"], auxdatatypes=[]) }}
+{{ MACROS___make_entity_table(datatypes=["anat", "dwi", "func", "fmap", "perf"]) }}
 
 ## Biopotential Amplification (EEG and iEEG)
 
@@ -28,7 +28,7 @@ while entity definitions are in [Appendix IX](09-entities.md).
 
 ## Magnetoencephalography (MEG)
 
-{{ MACROS___make_entity_table(datatypes=["meg"], auxdatatypes=["channels", "events", "photo"]) }}
+{{ MACROS___make_entity_table(datatypes=["meg"]) }}
 
 ## Positron Emission Tomography (PET)
 
@@ -36,8 +36,8 @@ while entity definitions are in [Appendix IX](09-entities.md).
 
 ## Behavioral Data
 
-{{ MACROS___make_entity_table(datatypes=["beh"], auxdatatypes=[]) }}
+{{ MACROS___make_entity_table(datatypes=["beh"]) }}
 
 ## Microscopy
 
-{{ MACROS___make_entity_table(datatypes=["micr"], auxdatatypes=[]) }}
+{{ MACROS___make_entity_table(datatypes=["micr"]) }}


### PR DESCRIPTION
Closes None.

Changes proposed:

- Remove uses of the `auxdatatypes` keyword from macro calls, since we dropped the `auxdatatypes` "category" from the schema back in #609. For some reason the entity table functions were still using this keyword. Fortunately, it didn't have any effect on the actual entity tables, but it could be confusing for folks who look at the code.