### PR TITLE
[SCHEMA] Tests for render listings

### DIFF
--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -5,6 +5,10 @@ from schemacode import render
 
 
 def test_make_entity_definitions(schema_obj):
+    """
+    Test whether expected format strings are present.
+    This should be stable with respect to schema format.
+    """
     schema_text = render.make_entity_definitions(schema_obj)
     expected_formats = [
         "Format: `sub-<label>`",
@@ -29,6 +33,11 @@ def test_make_entity_definitions(schema_obj):
 
 
 def test_make_glossary(schema_obj, schema_dir):
+    """
+    Test whether files under the schema objects subdirectory correspond to entries, and
+    that rules are not mis-loaded as objects.
+    This may need to be updated for schema hierarchy changes.
+    """
     # Test consistency
     object_files = []
     for root, dirs, files in os.walk(schema_dir, topdown=False):
@@ -54,6 +63,15 @@ def test_make_glossary(schema_obj, schema_dir):
 
 
 def test_make_filename_template(schema_obj, schema_dir):
+    """
+    Test whether:
+        * the base hierarchy structure of mandatory subject and optional session is
+        returned. This should be robust with respect to schema format.
+        * each directory contains at least one possible pattern.
+        This should be robust with respect to schema format.
+        * all files under the datatype rules subdirectory have corresponding entries.
+        This may need to be updated for schema hierarchy changes.
+    """
     filename_template = render.make_filename_template(schema_obj)
 
     # Test predefined substrings
@@ -90,6 +108,10 @@ sub-<label>/
 
 
 def test_make_entity_table(schema_obj):
+    """
+    Test whether expected entities are present and listed correctly.
+    This should be robust with respect to schema format.
+    """
     entity_table = render.make_entity_table(schema_obj)
 
     # Non-exhaustive list covering both value and index formats
@@ -112,6 +134,11 @@ def test_make_entity_table(schema_obj):
 
 
 def test_make_suffix_table(schema_obj):
+    """
+    Test whether expected suffixes are present and listed with correct names.
+    Values are hard-coded from the present YAML, but should nevertheless be robust
+    with respect to schema format, other than case changes for the names.
+    """
     target_suffixes = [
         "beh",
         "cbv",
@@ -130,6 +157,11 @@ def test_make_suffix_table(schema_obj):
 
 
 def test_make_metadata_table(schema_obj):
+    """
+    Test whether expected metadata fields are present and the requirement level is
+    applied correctly.
+    This should be robust with respect to schema format.
+    """
     target_metadata = {
         "Authors": "required",
         "BIDSVersion": "required",
@@ -152,6 +184,11 @@ def test_make_metadata_table(schema_obj):
 
 
 def test_make_columns_table(schema_obj):
+    """
+    Test whether expected columns are present and the requirement level is applied
+    correctly.
+    This should be robust with respect to schema format.
+    """
     target_columns = {
         "time": "required",
         "trial_type": "required",

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -1,8 +1,5 @@
 """Tests for the schemacode package."""
 import os
-import re
-
-import pytest
 
 from schemacode import render
 
@@ -45,7 +42,6 @@ def test_make_glossary(schema_obj, schema_dir):
             for rule_file in files:
                 rule_base, _ = os.path.splitext(rule_file)
                 rule_files.append(rule_base)
-    objects_only = list(filter(lambda a: a not in rule_files, object_files))
     rules_only = list(filter(lambda a: a not in object_files, rule_files))
 
     glossary = render.make_glossary(schema_obj)

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -26,7 +26,7 @@ def test_make_entity_definitions(schema_obj):
         "Format: `flip-<index>`",
         "Format: `inv-<index>`",
         "Format: `mt-<label>`",
-        ]
+    ]
     for expected_format in expected_formats:
         assert expected_format in schema_text
 
@@ -92,50 +92,53 @@ sub-<label>/
     # Are all datatypes listed?
     assert datatype_bases_found == datatype_count
 
+
 def test_make_entity_table(schema_obj):
     entity_table = render.make_entity_table(schema_obj)
 
     # Non-exhaustive list covering both value and index formats
     expected_entities = [
-            "[`acq-<label>`](09-entities.md#acq)",
-            "[`ses-<label>`](09-entities.md#ses)",
-            "[`sample-<label>`](09-entities.md#sample)",
-            "[`task-<label>`](09-entities.md#task)",
-            "[`acq-<label>`](09-entities.md#acq)",
-            "[`ce-<label>`](09-entities.md#ce)",
-            "[`trc-<label>`](09-entities.md#trc)",
-            "[`stain-<label>`](09-entities.md#stain)",
-            "[`rec-<label>`](09-entities.md#rec)",
-            "[`dir-<label>`](09-entities.md#dir)",
-            "[`run-<index>`](09-entities.md#run)",
-            ]
+        "[`acq-<label>`](09-entities.md#acq)",
+        "[`ses-<label>`](09-entities.md#ses)",
+        "[`sample-<label>`](09-entities.md#sample)",
+        "[`task-<label>`](09-entities.md#task)",
+        "[`acq-<label>`](09-entities.md#acq)",
+        "[`ce-<label>`](09-entities.md#ce)",
+        "[`trc-<label>`](09-entities.md#trc)",
+        "[`stain-<label>`](09-entities.md#stain)",
+        "[`rec-<label>`](09-entities.md#rec)",
+        "[`dir-<label>`](09-entities.md#dir)",
+        "[`run-<index>`](09-entities.md#run)",
+    ]
 
     for expected_entity in expected_entities:
         assert expected_entity in entity_table
 
+
 def test_make_suffix_table(schema_obj):
     target_suffixes = [
-            "beh",
-            "cbv",
-            "dwi",
-            ]
+        "beh",
+        "cbv",
+        "dwi",
+    ]
     suffix_table = render.make_suffix_table(schema_obj, target_suffixes)
 
     expected_names = [
-            "Behavioral recording",
-            "Cerebral blood volume image",
-            "Diffusion-weighted image",
-            ]
+        "Behavioral recording",
+        "Cerebral blood volume image",
+        "Diffusion-weighted image",
+    ]
 
     for expected_name in expected_names:
         assert expected_name in suffix_table
 
