### PR TITLE
[SCHEMA] Define YAML tables for MRI common metadata fields and anatomy data

### DIFF
--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -227,3 +227,74 @@ MRIAnatomyCommonMetadataFields:
         ContrastBolusIngredient: OPTIONAL
         RepetitionTimeExcitation: OPTIONAL
         RepetitionTimePreparation: OPTIONAL
+
+# Entities
+
+EntitiesTaskMetadata:
+    selectors:
+        - entities.task != "n/a"
+    fields:
+        TaskName: RECOMMENDED
+
+EntitiesCeMetadata:
+    selectors:
+        - entities.ce != "n/a"
+    fields:
+        ContrastBolusIngredient: OPTIONAL
+
+EntitiesTrcMetadata:
+    selectors:
+        - entities.trc != "n/a"
+    fields:
+        TracerName: REQUIRED
+
+EntitiesStainMetadata:
+    selectors:
+        - entities.stain != "n/a"
+    fields:
+        SampleStaining: RECOMMENDED
+        SamplePrimaryAntibodies: RECOMMENDED
+        SampleSecondaryAntibodies: RECOMMENDED
+
+EntitiesEchoMetadata:
+    selectors:
+        - entities.echo != "n/a"
+    fields:
+        EchoTime: REQUIRED
+
+EntitiesFlipMetadata:
+    selectors:
+        - entities.flip != "n/a"
+    fields:
+        FlipAngle: REQUIRED
+
+EntitiesInvMetadata:
+    selectors:
+        - entities.inv != "n/a"
+    fields:
+        InversionTime: REQUIRED
+
+EntitiesMTMetadata:
+    selectors:
+        - entities.mt != "n/a"
+    fields:
+        MTState: REQUIRED
+
+EntitiesPartMetadata:
+    selectors:
+        - entities.part == "phase"
+    fields:
+        # Can we require Units to be either "rad" or "arbitrary" here?
+        Units: REQUIRED
+
+EntitiesResMetadata:
+    selectors:
+        - entities.res != "n/a"
+    fields:
+        Resolution: REQUIRED
+
+EntitiesDenMetadata:
+    selectors:
+        - entities.den != "n/a"
+    fields:
+        Density: REQUIRED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -217,3 +217,13 @@ MRIInstitutionInformation:
             level: RECOMMENDED
             addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
 
+# Anatomy imaging data
+
+MRIAnatomyCommonMetadataFields:
+    selectors:
+        - modality == "MRI"
+        - datatype == "anat"
+    fields:
+        ContrastBolusIngredient: OPTIONAL
+        RepetitionTimeExcitation: OPTIONAL
+        RepetitionTimePreparation: OPTIONAL

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -164,8 +164,7 @@ SliceTimingASL:
 SliceTimingSparse:
     selectors:
     - modality == "MRI"
-    # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
-    - sidecar.DelayTime != "n/a"
+    - sidecar.DelayTime isDefined
     fields:
         SliceTiming: REQUIRED
 
@@ -181,7 +180,7 @@ MRIRFandContrast:
 MRIFlipAngleLookLocker:
     selectors:
     - modality == "MRI"
-    - sidecar.LookLocker == "true"
+    - sidecar.LookLocker == True
     fields:
         FlipAngle: REQUIRED
 
@@ -233,25 +232,25 @@ MRIAnatomyCommonMetadataFields:
 
 EntitiesTaskMetadata:
     selectors:
-    - entities.task != "n/a"
+    - entities.task isDefined
     fields:
         TaskName: RECOMMENDED
 
 EntitiesCeMetadata:
     selectors:
-    - entities.ce != "n/a"
+    - entities.ce isDefined
     fields:
         ContrastBolusIngredient: OPTIONAL
 
 EntitiesTrcMetadata:
     selectors:
-    - entities.trc != "n/a"
+    - entities.trc isDefined
     fields:
         TracerName: REQUIRED
 
 EntitiesStainMetadata:
     selectors:
-    - entities.stain != "n/a"
+    - entities.stain isDefined
     fields:
         SampleStaining: RECOMMENDED
         SamplePrimaryAntibodies: RECOMMENDED
@@ -259,25 +258,25 @@ EntitiesStainMetadata:
 
 EntitiesEchoMetadata:
     selectors:
-    - entities.echo != "n/a"
+    - entities.echo isDefined
     fields:
         EchoTime: REQUIRED
 
 EntitiesFlipMetadata:
     selectors:
-    - entities.flip != "n/a"
+    - entities.flip isDefined
     fields:
         FlipAngle: REQUIRED
 
 EntitiesInvMetadata:
     selectors:
-    - entities.inv != "n/a"
+    - entities.inv isDefined
     fields:
         InversionTime: REQUIRED
 
 EntitiesMTMetadata:
     selectors:
-    - entities.mt != "n/a"
+    - entities.mt isDefined
     fields:
         MTState: REQUIRED
 
@@ -285,17 +284,19 @@ EntitiesPartMetadata:
     selectors:
     - entities.part == "phase"
     fields:
-        # Can we require Units to be either "rad" or "arbitrary" here?
-        Units: REQUIRED
+        Units:
+            level: REQUIRED
+            rules:
+            - value in ["rad", "arbitrary"]
 
 EntitiesResMetadata:
     selectors:
-    - entities.res != "n/a"
+    - entities.res isDefined
     fields:
         Resolution: REQUIRED
 
 EntitiesDenMetadata:
     selectors:
-    - entities.den != "n/a"
+    - entities.den isDefined
     fields:
         Density: REQUIRED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -64,7 +64,7 @@ MRISequenceSpecifics:
 PETMRISequenceSpecifics:
     selectors:
     - modality == "MRI"
-    - PET in dataset.modalities
+    - dataset.modalities contains "PET"
     fields:
         NonLinearGradientCorrection: REQUIRED
 
@@ -164,7 +164,7 @@ SliceTimingASL:
 SliceTimingSparse:
     selectors:
     - modality == "MRI"
-    - sidecar.DelayTime isDefined
+    - sidecar contains "DelayTime"
     fields:
         SliceTiming: REQUIRED
 
@@ -232,25 +232,25 @@ MRIAnatomyCommonMetadataFields:
 
 EntitiesTaskMetadata:
     selectors:
-    - entities.task isDefined
+    - entities contains "task"
     fields:
         TaskName: RECOMMENDED
 
 EntitiesCeMetadata:
     selectors:
-    - entities.ce isDefined
+    - entities contains "ce"
     fields:
         ContrastBolusIngredient: OPTIONAL
 
 EntitiesTrcMetadata:
     selectors:
-    - entities.trc isDefined
+    - entities contains "trc"
     fields:
         TracerName: REQUIRED
 
 EntitiesStainMetadata:
     selectors:
-    - entities.stain isDefined
+    - entities contains "stain"
     fields:
         SampleStaining: RECOMMENDED
         SamplePrimaryAntibodies: RECOMMENDED
@@ -258,25 +258,25 @@ EntitiesStainMetadata:
 
 EntitiesEchoMetadata:
     selectors:
-    - entities.echo isDefined
+    - entities contains "echo"
     fields:
         EchoTime: REQUIRED
 
 EntitiesFlipMetadata:
     selectors:
-    - entities.flip isDefined
+    - entities contains "flip"
     fields:
         FlipAngle: REQUIRED
 
 EntitiesInvMetadata:
     selectors:
-    - entities.inv isDefined
+    - entities contains "inv"
     fields:
         InversionTime: REQUIRED
 
 EntitiesMTMetadata:
     selectors:
-    - entities.mt isDefined
+    - entities contains "mt"
     fields:
         MTState: REQUIRED
 
@@ -291,12 +291,12 @@ EntitiesPartMetadata:
 
 EntitiesResMetadata:
     selectors:
-    - entities.res isDefined
+    - entities contains "res"
     fields:
         Resolution: REQUIRED
 
 EntitiesDenMetadata:
     selectors:
-    - entities.den isDefined
+    - entities contains "den"
     fields:
         Density: REQUIRED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -9,7 +9,7 @@
 # MRI Common metadata fields
 MRIScannerHardware:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         Manufacturer:
             level: RECOMMENDED
@@ -38,7 +38,7 @@ MRIScannerHardware:
 
 MRISequenceSpecifics:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         PulseSequenceType: RECOMMENDED
         ScanningSequence: RECOMMENDED
@@ -46,7 +46,8 @@ MRISequenceSpecifics:
         ScanOptions: RECOMMENDED
         SequenceName: RECOMMENDED
         PulseSequenceDetails: RECOMMENDED
-        NonlinearGradientCorrection: RECOMMENDED, but REQUIRED if [PET](./09-positron-emission-tomography.md) data are present
+        NonlinearGradientCorrection: |
+            RECOMMENDED, but REQUIRED if [PET](./09-positron-emission-tomography.md) data are present
         MRAcquisitionType: RECOMMENDED, but REQUIRED for Arterial Spin Labeling
         MTState: RECOMMENDED
         MTOffsetFrequency: OPTIONAL
@@ -62,21 +63,21 @@ MRISequenceSpecifics:
 
 PETMRISequenceSpecifics:
     selectors:
-        - modality == "MRI"
-        - "PET" in dataset.modalities
+    - modality == "MRI"
+    - PET in dataset.modalities
     fields:
         NonLinearGradientCorrection: REQUIRED
 
 ASLMRISequenceSpecifics:
     selectors:
-        - modality == "MRI"
-        - datatype == "perf"
+    - modality == "MRI"
+    - datatype == "perf"
     fields:
         MRAcquisitionType: REQUIRED
 
 MTParameters:
     selectors:
-        - sidecar.MTState == True
+    - sidecar.MTState == True
     fields:
         MTOffsetFrequency: RECOMMENDED
         MTPulseBandwidth: RECOMMENDED
@@ -86,26 +87,26 @@ MTParameters:
 
 SpoilingType:
     selectors:
-        - sidecar.SpoilingState == True
+    - sidecar.SpoilingState == True
     fields:
         SpoilingType: RECOMMENDED
 
 SpoilingRF:
     selectors:
-        - sidecar.SpoilingType in ["RF", "COMBINED"]
+    - sidecar.SpoilingType in ["RF", "COMBINED"]
     fields:
         SpoilingRFPhaseIncrement: RECOMMENDED
 
 SpoilingGradient:
     selectors:
-        - sidecar.SpoilingType in ["GRADIENT", "COMBINED"]
+    - sidecar.SpoilingType in ["GRADIENT", "COMBINED"]
     fields:
         SpoilingGradientMoment: RECOMMENDED
         SpoilingGradientDuration: RECOMMENDED
 
 MRISpatialEncoding:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         NumberShots: RECOMMENDED
         ParallelReductionFactorInPlane: RECOMMENDED
@@ -134,7 +135,7 @@ MRISpatialEncoding:
 
 MRITimingParameters:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         EchoTime:
             level: RECOMMENDED
@@ -152,25 +153,25 @@ MRITimingParameters:
 
 SliceTimingASL:
     selectors:
-        - modality == "MRI"
-        - datatype == "perf"
-        - suffix in ["asl", "m0scan"]
-        - sidecar.MRAcquisitionType == "2D"
+    - modality == "MRI"
+    - datatype == "perf"
+    - suffix in ["asl", "m0scan"]
+    - sidecar.MRAcquisitionType == "2D"
     fields:
         SliceTiming: REQUIRED
 
 # This is technically for sparse sequences only, but I don't know how to encode that.
 SliceTimingSparse:
     selectors:
