### PR TITLE
[FIX] update highlighting of examples, JSON keys and values, and TSV headers or values in the schema

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -70,7 +70,7 @@ duration:
   name: duration
   description: |
     Duration of the event (measured from onset) in seconds.
-    Must always be either zero or positive (or `"n/a"` if unavailable).
+    Must always be either zero or positive (or `n/a` if unavailable).
     A "duration" value of zero implies that the delta function or event is so
     short as to be effectively modeled as an impulse.
   anyOf:
@@ -188,7 +188,7 @@ mapping:
 material:
   name: material
   description: |
-    Material of the electrode (for example, `"Tin"`, `"Ag/AgCl"`, `"Gold"`).
+    Material of the electrode (for example, `Tin`, `Ag/AgCl`, `Gold`).
   type: string
 metabolite_parent_fraction:
   name: metabolite_parent_fraction
@@ -269,7 +269,7 @@ participant_id:
 plasma_radioactivity:
   name: plasma_radioactivity
   description: |
-    Radioactivity in plasma, in unit of plasma radioactivity (for example, `"kBq/mL"`).
+    Radioactivity in plasma, in unit of plasma radioactivity (for example, `kBq/mL`).
   type: number
 # reference column for channels.tsv files for EEG data
 reference__eeg:
@@ -283,7 +283,7 @@ reference__eeg:
 reference__ieeg:
   name: reference
   description: |
-    Specification of the reference (for example, 'mastoid', 'ElectrodeName01', 'intracranial', 'CAR', 'other', 'n/a').
+    Specification of the reference (for example, `mastoid`, `ElectrodeName01`, `intracranial`, `CAR`, `other`, `n/a`).
     If the channel is not an electrode channel (for example, a microphone channel) use `n/a`.
   anyOf:
   - type: string
@@ -300,7 +300,7 @@ response_time:
   description: |
     Response time measured in seconds.
     A negative response time can be used to represent preemptive responses and
-    "n/a" denotes a missed response.
+    `n/a` denotes a missed response.
   anyOf:
   - type: number
     unit: s
@@ -387,7 +387,7 @@ software_filters:
   name: software_filters
   description: |
     List of temporal and/or spatial software filters applied
-    (for example, "SSS", `"SpatialCompensation"`).
+    (for example, `SSS`, `SpatialCompensation`).
     Note that parameters should be defined in the general MEG sidecar .json file.
     Indicate `n/a` in the absence of software filters applied.
   anyOf:
@@ -408,8 +408,8 @@ status:
   name: status
   description: |
     Data quality observed on the channel.
-    A channel is considered `"bad"` if its data quality is compromised by excessive noise.
-    If quality is unknown, then a value of `"n/a"` may be used.
+    A channel is considered `bad` if its data quality is compromised by excessive noise.
+    If quality is unknown, then a value of `n/a` may be used.
     Description of noise type SHOULD be provided in `[status_description]`.
   type: string
   enum:
@@ -432,7 +432,7 @@ stim_file:
     (under the root folder of the dataset; with optional subfolders).
     The values under the `stim_file` column correspond to a path relative to
     `/stimuli`.
-    For example `"images/cat03.jpg"` will be translated to `"/stimuli/images/cat03.jpg"`.
+    For example `images/cat03.jpg` will be translated to `/stimuli/images/cat03.jpg`.
   type: string
   format: stimuli_relative
 strain:
@@ -461,8 +461,8 @@ trial_type:
   description: |
     Primary categorisation of each trial to identify them as instances of the
     experimental conditions.
-    For example: for a response inhibition task, it could take on values "go" and
-    "no-go" to refer to response initiation and response inhibition experimental
+    For example: for a response inhibition task, it could take on values `go` and
+    `no-go` to refer to response initiation and response inhibition experimental
     conditions.
   type: string
 trigger:
@@ -544,7 +544,7 @@ whole_blood_radioactivity:
   name: whole_blood_radioactivity
   description: |
     Radioactivity in whole blood samples,
-    in unit of radioactivity measurements in whole blood samples (for example, `"kBq/mL"`).
+    in unit of radioactivity measurements in whole blood samples (for example, `kBq/mL`).
   type: number
 x:
   name: x

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -15,13 +15,13 @@ acquisition:
     resolution.
     In such case two files could have the following names:
     `sub-01_acq-highres_T1w.nii.gz` and `sub-01_acq-lowres_T1w.nii.gz`, however
-    the user is free to choose any other label than highres and lowres as long
+    the user is free to choose any other label than `highres` and `lowres` as long
     as they are consistent across subjects and sessions.
     In case different sequences are used to record the same modality
-    (for example, RARE and FLASH for T1w)
+    (for example, `RARE` and `FLASH` for T1w)
     this field can also be used to make that distinction.
     At what level of detail to make the distinction (for example,
-    just between RARE and FLASH, or between RARE, FLASH, and FLASHsubsampled)
+    just between `RARE` and `FLASH`, or between `RARE`, `FLASH`, and `FLASHsubsampled`)
     remains at the discretion of the researcher.
   type: string
   format: label