+
 def test_make_metadata_table(schema_obj):
     target_metadata = {
-            "Authors":"required",
-            "BIDSVersion":"required",
-            "DatasetDOI":"optional",
-            }
+        "Authors": "required",
+        "BIDSVersion": "required",
+        "DatasetDOI": "optional",
+    }
     metadata_table = render.make_metadata_table(schema_obj, target_metadata).split("\n")
 
     metadata_tracking = list(target_metadata.keys())
@@ -151,12 +154,13 @@ def test_make_metadata_table(schema_obj):
     # Have we found all fields?
     assert len(metadata_tracking) == 0
 
+
 def test_make_columns_table(schema_obj):
     target_columns = {
-            "time":"required",
-            "trial_type":"required",
-            "units":"optional",
-            }
+        "time": "required",
+        "trial_type": "required",
+        "units": "optional",
+    }
     columns_table = render.make_columns_table(schema_obj, target_columns).split("\n")
 
     columns_tracking = list(target_columns.keys())

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -1,0 +1,73 @@
+"""Tests for the schemacode package."""
+import pytest
+import os
+
+from schemacode import render
+
+def test_make_entity_definitions(schema_obj):
+    schema_text = render.make_entity_definitions(schema_obj)
+    assert "Format: `sub-<label>`" in schema_text
+    assert "Format: `ses-<label>`" in schema_text
+    assert "Format: `sample-<label>`" in schema_text
+    assert "Format: `task-<label>`" in schema_text
+    assert "Format: `acq-<label>`" in schema_text
+    assert "Format: `ce-<label>`" in schema_text
+
+def test_make_glossary(schema_obj, schema_dir):
+    # Test consistency
+    object_files = []
+    for root, dirs, files in os.walk(schema_dir, topdown=False):
+       if "objects" in root:
+           for object_file in files:
+               object_base, _ = os.path.splitext(object_file)
+               object_files.append(object_base)
+    rule_files = []
+    for root, dirs, files in os.walk(schema_dir, topdown=False):
+       if "rules" in root:
+           for rule_file in files:
+               rule_base, _ = os.path.splitext(rule_file)
+               rule_files.append(rule_base)
+    objects_only = list(filter(lambda a: a not in rule_files, object_files))
+    rules_only = list(filter(lambda a: a not in object_files, rule_files))
+
+    glossary = render.make_glossary(schema_obj)
+    for line in glossary.split('\n'):
+        if line.startswith('<a name="objects.'):
+            # Are all objects objects?
+            assert any([line.startswith(f'<a name="objects.{i}') for i in object_files])
+            assert not any([line.startswith(f'<a name="objects.{i}') for i in rules_only])
+
+def test_make_filename_template(schema_obj, schema_dir):
+    filename_template = render.make_filename_template(schema_obj)
+
+    # Test predefined substrings
+    expected_template_part = """
+sub-<label>/
+    [ses-<label>/]
+        anat/
+    """
+    assert expected_template_part in filename_template
+
+    # Test consistency
+    datatype_bases = []
+    for root, dirs, files in os.walk(schema_dir, topdown=False):
+       if "datatype" in root:
+           for datatype_file in files:
+               datatype_base, _ = os.path.splitext(datatype_file)
+               datatype_bases.append(datatype_base)
+
+    datatype_count = len(datatype_bases)
+    datatype_bases = [f'        {i}/' for i in datatype_bases]
+    datatype_level = False
+    datatype_file_start = '            sub-<label>'
+    datatype_bases_found = 0
+    for line in filename_template.split('\n'):
+        if datatype_level:
+            # Is there at least one file pattern per datatype?
+            assert line.startswith(datatype_file_start)
+            datatype_level = False
+        if line in datatype_bases:
+            datatype_level = True
+            datatype_bases_found+=1
+    # Are all datatypes listed?
+    assert datatype_bases_found == datatype_count

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -1,8 +1,10 @@
 """Tests for the schemacode package."""