-        - modality == "MRI"
-        # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
-        - sidecar.DelayTime != "n/a"
+    - modality == "MRI"
+    # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
+    - sidecar.DelayTime != "n/a"
     fields:
         SliceTiming: REQUIRED
 
 MRIRFandContrast:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         FlipAngle:
             level: RECOMMENDED
@@ -179,33 +180,33 @@ MRIRFandContrast:
 
 MRIFlipAngleLookLocker:
     selectors:
-        - modality == "MRI"
-        - sidecar.LookLocker == "true"
+    - modality == "MRI"
+    - sidecar.LookLocker == "true"
     fields:
         FlipAngle: REQUIRED
 
 MRISliceAcceleration:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         MultibandAccelerationFactor: RECOMMENDED
 
 MRIAnatomicalLandmarks:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         AnatomicalLandmarkCoordinates__mri: RECOMMENDED
 
 MRIEchoPlanarImagingAndB0Mapping:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         B0FieldIdentifier: RECOMMENDED
         B0FieldSource: RECOMMENDED
 
 MRIInstitutionInformation:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         InstitutionName:
             level: RECOMMENDED
@@ -221,8 +222,8 @@ MRIInstitutionInformation:
 
 MRIAnatomyCommonMetadataFields:
     selectors:
-        - modality == "MRI"
-        - datatype == "anat"
+    - modality == "MRI"
+    - datatype == "anat"
     fields:
         ContrastBolusIngredient: OPTIONAL
         RepetitionTimeExcitation: OPTIONAL
@@ -232,25 +233,25 @@ MRIAnatomyCommonMetadataFields:
 
 EntitiesTaskMetadata:
     selectors:
-        - entities.task != "n/a"
+    - entities.task != "n/a"
     fields:
         TaskName: RECOMMENDED
 
 EntitiesCeMetadata:
     selectors:
-        - entities.ce != "n/a"
+    - entities.ce != "n/a"
     fields:
         ContrastBolusIngredient: OPTIONAL
 
 EntitiesTrcMetadata:
     selectors:
-        - entities.trc != "n/a"
+    - entities.trc != "n/a"
     fields:
         TracerName: REQUIRED
 
 EntitiesStainMetadata:
     selectors:
-        - entities.stain != "n/a"
+    - entities.stain != "n/a"
     fields:
         SampleStaining: RECOMMENDED
         SamplePrimaryAntibodies: RECOMMENDED
@@ -258,43 +259,43 @@ EntitiesStainMetadata:
 
 EntitiesEchoMetadata:
     selectors:
-        - entities.echo != "n/a"
+    - entities.echo != "n/a"
     fields:
         EchoTime: REQUIRED
 
 EntitiesFlipMetadata:
     selectors:
-        - entities.flip != "n/a"
+    - entities.flip != "n/a"
     fields:
         FlipAngle: REQUIRED
 
 EntitiesInvMetadata:
     selectors:
-        - entities.inv != "n/a"
+    - entities.inv != "n/a"
     fields:
         InversionTime: REQUIRED
 
 EntitiesMTMetadata:
     selectors:
-        - entities.mt != "n/a"
+    - entities.mt != "n/a"
     fields:
         MTState: REQUIRED
 
 EntitiesPartMetadata:
     selectors:
-        - entities.part == "phase"
+    - entities.part == "phase"
     fields:
         # Can we require Units to be either "rad" or "arbitrary" here?
         Units: REQUIRED
 
 EntitiesResMetadata:
     selectors:
-        - entities.res != "n/a"
+    - entities.res != "n/a"
     fields:
         Resolution: REQUIRED
 
 EntitiesDenMetadata:
     selectors:
-        - entities.den != "n/a"
+    - entities.den != "n/a"
     fields:
         Density: REQUIRED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -6,6 +6,7 @@
 
 
 ---
+# MRI Common metadata fields
 MRIScannerHardware:
     selectors:
         - modality == "MRI"
@@ -101,3 +102,118 @@ SpoilingGradient:
     fields:
         SpoilingGradientMoment: RECOMMENDED
         SpoilingGradientDuration: RECOMMENDED