@@ -32,7 +32,7 @@ ceagent:
     The `ce-<label>` key/value can be used to distinguish
     sequences using different contrast enhanced images.
     The label is the name of the contrast agent.
-    The key `ContrastBolusIngredient` MAY also be added in the JSON file,
+    The key `"ContrastBolusIngredient"` MAY also be added in the JSON file,
     with the same label.
   type: string
   format: label
@@ -82,9 +82,9 @@ echo:
     If files belonging to an entity-linked file collection are acquired at different
     echo times, the `_echo-<index>` key/value pair MUST be used to distinguish
     individual files.
-    This entity represents the `EchoTime` metadata field. Please note that the `<index>`
+    This entity represents the `"EchoTime"` metadata field. Please note that the `<index>`
     denotes the number/index (in the form of a nonnegative integer), not the
-    `EchoTime` value which needs to be stored in the field `EchoTime` of the separate
+    `"EchoTime"` value which needs to be stored in the field `"EchoTime"` of the separate
     JSON file.
   type: string
   format: index
@@ -95,9 +95,9 @@ flip:
     If files belonging to an entity-linked file collection are acquired at different
     flip angles, the `_flip-<index>` key/value pair MUST be used to distinguish
     individual files.
-    This entity represents the `FlipAngle` metadata field. Please note that the `<index>`
-    denotes the number/index (in the form of a nonnegative integer), not the `FlipAngle`
-    value which needs to be stored in the field `FlipAngle` of the separate JSON file.
+    This entity represents the `"FlipAngle"` metadata field. Please note that the `<index>`
+    denotes the number/index (in the form of a nonnegative integer), not the `"FlipAngle"`
+    value which needs to be stored in the field `"FlipAngle"` of the separate JSON file.
   type: string
   format: index
 hemisphere:
@@ -119,9 +119,9 @@ inversion:
     If files belonging to an entity-linked file collection are acquired at different
     inversion times, the `_inv-<index>` key/value pair MUST be used to distinguish
     individual files.
-    This entity represents the `InversionTime` metadata field. Please note that the `<index>`
-    denotes the number/index (in the form of a nonnegative integer), not the `InversionTime`
-    value which needs to be stored in the field `InversionTime` of the separate JSON file.
+    This entity represents the `"InversionTime` metadata field. Please note that the `<index>`
+    denotes the number/index (in the form of a nonnegative integer), not the `"InversionTime"`
+    value which needs to be stored in the field `"InversionTime"` of the separate JSON file.
   type: string
   format: index
 label:
@@ -151,7 +151,7 @@ mtransfer:
     If files belonging to an entity-linked file collection are acquired at different
     magnetization transfer (MT) states, the `_mt-<label>` key/value pair MUST be used to
     distinguish individual files.
-    This entity represents the `MTState` metadata field. Allowed label values for this
+    This entity represents the `"MTState"` metadata field. Allowed label values for this
     entity are `on` and `off`, for images acquired in presence and absence of an MT pulse,
     respectively.
   type: string
@@ -172,7 +172,7 @@ part:
 
     Phase images MAY be in radians or in arbitrary units.
     The sidecar JSON file MUST include the units of the `phase` image.
-    The possible options are `rad` or `arbitrary`.
+    The possible options are `"rad"` or `"arbitrary"`.
 
     When there is only a magnitude image of a given type, the `part` key MAY be
     omitted.
@@ -190,7 +190,7 @@ processing:
     a file that was a result of particular processing performed on the device.
 
     This is useful for files produced in particular by Elekta's MaxFilter
-    (for example, sss, tsss, trans, quat or mc),
+    (for example, `sss`, `tsss`, `trans`, `quat` or `mc`),
     which some installations impose to be run on raw data because of active
     shielding software corrections before the MEG data can actually be
     exploited.
@@ -201,7 +201,7 @@ reconstruction:
   entity: rec
   description: |
     The `rec-<label>` key/value can be used to distinguish