-import pytest
 import os
 
+import pytest
+
 from schemacode import render
+
 
 def test_make_entity_definitions(schema_obj):
     schema_text = render.make_entity_definitions(schema_obj)
@@ -13,29 +15,31 @@ def test_make_entity_definitions(schema_obj):
     assert "Format: `acq-<label>`" in schema_text
     assert "Format: `ce-<label>`" in schema_text
 
+
 def test_make_glossary(schema_obj, schema_dir):
     # Test consistency
     object_files = []
     for root, dirs, files in os.walk(schema_dir, topdown=False):
-       if "objects" in root:
-           for object_file in files:
-               object_base, _ = os.path.splitext(object_file)
-               object_files.append(object_base)
+        if "objects" in root:
+            for object_file in files:
+                object_base, _ = os.path.splitext(object_file)
+                object_files.append(object_base)
     rule_files = []
     for root, dirs, files in os.walk(schema_dir, topdown=False):
-       if "rules" in root:
-           for rule_file in files:
-               rule_base, _ = os.path.splitext(rule_file)
-               rule_files.append(rule_base)
+        if "rules" in root:
+            for rule_file in files:
+                rule_base, _ = os.path.splitext(rule_file)
+                rule_files.append(rule_base)
     objects_only = list(filter(lambda a: a not in rule_files, object_files))
     rules_only = list(filter(lambda a: a not in object_files, rule_files))
 
     glossary = render.make_glossary(schema_obj)
-    for line in glossary.split('\n'):
+    for line in glossary.split("\n"):
         if line.startswith('<a name="objects.'):
             # Are all objects objects?
             assert any([line.startswith(f'<a name="objects.{i}') for i in object_files])
             assert not any([line.startswith(f'<a name="objects.{i}') for i in rules_only])
+
 
 def test_make_filename_template(schema_obj, schema_dir):
     filename_template = render.make_filename_template(schema_obj)
@@ -51,23 +55,23 @@ sub-<label>/
     # Test consistency
     datatype_bases = []
     for root, dirs, files in os.walk(schema_dir, topdown=False):
-       if "datatype" in root:
-           for datatype_file in files:
-               datatype_base, _ = os.path.splitext(datatype_file)
-               datatype_bases.append(datatype_base)
+        if "datatype" in root:
+            for datatype_file in files:
+                datatype_base, _ = os.path.splitext(datatype_file)
+                datatype_bases.append(datatype_base)
 
     datatype_count = len(datatype_bases)
-    datatype_bases = [f'        {i}/' for i in datatype_bases]
+    datatype_bases = [f"        {i}/" for i in datatype_bases]
     datatype_level = False
-    datatype_file_start = '            sub-<label>'
+    datatype_file_start = "            sub-<label>"
     datatype_bases_found = 0
-    for line in filename_template.split('\n'):
+    for line in filename_template.split("\n"):
         if datatype_level:
             # Is there at least one file pattern per datatype?
             assert line.startswith(datatype_file_start)
             datatype_level = False
         if line in datatype_bases:
             datatype_level = True
-            datatype_bases_found+=1
+            datatype_bases_found += 1
     # Are all datatypes listed?
     assert datatype_bases_found == datatype_count


### PR DESCRIPTION
As discussed in last week's meeting.

Turns out this is a bit more tricky than I thought, because the outputs are large blocks of text which are hard to test w/o reproducing the code that created them or hard-coding output (which will automatically “break” whenever the schema is meaningfully changed — so of limited use, really, and a bit of a chore to re-write for schema contributors).

I tried to hard-code only small stable bits, and come up with some sanity/consistency checks.
Better than nothing, and it will definitely fail if the functions are *badly* broken, but really doesn't cover all the possible failures of the functions...

Another approach would be to assert line number or checksums — that would be less of a chore to update, but still of limited use since they would need to be updated very frequently.

In any case it's moderately useful as is for the addition of regex support which I wanted to do.
And testing regex consistency will in any case be easier than testing human-readable output. 

@tsalo — thoughts?