### PR TITLE
BF: Use wikipedia for TIFF URL, adobe's page is 404ing now

### DIFF
--- a/src/04-modality-specific-files/10-microscopy.md
+++ b/src/04-modality-specific-files/10-microscopy.md
@@ -41,7 +41,7 @@ Microscopy raw data MUST be stored in one of the following formats:
 
 -   [Portable Network Graphics](http://www.libpng.org/pub/png/) (`.png`)
 
--   [Tag Image File Format](https://www.adobe.io/open/standards/TIFF.html) (`.tif`)
+-   [Tag Image File Format](https://en.wikipedia.org/wiki/TIFF) (`.tif`)
 
 -   [OME-TIFF](https://docs.openmicroscopy.org/ome-model/6.1.2/ome-tiff/specification.html#)
     (`.ome.tif` for standard TIFF files or `.ome.btf` for


### PR DESCRIPTION
Attn was brought up in https://github.com/bids-standard/bids-specification/pull/1006#issuecomment-1034936048
by @TheChymera

I think wikipedia would be the most reliable and informative source on TIFF format.

Attn @bids-standard/bep031 