-    different reconstruction algorithms (for example ones using motion
+    different reconstruction algorithms (for example `MoCo` for the ones using motion
     correction).
   type: string
   format: label
@@ -220,7 +220,7 @@ resolution:
   entity: res
   description: |
     Resolution of regularly sampled N-dimensional data.
-    MUST have a corresponding `Resolution` metadata field to provide
+    MUST have a corresponding `"Resolution"` metadata field to provide
     interpretation.
 
     This entity is only applicable to derivative data.
@@ -350,7 +350,7 @@ tracer:
   description: |
     The `trc-<label>` key/value can be used to distinguish
     sequences using different tracers.
-    The key `TracerName` MUST also be included in the associated JSON file,
+    The key `"TracerName"` MUST also be included in the associated JSON file,
     although the label may be different.
   type: string
   format: label

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -13,7 +13,7 @@ AcquisitionDuration:
   description: |
     Duration (in seconds) of volume acquisition.
     Corresponds to DICOM Tag 0018, 9073 `Acquisition Duration`.
-    This field is mutually exclusive with RepetitionTime.
+    This field is mutually exclusive with `"RepetitionTime"`.
   type: number
   exclusiveMinimum: 0
   unit: s
@@ -46,7 +46,7 @@ Anaesthesia:
 AnalyticalApproach:
   name: AnalyticalApproach
   description: |
-    Methodology or methodologies used to analyse the `GeneticLevel`.
+    Methodology or methodologies used to analyse the `"GeneticLevel"`.
     Values MUST be taken from the
     [database of Genotypes and Phenotypes
     (dbGaP)](https://www.ncbi.nlm.nih.gov/gap/advanced)
@@ -64,7 +64,7 @@ AnatomicalLandmarkCoordinateSystem:
     See [Appendix VIII](/99-appendices/08-coordinate-systems.html)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
-    `AnatomicalLandmarkCoordinateSystemDescription`.
+    `"AnatomicalLandmarkCoordinateSystemDescription"`.
   anyOf:
   - $ref: _MEGCoordSys
   - $ref: _EEGCoordSys
@@ -80,7 +80,7 @@ AnatomicalLandmarkCoordinateSystemDescription:
 AnatomicalLandmarkCoordinateUnits:
   name: AnatomicalLandmarkCoordinateUnits
   description: |
-    Units of the coordinates of `AnatomicalLandmarkCoordinateSystem`.
+    Units of the coordinates of `"AnatomicalLandmarkCoordinateSystem"`.
   type: string
   enum:
   - m
@@ -91,7 +91,7 @@ AnatomicalLandmarkCoordinates:
   name: AnatomicalLandmarkCoordinates
   description: |
     Key:value pairs of the labels and 3-D digitized locations of anatomical landmarks,
-    interpreted following the `AnatomicalLandmarkCoordinateSystem`
+    interpreted following the `"AnatomicalLandmarkCoordinateSystem"`
     (for example, `{"NAS": [12.7,21.3,13.9], "LPA": [5.2,11.3,9.6],
     "RPA": [20.2,11.3,9.1]}`.
     Each array MUST contain three numeric values corresponding to x, y, and z
@@ -173,7 +173,7 @@ B0FieldIdentifier:
   description: |
     The presence of this key states that this particular 3D or 4D image MAY be
     used for fieldmap estimation purposes.
-    Each `B0FieldIdentifier` MUST be a unique string within one participant's tree,
+    Each `"B0FieldIdentifier"` MUST be a unique string within one participant's tree,
     shared only by the images meant to be used as inputs for the estimation of a
     particular instance of the *B<sub>0</sub> field* estimation.
     It is RECOMMENDED to derive this identifier from DICOM Tags, for example,
@@ -187,12 +187,12 @@ B0FieldIdentifier:
 B0FieldSource:
   name: B0FieldSource
   description: |
-    At least one existing `B0FieldIdentifier` defined by images in the
+    At least one existing `"B0FieldIdentifier"` defined by images in the
     participant's tree.
     This field states the *B<sub>0</sub> field* estimation designated by the
-    `B0FieldIdentifier` that may be used to correct the dataset for distortions
+    `"B0FieldIdentifier"` that may be used to correct the dataset for distortions
     caused by B<sub>0</sub> inhomogeneities.
-    `B0FieldSource` and `B0FieldIdentifier` MAY both be present for images that
+    `"B0FieldSource"` and `"B0FieldIdentifier"` MAY both be present for images that
     are used to estimate their own B<sub>0</sub> field, for example, in "pepolar"
     acquisitions.
   anyOf:
@@ -301,7 +301,7 @@ BolusCutOffTechnique:
 BrainLocation:
   name: BrainLocation
   description: |
-    Refers to the location in space of the `TissueOrigin`.
+    Refers to the location in space of the `"TissueOrigin"`.
     Values may be an MNI coordinate,
     a label taken from the
     [Allen Brain Atlas](https://atlas.brain-map.org/atlas?atlas=265297125&plate=\
@@ -473,7 +473,7 @@ DelayAfterTrigger:
     Duration (in seconds) from trigger delivery to scan onset.
     This delay is commonly caused by adjustments and loading times.
     This specification is entirely independent of
-    `NumberOfVolumesDiscardedByScanner` or `NumberOfVolumesDiscardedByUser`,
+    `"NumberOfVolumesDiscardedByScanner"` or `"NumberOfVolumesDiscardedByUser"`,
     as the delay precedes the acquisition.
   type: number
   unit: s
@@ -484,10 +484,10 @@ DelayTime:
     following volume.
     If the field is not present it is assumed to be set to zero.
     Corresponds to Siemens CSA header field `lDelayTimeInTR`.
-    This field is REQUIRED for sparse sequences using the `RepetitionTime` field
-    that do not have the `SliceTiming` field set to allowed for accurate
+    This field is REQUIRED for sparse sequences using the `"RepetitionTime"` field
+    that do not have the `"SliceTiming"` field set to allowed for accurate
     calculation of "acquisition time".
-    This field is mutually exclusive with `VolumeTiming`.
+    This field is mutually exclusive with `"VolumeTiming"`.
   type: number
   unit: s
 Density:
@@ -541,7 +541,7 @@ DigitizedHeadPointsCoordinateSystem:
     [Appendix VIII](/99-appendices/08-coordinate-systems.html)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
-    `DigitizedHeadPointsCoordinateSystemDescription`.
+    `"DigitizedHeadPointsCoordinateSystemDescription"`.
   anyOf:
   - $ref: _MEGCoordSys
   - $ref: _EEGCoordSys
@@ -557,7 +557,7 @@ DigitizedHeadPointsCoordinateSystemDescription:
 DigitizedHeadPointsCoordinateUnits:
   name: DigitizedHeadPointsCoordinateUnits
   description: |
-    Units of the coordinates of `DigitizedHeadPointsCoordinateSystem`.
+    Units of the coordinates of `"DigitizedHeadPointsCoordinateSystem"`.
   type: string
   enum:
   - m
@@ -599,7 +599,7 @@ DwellTime:
     anatomicals in the HCP Pipelines.
     It also usefully provides a handle on the readout bandwidth,
     which isn't captured in the other metadata tags.
-    Not to be confused with `EffectiveEchoSpacing`, and the frequent mislabeling
+    Not to be confused with `"EffectiveEchoSpacing"`, and the frequent mislabeling
     of echo spacing (which is spacing in the phase encoding direction) as
     "dwell time" (which is spacing in the readout direction).
   type: number
@@ -744,7 +744,7 @@ EffectiveEchoSpacing:
     between lines in the phase-encoding direction,
     defined based on the size of the reconstructed image in the phase direction.
     It is frequently, but incorrectly, referred to as "dwell time"
-    (see `DwellTime` parameter below for actual dwell time).
+    (see `"DwellTime"` parameter for actual dwell time).
     It is required for unwarping distortions using field maps.
     Note that beyond just in-plane acceleration,
     a variety of other manipulations to the phase encoding need to be accounted
@@ -758,7 +758,7 @@ ElectricalStimulation:
   description: |
     Boolean field to specify if electrical stimulation was done during the
     recording (options are `true` or `false`). Parameters for event-like
-    stimulation should be specified in the events.tsv file.
+    stimulation should be specified in the `_events.tsv` file.
   type: boolean
 ElectricalStimulationParameters:
   name: ElectricalStimulationParameters
@@ -793,7 +793,7 @@ EstimationAlgorithm:
   name: EstimationAlgorithm
   description: |
     Type of algorithm used to perform fitting
-    (for example, linear, non-linear, LM and such).
+    (for example, `"linear"`, `"non-linear"`, `"LM"` and such).
   type: string
 EstimationReference:
   name: EstimationReference
@@ -812,12 +812,12 @@ FiducialsCoordinateSystem:
   name: FiducialsCoordinateSystem
   description: |
     Defines the coordinate system for the fiducials.
-    Preferably the same as the `EEGCoordinateSystem`.
+    Preferably the same as the `"EEGCoordinateSystem"`.
     See
     [Appendix VIII](/99-appendices/08-coordinate-systems.html)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
-    `FiducialsCoordinateSystemDescription`.
+    `"FiducialsCoordinateSystemDescription"`.
   anyOf:
   - $ref: _MEGCoordSys
   - $ref: _EEGCoordSys
@@ -834,7 +834,7 @@ FiducialsCoordinateUnits:
   name: FiducialsCoordinateUnits
   description: |
     Units in which the coordinates that are  listed in the field
-    `FiducialsCoordinateSystem` are represented.
+    `"FiducialsCoordinateSystem"` are represented.
   type: string
   enum:
   - m
@@ -845,7 +845,7 @@ FiducialsCoordinates:
   name: FiducialsCoordinates
   description: |
     Key:value pairs of the labels and 3-D digitized position of anatomical
-    landmarks, interpreted following the `FiducialsCoordinateSystem`
+    landmarks, interpreted following the `"FiducialsCoordinateSystem"`
     (for example, `{"NAS": [12.7,21.3,13.9], "LPA": [5.2,11.3,9.6],
     "RPA": [20.2,11.3,9.1]}`).
     Each array MUST contain three numeric values corresponding to x, y, and z
@@ -863,7 +863,7 @@ FiducialsDescription:
     Free-form text description of how the fiducials such as vitamin-E capsules
     were placed relative to anatomical landmarks,
     and how the position of the fiducials were measured
-    (for example, both with Polhemus and with T1w MRI).
+    (for example, `"both with Polhemus and with T1w MRI"`).
   type: string
 FlipAngle:
   name: FlipAngle
@@ -905,7 +905,7 @@ FrameDuration:
 FrameTimesStart:
   name: FrameTimesStart
   description: |
-    Start times for all frames relative to `TimeZero` in default unit seconds.
+    Start times for all frames relative to `"TimeZero"` in default unit seconds.
   type: array
   items:
     type: number
@@ -1035,7 +1035,7 @@ HardcopyDeviceSoftwareVersion:
 HardwareFilters:
   name: HardwareFilters
   description: |
-    Object of temporal hardware filters applied, or "n/a" if the data is not
+    Object of temporal hardware filters applied, or `"n/a"` if the data is not
     available. Each key:value pair in the JSON object is a name of the filter and
     an object in which its parameters are defined as key:value pairs.
     For example, `{"Highpass RC filter": {"Half amplitude cutoff (Hz)":
@@ -1143,7 +1143,7 @@ ImageDecayCorrectionTime:
   name: ImageDecayCorrectionTime
   description: |
     Point in time from which the decay correction was applied with respect to
-    TimeZero in the default unit seconds.
+    `"TimeZero"` in the default unit seconds.
   type: number
   unit: s
 Immersion:
@@ -1157,8 +1157,8 @@ InfusionRadioactivity:
   description: |
     Amount of radioactivity infused into the patient.
     This value must be less than or equal to the total injected radioactivity
-    (`InjectedRadioactivity`).
-    Units should be the same as `InjectedRadioactivityUnits`.
+    (`"InjectedRadioactivity"`).
+    Units should be the same as `"InjectedRadioactivityUnits"`.
   type: number
 InfusionSpeed:
   name: InfusionSpeed
@@ -1174,16 +1174,16 @@ InfusionSpeedUnits:
 InfusionStart:
   name: InfusionStart
   description: |
-    Time of start of infusion with respect to `TimeZero` in the default unit
+    Time of start of infusion with respect to `"TimeZero"` in the default unit
     seconds.
   type: number
   unit: s
 InjectedMass:
   name: InjectedMass
   description: |
-    Total mass of radiolabeled compound injected into subject (for example, 10).
-    This can be derived as the ratio of the `InjectedRadioactivity` and
-    `MolarRadioactivity`.
+    Total mass of radiolabeled compound injected into subject (for example, `10`).
+    This can be derived as the ratio of the `"InjectedRadioactivity"` and
+    `"MolarRadioactivity"`.
     **For those tracers in which injected mass is not available (for example FDG)
     can be set to `"n/a"`)**.
   anyOf:
@@ -1219,7 +1219,7 @@ InjectedMassUnits:
 InjectedRadioactivity:
   name: InjectedRadioactivity
   description: |
-    Total amount of radioactivity injected into the patient (for example, 400).
+    Total amount of radioactivity injected into the patient (for example, `400`).
     For bolus-infusion experiments, this value should be the sum of all injected
     radioactivity originating from both bolus and infusion.
     Corresponds to DICOM Tag 0018, 1074 `Radionuclide Total Dose`.
@@ -1239,17 +1239,17 @@ InjectedVolume:
 InjectionEnd:
   name: InjectionEnd
   description: |
-    Time of end of injection with respect to `TimeZero` in the default unit
+    Time of end of injection with respect to `"TimeZero"` in the default unit
     seconds.
   type: number
   unit: s
 InjectionStart:
   name: InjectionStart
   description: |
-    Time of start of injection with respect to `TimeZero` in the default unit
+    Time of start of injection with respect to `"TimeZero"` in the default unit
     seconds.
     This corresponds to DICOM Tag 0018, 1042 `Contrast/Bolus Start Time`
-    converted to seconds relative to `TimeZero`.
+    converted to seconds relative to `"TimeZero"`.
   type: number
   unit: s
 InstitutionAddress:
@@ -1321,8 +1321,8 @@ LabelingDuration:
     In case all control-label volumes (or deltam or CBF) have the same
     `LabelingDuration`, a scalar must be specified.
     In case the control-label volumes (or deltam or cbf) have a different
-    `LabelingDuration`, an array of numbers must be specified,
-    for which any `m0scan` in the timeseries has a `LabelingDuration` of zero.
+    `"LabelingDuration"`, an array of numbers must be specified,
+    for which any `m0scan` in the timeseries has a `"LabelingDuration"` of zero.
     In case an array of numbers is provided,
     its length should be equal to the number of volumes specified in
     `*_aslcontext.tsv`.
@@ -1368,7 +1368,7 @@ LabelingPulseAverageB1:
   name: LabelingPulseAverageB1
   description: |
     The average B1-field strength of the RF labeling pulses, in microteslas.
-    As an alternative, `LabelingPulseFlipAngle` can be provided.
+    As an alternative, `"LabelingPulseFlipAngle"` can be provided.
   type: number
   exclusiveMinimum: 0
   unit: uT
@@ -1390,7 +1390,7 @@ LabelingPulseFlipAngle:
   name: LabelingPulseFlipAngle
   description: |
     The flip angle of a single labeling pulse, in degrees,
-    which can be given as an alternative to `LabelingPulseAverageB1`.
+    which can be given as an alternative to `"LabelingPulseAverageB1"`.
   type: number
   exclusiveMinimum: 0
   maximum: 360
@@ -1472,7 +1472,7 @@ M0Type:
 MEGChannelCount:
   name: MEGChannelCount
   description: |
-    Number of MEG channels (for example, 275).
+    Number of MEG channels (for example, `275`).
   type: integer
   minimum: 0
 MEGCoordinateSystem:
@@ -1482,7 +1482,7 @@ MEGCoordinateSystem:
     See [Appendix VIII](/99-appendices/08-coordinate-systems.html)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
-    `MEGCoordinateSystemDescription`.
+    `"MEGCoordinateSystemDescription"`.
   anyOf:
   - $ref: _MEGCoordSys
   - $ref: _EEGCoordSys
@@ -1498,7 +1498,7 @@ MEGCoordinateSystemDescription:
 MEGCoordinateUnits:
   name: MEGCoordinateUnits
   description: |
-    Units of the coordinates of `MEGCoordinateSystem`.
+    Units of the coordinates of `"MEGCoordinateSystem"`.
   type: string
   enum:
   - m
@@ -1508,7 +1508,7 @@ MEGCoordinateUnits:
 MEGREFChannelCount:
   name: MEGREFChannelCount
   description: |
-    Number of MEG reference channels (for example, 23).
+    Number of MEG reference channels (for example, `23`).
     For systems without such channels (for example, Neuromag Vectorview),
     `MEGREFChannelCount` should be set to `0`.
   type: integer
@@ -1584,7 +1584,7 @@ Magnification:
   name: Magnification
   description: |
     Lens magnification (for example: `40`). If the file format is OME-TIFF,
-    the value MUST be consistent with the `NominalMagnification` OME metadata field.
+    the value MUST be consistent with the `"NominalMagnification"` OME metadata field.
   type: number
   exclusiveMinimum: 0
 Manual:
@@ -1616,7 +1616,7 @@ MaxMovement:
   name: MaxMovement
   description: |
     Maximum head movement (in mm) detected during the recording,
-    as measured by the head localisation coils (for example, 4.8).
+    as measured by the head localisation coils (for example, `4.8`).
   type: number
   unit: mm
 MeasurementToolMetadata:
@@ -1734,11 +1734,11 @@ NumberOfVolumesDiscardedByScanner:
     before saving the imaging file.
     For example, a sequence that automatically discards the first 4 volumes
     before saving would have this field as 4.
-    A sequence that doesn't discard dummy scans would have this set to 0.
-    Please note that the onsets recorded in the `events.tsv` file should always
+    A sequence that does not discard dummy scans would have this set to 0.
+    Please note that the onsets recorded in the `_events.tsv` file should always
     refer to the beginning of the acquisition of the first volume in the
     corresponding imaging file - independent of the value of
-    `NumberOfVolumesDiscardedByScanner` field.
+    `"NumberOfVolumesDiscardedByScanner"` field.
   type: integer
   minimum: 0
 NumberOfVolumesDiscardedByUser:
@@ -1747,10 +1747,10 @@ NumberOfVolumesDiscardedByUser:
     Number of volumes ("dummy scans") discarded by the user before including the
     file in the dataset.
     If possible, including all of the volumes is strongly recommended.
-    Please note that the onsets recorded in the `events.tsv` file should always
+    Please note that the onsets recorded in the `_events.tsv` file should always
     refer to the beginning of the acquisition of the first volume in the
     corresponding imaging file - independent of the value of
-    `NumberOfVolumesDiscardedByUser` field.
+    `"NumberOfVolumesDiscardedByUser"` field.
   type: integer
   minimum: 0
 NumberShots:
@@ -1763,7 +1763,7 @@ NumberShots:
     The data type array is applicable for specifying this parameter before and
     after the k-space center is sampled.
     Please see
-    [`NumberShots` metadata field]\
+    [`"NumberShots"` metadata field]\
     (/99-appendices/11-qmri.html#numbershots-metadata-field)
     in the qMRI appendix for corresponding calculations.
   anyOf:
@@ -1798,7 +1798,7 @@ PASLType:
 PCASLType:
   name: PCASLType
   description: |
-    The type of gradient pulses used in the `"control"` condition.
+    The type of gradient pulses used in the `control` condition.
   type: string
   enum:
   - balanced
@@ -1852,7 +1852,7 @@ PharmaceuticalDoseTime:
     For an infusion, this should be a vector with two elements specifying the
     start and end of the infusion period. For more complex dose regimens,
     the regimen description should be complete enough to enable unambiguous
-    interpretation of `PharmaceuticalDoseTime`.
+    interpretation of `"PharmaceuticalDoseTime"`.
     Unit format of the specified pharmaceutical dose time MUST be seconds.
   anyOf:
   - type: number
@@ -1913,7 +1913,7 @@ PixelSize:
 PixelSizeUnits:
   name: PixelSizeUnits
   description: |
-    Unit format of the specified `PixelSize`. MUST be one of: `"mm"` (millimeter), `"um"`
+    Unit format of the specified `"PixelSize"`. MUST be one of: `"mm"` (millimeter), `"um"`
     (micrometer) or `"nm"` (nanometer).
   type: string
   enum:
@@ -2008,7 +2008,7 @@ Purity:
 RandomRate:
   name: RandomRate
   description: |
-    Random rate for each frame (same units as `Units`, for example, `"Bq/mL"`).
+    Random rate for each frame (same units as `"Units"`, for example, `"Bq/mL"`).
   type: array
   items:
     type: number
@@ -2025,7 +2025,7 @@ ReceiveCoilActiveElements:
   name: ReceiveCoilActiveElements
   description: |
     Information describing the active/selected elements of the receiver coil.
-    This doesn't correspond to a tag in the DICOM ontology.
+    This does not correspond to a tag in the DICOM ontology.
     The vendor-defined terminology for active coil elements can go in this field.
   type: string
 ReceiveCoilName:
@@ -2143,12 +2143,12 @@ RepetitionTimeExcitation:
     The interval, in seconds, between two successive excitations.
     [DICOM Tag 0018, 0080](http://dicomlookup.com/lookup.asp?sw=Tnumber&q=(0018,0080)
     best refers to this parameter.
-    This field may be used together with the `RepetitionTimePreparation` for
+    This field may be used together with the `"RepetitionTimePreparation"` for
     certain use cases, such as
     [MP2RAGE](https://doi.org/10.1016/j.neuroimage.2009.10.002).
     Use `RepetitionTimeExcitation` (in combination with
-    `RepetitionTimePreparation` if needed) for anatomy imaging data rather than
-    `RepetitionTime` as it is already defined as the amount of time that it takes
+    `"RepetitionTimePreparation"` if needed) for anatomy imaging data rather than
+    `"RepetitionTime"` as it is already defined as the amount of time that it takes
     to acquire a single volume in the
     [task imaging data](/04-modality-specific-files/01-magnetic-resonance-\
     imaging-data.html#task-including-resting-state-imaging-data)
@@ -2373,15 +2373,15 @@ SliceEncodingDirection:
   name: SliceEncodingDirection
   description: |
     The axis of the NIfTI data along which slices were acquired,
-    and the direction in which `SliceTiming` is defined with respect to.
+    and the direction in which `"SliceTiming"` is defined with respect to.
     `i`, `j`, `k` identifiers correspond to the first, second and third axis of
     the data in the NIfTI file.
-    A `-` sign indicates that the contents of `SliceTiming` are defined in
+    A `-` sign indicates that the contents of `"SliceTiming"` are defined in
     reverse order - that is, the first entry corresponds to the slice with the
     largest index, and the final entry corresponds to slice index zero.
-    When present, the axis defined by `SliceEncodingDirection` needs to be
+    When present, the axis defined by `"SliceEncodingDirection"` needs to be
     consistent with the `slice_dim` field in the NIfTI header.
-    When absent, the entries in `SliceTiming` must be in the order of increasing
+    When absent, the entries in `"SliceTiming"` must be in the order of increasing
     slice index as defined by the NIfTI header.
   type: string
   enum:
@@ -2408,11 +2408,11 @@ SliceTiming:
     of volume acquisition.
     The list goes through the slices along the slice axis in the slice encoding
     dimension (see below).
-    Note that to ensure the proper interpretation of the `SliceTiming` field,
+    Note that to ensure the proper interpretation of the `"SliceTiming"` field,
     it is important to check if the OPTIONAL `SliceEncodingDirection` exists.
-    In particular, if `SliceEncodingDirection` is negative,
-    the entries in `SliceTiming` are defined in reverse order with respect to the
-    slice axis, such that the final entry in the `SliceTiming` list is the time
+    In particular, if `"SliceEncodingDirection"` is negative,
+    the entries in `"SliceTiming"` are defined in reverse order with respect to the
+    slice axis, such that the final entry in the `"SliceTiming"` list is the time
     of acquisition of slice 0. Without this parameter slice time correction will
     not be possible.
   type: array
@@ -2466,9 +2466,9 @@ SourceDatasets:
   name: SourceDatasets
   description: |
     Used to specify the locations and relevant attributes of all source datasets.
-    Valid keys in each object include `URL`, `DOI` (see
+    Valid keys in each object include `"URL"`, `"DOI"` (see
     [URI](/02-common-principles.html#uniform-resource-indicator)), and
-    `Version` with
+    `"Version"` with
     [string](https://www.w3schools.com/js/js_json_datatypes.asp)
     values.
   type: array
@@ -2489,9 +2489,9 @@ Sources:
     these files were directly used in the creation of this derivative data file.
     For example, if a derivative A is used in the creation of another
     derivative B, which is in turn used to generate C in a chain of A->B->C,
-    C should only list B in `Sources`, and B should only list A in `Sources`.
+    C should only list B in `"Sources"`, and B should only list A in `"Sources"`.
     However, in case both X and Y are directly used in the creation of Z,
-    then Z should list X and Y in `Sources`,
+    then Z should list X and Y in `"Sources"`,
     regardless of whether X was used to generate Y.
   type: array
   items:
@@ -2606,8 +2606,8 @@ StimulusPresentation:
   description: |
     Object containing key value pairs related to the software used to present
     the stimuli during the experiment, specifically:
-    `OperatingSystem`, `SoftwareName`, `SoftwareRRID`, `SoftwareVersion` and
-    `Code`.
+    `"OperatingSystem"`, `"SoftwareName"`, `"SoftwareRRID"`, `"SoftwareVersion"` and
+    `"Code"`.
     See table below for more information.
   type: object
   properties:
@@ -2639,9 +2639,9 @@ TaskName:
   description: |
     Name of the task.
     No two tasks should have the same name.
-    The task label included in the file name is derived from this TaskName field
+    The task label included in the file name is derived from this `"TaskName"` field
     by removing all non-alphanumeric (`[a-zA-Z0-9]`) characters.
-    For example `TaskName` `"faces n-back"` will correspond to task label
+    For example `"TaskName"` `"faces n-back"` will correspond to task label
     `facesnback`.
   type: string
 TermURL:
@@ -2655,7 +2655,7 @@ TimeZero:
   description: |
     Time zero to which all scan and/or blood measurements have been adjusted to,
     in the unit "hh:mm:ss".
-    This should be equal to `InjectionStart` or `ScanStart`.
+    This should be equal to `"InjectionStart"` or `"ScanStart"`.
   type: string
   pattern: ^(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]$
 TissueDeformationScaling:
@@ -2669,7 +2669,7 @@ TissueDeformationScaling:
 TissueOrigin:
   name: TissueOrigin
   description: |
-    Describes the type of tissue analyzed for `SampleOrigin` `brain`.
+    Describes the type of tissue analyzed for `"SampleOrigin"` `brain`.
   type: string
   enum:
   - gray matter
@@ -2692,7 +2692,7 @@ TotalReadoutTime:
     defined as the readout duration, specified in seconds,
     that would have generated data with the given level of distortion.
     It is NOT the actual, physical duration of the readout train.
-    If `EffectiveEchoSpacing` has been properly computed,
+    If `"EffectiveEchoSpacing"` has been properly computed,
     it is just `EffectiveEchoSpacing * (ReconMatrixPE - 1)`.
   type: number
   unit: s
@@ -2797,9 +2797,9 @@ VolumeTiming:
     in the BOLD series.
     The list must have the same length as the BOLD series,
     and the values must be non-negative and monotonically increasing.
-    This field is mutually exclusive with `RepetitionTime` and `DelayTime`.
+    This field is mutually exclusive with `"RepetitionTime"` and `"DelayTime"`.
     If defined, this requires acquisition time (TA) be defined via either
-    `SliceTiming` or `AcquisitionDuration` be defined.
+    `"SliceTiming"` or `"AcquisitionDuration"` be defined.
   type: array
   minItems: 1
   items:
@@ -2991,5 +2991,5 @@ iEEGReference:
     `"upside down electrode"`).
     If different channels have a different reference,
     this field should have a general description and the channel specific
-    reference should be defined in the channels.tsv file.
+    reference should be defined in the `channels.tsv` file.
   type: string

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -744,7 +744,7 @@ EffectiveEchoSpacing:
     between lines in the phase-encoding direction,
     defined based on the size of the reconstructed image in the phase direction.
     It is frequently, but incorrectly, referred to as "dwell time"
-    (see `"DwellTime"` parameter for actual dwell time).
+    (see the `"DwellTime"` parameter for actual dwell time).
     It is required for unwarping distortions using field maps.
     Note that beyond just in-plane acceleration,
     a variety of other manipulations to the phase encoding need to be accounted
@@ -758,7 +758,7 @@ ElectricalStimulation:
   description: |
     Boolean field to specify if electrical stimulation was done during the
     recording (options are `true` or `false`). Parameters for event-like
-    stimulation should be specified in the `_events.tsv` file.
+    stimulation should be specified in the `events.tsv` file.
   type: boolean
 ElectricalStimulationParameters:
   name: ElectricalStimulationParameters

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1735,7 +1735,7 @@ NumberOfVolumesDiscardedByScanner:
     For example, a sequence that automatically discards the first 4 volumes
     before saving would have this field as 4.
     A sequence that does not discard dummy scans would have this set to 0.
-    Please note that the onsets recorded in the `_events.tsv` file should always
+    Please note that the onsets recorded in the `events.tsv` file should always
     refer to the beginning of the acquisition of the first volume in the
     corresponding imaging file - independent of the value of
     `"NumberOfVolumesDiscardedByScanner"` field.
@@ -1747,7 +1747,7 @@ NumberOfVolumesDiscardedByUser:
     Number of volumes ("dummy scans") discarded by the user before including the
     file in the dataset.
     If possible, including all of the volumes is strongly recommended.
-    Please note that the onsets recorded in the `_events.tsv` file should always
+    Please note that the onsets recorded in the `events.tsv` file should always
     refer to the beginning of the acquisition of the first volume in the
     corresponding imaging file - independent of the value of
     `"NumberOfVolumesDiscardedByUser"` field.


### PR DESCRIPTION
closes #746 

make sure that that examples appear "as they should" be in JSON or TSV files

- [x] numeric examples appear for example like this ``1``
- [x] JSON keys or values when appearing in metadata descriptions appear with double quotes for example like `"Key"` or `"n/a"`
- [x] TSV column header or value appear without double quotes for example like `1` or like this `n/a`

I am sure I have missed some but this is a never ending battle (and I don't thing we want to automate or CI check this) so I suggest that this should close #746 