### PR TITLE
[FIX] Change recording entity to REQUIRED for pet/blood modality

### DIFF
--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -315,7 +315,7 @@ If collected, blood measurements of radioactivity are be stored in
 [Tabular files](../02-common-principles.md#tabular-files) and located in
 the `pet/` directory along with the corresponding PET data.
 
-The OPTIONAL `recording` entity is used to distinguish sampling methods.
+The REQUIRED `recording` entity is used to distinguish sampling methods.
 For example, if an autosampler is used to record continuous blood samples,
 and manual measurements are also taken,
 then the files may have recording labels `autosampler` and `manual`,

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -320,7 +320,7 @@ For example, if an autosampler is used to record continuous blood samples,
 and manual measurements are also taken,
 then the files may have recording labels `autosampler` and `manual`,
 respectively.
-if the sampling method is unknown, then recording is assumed `manual`.
+If the sampling method is unknown, then recording SHOULD be set as `manual`.
 All blood measurements should be reported according to a single time-scale
 in relation to time zero defined by the PET data (Figure 1).
 All definitions used below are in accordance with

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -320,8 +320,7 @@ For example, if an autosampler is used to record continuous blood samples,
 and manual measurements are also taken,
 then the files may have recording labels `autosampler` and `manual`,
 respectively.
-If multiple recording methods are used on the same PET acquisition,
-the `recording` entity MUST be used to distinguish them.
+if the sampling method is unknown, then recording is assumed `manual`.
 All blood measurements should be reported according to a single time-scale
 in relation to time zero defined by the PET data (Figure 1).
 All definitions used below are in accordance with


### PR DESCRIPTION
To make it consistent with the [rules](https://github.com/bids-standard/bids-specification/blob/e47283a268f20b98d5c05ad1bb8c63da3d2a1ceb/src/schema/rules/datatypes/pet.yaml#L30) and the [examples](https://github.com/bids-standard/bids-examples/tree/master/pet003/sub-01/ses-01/pet)