### PR TITLE
[SCHEMA] Tabular metadata rules for both top and second-level tabular files

### DIFF
--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -617,6 +617,33 @@ sbref:
   name: Single-band reference image
   description: |
     Single-band reference for one or more multi-band `dwi` images.
+scans:
+  name: Scans file
+  description: |
+    The purpose of this file is to describe timing and other properties of each imaging acquisition
+    sequence (each run file) within one session.
+    Each neural recording file SHOULD be described by exactly one row. Some recordings consist of
+    multiple parts, that span several files, for example through echo-, part-, or split- entities.
+    Such recordings MUST be documented with one row per file.
+    Relative paths to files should be used under a compulsory filename header.
+    If acquisition time is included it should be listed under the acq_time header.
+    Acquisition time refers to when the first data point in each run was acquired.
+    Furthermore, if this header is provided, the acquisition times of all files that belong to a
+    recording MUST be identical.
+    Datetime should be expressed as described in Units.
+    Additional fields can include external behavioral measures relevant to the scan.
+    For example vigilance questionnaire score administered after a resting state scan.
+    All such included additional fields SHOULD be documented in an accompanying _scans.json file
+    that describes these fields in detail (see Tabular files).
+sessions:
+  name: Sessions file
+  description: |
+    In case of multiple sessions there is an option of adding additional sessions.tsv files
+    describing variables changing between sessions.
+    In such case one file per participant SHOULD be added.
+    These files MUST include a session_id column and describe each session by one and only one row.
+    Column names in sessions.tsv files MUST be different from group level participant key column
+    names in the participants.tsv file.
 stim:
   name: Continuous recording
   description: |

--- a/src/schema/rules/tabular_metadata.yaml
+++ b/src/schema/rules/tabular_metadata.yaml
@@ -1,0 +1,20 @@
+---
+# scans.tsv
+- suffixes:
+  - scans
+  extensions:
+  - .tsv
+  - .json
+  entities:
+    subject: required
+    # session is required if session is present in the dataset.
+    session: optional
+# sessions.tsv
+# This file may only exist if session is present in the dataset.
+- suffixes:
+  - sessions
+  extensions:
+  - .tsv
+  - .json
+  entities:
+    subject: required


### PR DESCRIPTION
* Representation of second-level files added.
* Homogenization of modality and non-modality file representation.
* Documenting file identifiers such as README and _sessions as
  suffixes..

Co-authored-by: Taylor Salo <tsalo006@fiu.edu>

----

As per https://github.com/bids-standard/bids-specification/pull/987#issuecomment-1027163553

@tsalo @yarikoptic 