+
+MRISpatialEncoding:
+    selectors:
+        - modality == "MRI"
+    fields:
+        NumberShots: RECOMMENDED
+        ParallelReductionFactorInPlane: RECOMMENDED
+        ParallelAcquisitionTechnique: RECOMMENDED
+        PartialFourier: RECOMMENDED
+        PartialFourierDirection: RECOMMENDED
+        PhaseEncodingDirection:
+            level: RECOMMENDED
+            level_addendum: |
+                This parameter is REQUIRED if corresponding fieldmap data is present
+                or when using multiple runs with different phase encoding directions
+                (which can be later used for field inhomogeneity correction).
+        EffectiveEchoSpacing:
+            level: RECOMMENDED
+            level_addendum: |
+                <sup>2</sup> This parameter is REQUIRED if corresponding fieldmap data
+                is present.
+        TotalReadoutTime:
+            level: RECOMMENDED
+            level_addendum: |
+                <sup>3</sup> This parameter is REQUIRED if corresponding 'field/distortion' maps
+                acquired with opposing phase encoding directions are present
+                (see [Case 4: Multiple phase encoded
+                directions](#case-4-multiple-phase-encoded-directions-pepolar)).
+        MixingTime: RECOMMENDED
+
+MRITimingParameters:
+    selectors:
+        - modality == "MRI"
+    fields:
+        EchoTime:
+            level: RECOMMENDED
+            level_addendum: |
+                REQUIRED if corresponding fieldmap data is present,
+                or the data comes from a multi-echo sequence or Arterial Spin Labeling.
+        InversionTime: RECOMMENDED
+        SliceTiming:
+            level: RECOMMENDED
+            level_addendum: |
+                REQUIRED for sparse sequences that do not have the `DelayTime` field set,
+                and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.
+        SliceEncodingDirection: RECOMMENDED
+        DwellTime: RECOMMENDED
+
+SliceTimingASL:
+    selectors:
+        - modality == "MRI"
+        - datatype == "perf"
+        - suffix in ["asl", "m0scan"]
+        - sidecar.MRAcquisitionType == "2D"
+    fields:
+        SliceTiming: REQUIRED
+
+# This is technically for sparse sequences only, but I don't know how to encode that.
+SliceTimingSparse:
+    selectors:
+        - modality == "MRI"
+        # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
+        - sidecar.DelayTime != "n/a"
+    fields:
+        SliceTiming: REQUIRED
+
+MRIRFandContrast:
+    selectors:
+        - modality == "MRI"
+    fields:
+        FlipAngle:
+            level: RECOMMENDED
+            level_addendum: REQUIRED if LookLocker is set to `true`.
+        NegativeContrast: OPTIONAL
+
+MRIFlipAngleLookLocker:
+    selectors:
+        - modality == "MRI"
+        - sidecar.LookLocker == "true"
+    fields:
+        FlipAngle: REQUIRED
+
+MRISliceAcceleration:
+    selectors:
+        - modality == "MRI"
+    fields:
+        MultibandAccelerationFactor: RECOMMENDED
+
+MRIAnatomicalLandmarks:
+    selectors:
+        - modality == "MRI"
+    fields:
+        AnatomicalLandmarkCoordinates__mri: RECOMMENDED
+
+MRIEchoPlanarImagingAndB0Mapping:
+    selectors:
+        - modality == "MRI"
+    fields:
+        B0FieldIdentifier: RECOMMENDED
+        B0FieldSource: RECOMMENDED
+
+MRIInstitutionInformation:
+    selectors:
+        - modality == "MRI"
+    fields:
+        InstitutionName:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
+        InstitutionAddress:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
+        InstitutionalDepartmentName:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
+


### PR DESCRIPTION
References #1014 and #1002.

Changes proposed:

- Add YAML definitions for the remaining tables in the MRI page's common metadata fields and anatomy imaging data sections.