### PR TITLE
[SCHEMA] Define YAML tables for PET common metadata fields and radiopharmaceutical data

### DIFF
--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -227,3 +227,74 @@ MRIAnatomyCommonMetadataFields:
         ContrastBolusIngredient: OPTIONAL
         RepetitionTimeExcitation: OPTIONAL
         RepetitionTimePreparation: OPTIONAL
+
+# Entities
+
+EntitiesTaskMetadata:
+    selectors:
+        - entities.task != "n/a"
+    fields:
+        TaskName: RECOMMENDED
+
+EntitiesCeMetadata:
+    selectors:
+        - entities.ce != "n/a"
+    fields:
+        ContrastBolusIngredient: OPTIONAL
+
+EntitiesTrcMetadata:
+    selectors:
+        - entities.trc != "n/a"
+    fields:
+        TracerName: REQUIRED
+
+EntitiesStainMetadata:
+    selectors:
+        - entities.stain != "n/a"
+    fields:
+        SampleStaining: RECOMMENDED
+        SamplePrimaryAntibodies: RECOMMENDED
+        SampleSecondaryAntibodies: RECOMMENDED
+
+EntitiesEchoMetadata:
+    selectors:
+        - entities.echo != "n/a"
+    fields:
+        EchoTime: REQUIRED
+
+EntitiesFlipMetadata:
+    selectors:
+        - entities.flip != "n/a"
+    fields:
+        FlipAngle: REQUIRED
+
+EntitiesInvMetadata:
+    selectors:
+        - entities.inv != "n/a"
+    fields:
+        InversionTime: REQUIRED
+
+EntitiesMTMetadata:
+    selectors:
+        - entities.mt != "n/a"
+    fields:
+        MTState: REQUIRED
+
+EntitiesPartMetadata:
+    selectors:
+        - entities.part == "phase"
+    fields:
+        # Can we require Units to be either "rad" or "arbitrary" here?
+        Units: REQUIRED
+
+EntitiesResMetadata:
+    selectors:
+        - entities.res != "n/a"
+    fields:
+        Resolution: REQUIRED
+
+EntitiesDenMetadata:
+    selectors:
+        - entities.den != "n/a"
+    fields:
+        Density: REQUIRED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -217,3 +217,13 @@ MRIInstitutionInformation:
             level: RECOMMENDED
             addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
 
+# Anatomy imaging data
+
+MRIAnatomyCommonMetadataFields:
+    selectors:
+        - modality == "MRI"
+        - datatype == "anat"
+    fields:
+        ContrastBolusIngredient: OPTIONAL
+        RepetitionTimeExcitation: OPTIONAL
+        RepetitionTimePreparation: OPTIONAL

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -6,297 +6,183 @@
 
 
 ---
-# MRI Common metadata fields
-MRIScannerHardware:
-    selectors:
-    - modality == "MRI"
+# PET common metadata fields
+PETScannerHardware:
+    selectors: 
+    - modality == "PET"
     fields:
         Manufacturer:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
+            level: REQUIRED
+            addendum: Corresponds to DICOM Tag 0008, 0070 Manufacturer.
         ManufacturersModelName:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
-        DeviceSerialNumber:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0018, 1000 `DeviceSerialNumber`.
-        StationName:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0008, 1010 `Station Name`.
-        SoftwareVersions:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0018, 1020 `Software Versions`.
-        HardcopyDeviceSoftwareVersion: DEPRECATED
-        MagneticFieldStrength:
-            level: RECOMMENDED, but REQUIRED for Arterial Spin Labeling
-        ReceiveCoilName: RECOMMENDED
-        ReceiveCoilActiveElements: RECOMMENDED
-        GradientSetType: RECOMMENDED
-        MRTransmitCoilSequence: RECOMMENDED
-        MatrixCoilMode: RECOMMENDED
-        CoilCombinationMethod: RECOMMENDED
-
-MRISequenceSpecifics:
-    selectors:
-    - modality == "MRI"
-    fields:
-        PulseSequenceType: RECOMMENDED
-        ScanningSequence: RECOMMENDED
-        SequenceVariant: RECOMMENDED
-        ScanOptions: RECOMMENDED
-        SequenceName: RECOMMENDED
-        PulseSequenceDetails: RECOMMENDED
-        NonlinearGradientCorrection: |
-            RECOMMENDED, but REQUIRED if [PET](./09-positron-emission-tomography.md) data are present
-        MRAcquisitionType: RECOMMENDED, but REQUIRED for Arterial Spin Labeling
-        MTState: RECOMMENDED
-        MTOffsetFrequency: OPTIONAL
-        MTPulseBandwidth: OPTIONAL
-        MTNumberOfPulses: OPTIONAL
-        MTPulseShape: OPTIONAL
-        MTPulseDuration: OPTIONAL
-        SpoilingState: RECOMMENDED
-        SpoilingType: OPTIONAL
-        SpoilingRFPhaseIncrement: OPTIONAL
-        SpoilingGradientMoment: OPTIONAL
-        SpoilingGradientDuration: OPTIONAL
-
-PETMRISequenceSpecifics:
-    selectors:
-    - modality == "MRI"
-    - PET in dataset.modalities
-    fields:
-        NonLinearGradientCorrection: REQUIRED
-
-ASLMRISequenceSpecifics:
-    selectors:
-    - modality == "MRI"
-    - datatype == "perf"
-    fields:
-        MRAcquisitionType: REQUIRED
-
-MTParameters:
-    selectors:
-    - sidecar.MTState == True
-    fields:
-        MTOffsetFrequency: RECOMMENDED
-        MTPulseBandwidth: RECOMMENDED
-        MTNumberOfPulses: RECOMMENDED
-        MTPulseShape: RECOMMENDED
-        MTPulseDuration: RECOMMENDED
-
-SpoilingType:
-    selectors:
-    - sidecar.SpoilingState == True
-    fields:
-        SpoilingType: RECOMMENDED
-
-SpoilingRF:
-    selectors:
-    - sidecar.SpoilingType in ["RF", "COMBINED"]
-    fields:
-        SpoilingRFPhaseIncrement: RECOMMENDED
-
-SpoilingGradient:
-    selectors:
-    - sidecar.SpoilingType in ["GRADIENT", "COMBINED"]
-    fields:
-        SpoilingGradientMoment: RECOMMENDED
-        SpoilingGradientDuration: RECOMMENDED
-
-MRISpatialEncoding:
-    selectors:
-    - modality == "MRI"
-    fields:
-        NumberShots: RECOMMENDED
-        ParallelReductionFactorInPlane: RECOMMENDED
-        ParallelAcquisitionTechnique: RECOMMENDED
-        PartialFourier: RECOMMENDED
-        PartialFourierDirection: RECOMMENDED
-        PhaseEncodingDirection:
-            level: RECOMMENDED
-            level_addendum: |
-                This parameter is REQUIRED if corresponding fieldmap data is present
-                or when using multiple runs with different phase encoding directions
-                (which can be later used for field inhomogeneity correction).
-        EffectiveEchoSpacing:
-            level: RECOMMENDED
-            level_addendum: |
-                <sup>2</sup> This parameter is REQUIRED if corresponding fieldmap data
-                is present.
-        TotalReadoutTime:
-            level: RECOMMENDED
-            level_addendum: |
-                <sup>3</sup> This parameter is REQUIRED if corresponding 'field/distortion' maps
-                acquired with opposing phase encoding directions are present
-                (see [Case 4: Multiple phase encoded
-                directions](#case-4-multiple-phase-encoded-directions-pepolar)).
-        MixingTime: RECOMMENDED
-
-MRITimingParameters:
-    selectors:
-    - modality == "MRI"
-    fields:
-        EchoTime:
-            level: RECOMMENDED
-            level_addendum: |
-                REQUIRED if corresponding fieldmap data is present,
-                or the data comes from a multi-echo sequence or Arterial Spin Labeling.
-        InversionTime: RECOMMENDED
-        SliceTiming:
-            level: RECOMMENDED
-            level_addendum: |
-                REQUIRED for sparse sequences that do not have the `DelayTime` field set,
-                and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.
-        SliceEncodingDirection: RECOMMENDED
-        DwellTime: RECOMMENDED
-
-SliceTimingASL:
-    selectors:
-    - modality == "MRI"
-    - datatype == "perf"
-    - suffix in ["asl", "m0scan"]
-    - sidecar.MRAcquisitionType == "2D"
-    fields:
-        SliceTiming: REQUIRED
-
-# This is technically for sparse sequences only, but I don't know how to encode that.
-SliceTimingSparse:
-    selectors:
-    - modality == "MRI"
-    - sidecar.DelayTime isDefined
-    fields:
-        SliceTiming: REQUIRED
-
-MRIRFandContrast:
-    selectors:
-    - modality == "MRI"
-    fields:
-        FlipAngle:
-            level: RECOMMENDED
-            level_addendum: REQUIRED if LookLocker is set to `true`.
-        NegativeContrast: OPTIONAL
-
-MRIFlipAngleLookLocker:
-    selectors:
-    - modality == "MRI"
-    - sidecar.LookLocker == True
-    fields:
-        FlipAngle: REQUIRED
-
-MRISliceAcceleration:
-    selectors:
-    - modality == "MRI"
-    fields:
-        MultibandAccelerationFactor: RECOMMENDED
-
-MRIAnatomicalLandmarks:
-    selectors:
-    - modality == "MRI"
-    fields:
-        AnatomicalLandmarkCoordinates__mri: RECOMMENDED
-
-MRIEchoPlanarImagingAndB0Mapping:
-    selectors:
-    - modality == "MRI"
-    fields:
-        B0FieldIdentifier: RECOMMENDED
-        B0FieldSource: RECOMMENDED
-
-MRIInstitutionInformation:
-    selectors:
-    - modality == "MRI"
-    fields:
-        InstitutionName:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
-        InstitutionAddress:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
-        InstitutionalDepartmentName:
-            level: RECOMMENDED
-            addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
-
-# Anatomy imaging data
-
-MRIAnatomyCommonMetadataFields:
-    selectors:
-    - modality == "MRI"
-    - datatype == "anat"
-    fields:
-        ContrastBolusIngredient: OPTIONAL
-        RepetitionTimeExcitation: OPTIONAL
-        RepetitionTimePreparation: OPTIONAL
-
-# Entities
-
-EntitiesTaskMetadata:
-    selectors:
-    - entities.task isDefined
-    fields:
-        TaskName: RECOMMENDED
-
-EntitiesCeMetadata:
-    selectors:
-    - entities.ce isDefined
-    fields:
-        ContrastBolusIngredient: OPTIONAL
-
-EntitiesTrcMetadata:
-    selectors:
-    - entities.trc isDefined
-    fields:
-        TracerName: REQUIRED
-
-EntitiesStainMetadata:
-    selectors:
-    - entities.stain isDefined
-    fields:
-        SampleStaining: RECOMMENDED
-        SamplePrimaryAntibodies: RECOMMENDED
-        SampleSecondaryAntibodies: RECOMMENDED
-
-EntitiesEchoMetadata:
-    selectors:
-    - entities.echo isDefined
-    fields:
-        EchoTime: REQUIRED
-
-EntitiesFlipMetadata:
-    selectors:
-    - entities.flip isDefined
-    fields:
-        FlipAngle: REQUIRED
-
-EntitiesInvMetadata:
-    selectors:
-    - entities.inv isDefined
-    fields:
-        InversionTime: REQUIRED
-
-EntitiesMTMetadata:
-    selectors:
-    - entities.mt isDefined
-    fields:
-        MTState: REQUIRED
-
-EntitiesPartMetadata:
-    selectors:
-    - entities.part == "phase"
-    fields:
+            level: REQUIRED
+            addendum: Corresponds to DICOM Tag 0008, 1090 Manufacturers Model Name.
         Units:
             level: REQUIRED
-            rules:
-            - value in ["rad", "arbitrary"]
+            addendum: SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL"). Corresponds to DICOM Tag 0054, 1001 Units.
+        InstitutionName:
+            level: RECOMMENDED
+            addendum:  Corresponds to DICOM Tag 0008, 0080 InstitutionName.
+        InstitutionAddress:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0008, 0081 InstitutionAddress.
+        InstitutionalDepartmentName:
+            level: RECOMMENDED
+            addendum:  Corresponds to DICOM Tag 0008, 1040 Institutional Department Name.
+        BodyPart:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0018, 0015 Body Part Examined.
 
-EntitiesResMetadata:
+PETRadioChemistry:
     selectors:
-    - entities.res isDefined
+    - modality == "PET"
     fields:
-        Resolution: REQUIRED
+        TracerName:
+            level: REQUIRED
+        TracerRadionuclide:
+            level: REQUIRED
+        InjectedRadioactivity:
+            level: REQUIRED
+        InjectedRadioactivityUnits:
+            level: REQUIRED
+        InjectedMass:
+            level: REQUIRED
+        InjectedMassUnits:
+            level: REQUIRED
+        SpecificRadioactivity:
+            level: REQUIRED
+        SpecificRadioactivityUnits:
+            level: REQUIRED
+        ModeOfAdministration:
+            level: REQUIRED
+        TracerRadLex:
+            level: RECOMMENDED
+        TracerSNOMED:
+            level: RECOMMENDED
+        TracerMolecularWeight:
+            level: RECOMMENDED
+        TracerMolecularWeightUnits:
+            level: RECOMMENDED
+        InjectedMassPerWeight:
+            level: RECOMMENDED
+        InjectedMassPerWeightUnits:
+            level: RECOMMENDED
+        SpecificRadioactivityMeasTime:
+            level: RECOMMENDED
+        MolarActivity:
+            level: RECOMMENDED
+        MolarActivityUnits:
+            level: RECOMMENDED
+        MolarActivityMeasTime:
+            level: RECOMMENDED
+        InfusionRadioactivity:
+            level: RECOMMENDED
+            addendum: REQUIRED if PETRadioChemistry.fields.ModeOfAdministration == 'bolus-infusion'
+        InfusionStart:
+            level: RECOMMENDED
+            addendum: REQUIRED if PETRadioChemistry.fields.ModeOfAdministration == 'bolus-infusion'
+        InfusionSpeed:
+            level: RECOMMENDED
+            addendum: REQUIRED if PETRadioChemistry.fields.ModeOfAdministration == 'bolus-infusion'
+        InfusionSpeedUnits:
+            level: RECOMMENDED
+            addendum: REQUIRED if PETRadioChemistry.fields.ModeOfAdministration == 'bolus-infusion'
+        InjectedVolume:
+            level: RECOMMENDED
+            addendum: REQUIRED if PETRadioChemistry.fields.ModeOfAdministration == 'bolus-infusion'
+        Purity:
+            level: RECOMMENDED
 
-EntitiesDenMetadata:
+# PET Infusion conditionally REQUIRED entities 
+EntitiesBolusMetadata:
     selectors:
-    - entities.den isDefined
+        - modality == 'PET'
+        - sidecar.ModeOfAdministration == 'bolus-infusion'
     fields:
-        Density: REQUIRED
+        InfusionRadioactivity:
+            level: REQUIRED
+        InfusionStart:
+            level: REQUIRED
+        InfusionSpeed:
+            level: REQUIRED
+        InfusionSpeedUnits:
+            level: REQUIRED
+        InjectedVolume:
+            level: REQUIRED
+
+PETPharmaceuticals:
+    selectors:
+        - modality == "PET"
+    fields:
+        PharmaceuticalName:
+            level: RECOMMENDED
+        PharmaceuticalDoseAmount:
+            level: RECOMMENDED
+        PharmaCeuticalDoseUnits:
+            level: RECOMMENDED
+        PharmaCeuticalDoseRegimen:
+            level: RECOMMENDED
+        PharmaCeuticalDoseTime:
+            level: RECOMMENDED
+        Anaesthesia:
+            level: OPTIONAL
+
+PETTime:
+    selectors:
+        - modality == "PET"
+    fields:
+        TimeZero:
+            level: REQUIRED
+        ScanStart:
+            level: REQUIRED
+        InjectionStart:
+            level: REQUIRED
+        FramesTimesStart:
+            level: REQUIRED
+        FrameDuration:
+            level: REQUIRED
+        InjectionEnd:
+            level: RECOMMENDED
+        ScanDate:
+            level: DEPRECATED
+
+PETReconstruction:
+    selectors:
+        - modality == "PET"
+    fields:
+        AcquisitionMode:
+            level: REQUIRED
+        ImageDecayCorrected:
+            level: REQUIRED
+        ImageDecayCorrectionTime:
+            level: REQUIRED
+        ReconMethodName:
+            level: REQUIRED
+        ReconMethodParameterLabels:
+            level: REQUIRED
+        ReconMethodParameterUnits:
+            level: REQUIRED
+        ReconMethodParameterValues:
+            level: REQUIRED
+        ReconFilterType:
+            level: REQUIRED
+        ReconFilterSize:
+            level: REQUIRED
+        AttenuationCorrection:
+            level: REQUIRED
+        ReconMethodImplementationVersion:
+            level: RECOMMENDED
+        AttenuationCorrectionMethodReference:
+            level: RECOMMENDED
+        ScaleFactor:
+            level: RECOMMENDED
+        ScatterFraction:
+            level: RECOMMENDED
+        DecayCorrectionFactor:
+            level: RECOMMENDED
+        DoseCalibrationFactor:
+            level: RECOMMENDED
+        PromptRate:
+            level: RECOMMENDED
+        SinglesRate:
+            level: RECOMMENDED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -164,8 +164,7 @@ SliceTimingASL:
 SliceTimingSparse:
     selectors:
     - modality == "MRI"
-    # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
-    - sidecar.DelayTime != "n/a"
+    - sidecar.DelayTime isDefined
     fields:
         SliceTiming: REQUIRED
 
@@ -181,7 +180,7 @@ MRIRFandContrast:
 MRIFlipAngleLookLocker:
     selectors:
     - modality == "MRI"
-    - sidecar.LookLocker == "true"
+    - sidecar.LookLocker == True
     fields:
         FlipAngle: REQUIRED
 
@@ -233,25 +232,25 @@ MRIAnatomyCommonMetadataFields:
 
 EntitiesTaskMetadata:
     selectors:
-    - entities.task != "n/a"
+    - entities.task isDefined
     fields:
         TaskName: RECOMMENDED
 
 EntitiesCeMetadata:
     selectors:
-    - entities.ce != "n/a"
+    - entities.ce isDefined
     fields:
         ContrastBolusIngredient: OPTIONAL
 
 EntitiesTrcMetadata:
     selectors:
-    - entities.trc != "n/a"
+    - entities.trc isDefined
     fields:
         TracerName: REQUIRED
 
 EntitiesStainMetadata:
     selectors:
-    - entities.stain != "n/a"
+    - entities.stain isDefined
     fields:
         SampleStaining: RECOMMENDED
         SamplePrimaryAntibodies: RECOMMENDED
@@ -259,25 +258,25 @@ EntitiesStainMetadata:
 
 EntitiesEchoMetadata:
     selectors:
-    - entities.echo != "n/a"
+    - entities.echo isDefined
     fields:
         EchoTime: REQUIRED
 
 EntitiesFlipMetadata:
     selectors:
-    - entities.flip != "n/a"
+    - entities.flip isDefined
     fields:
         FlipAngle: REQUIRED
 
 EntitiesInvMetadata:
     selectors:
-    - entities.inv != "n/a"
+    - entities.inv isDefined
     fields:
         InversionTime: REQUIRED
 
 EntitiesMTMetadata:
     selectors:
-    - entities.mt != "n/a"
+    - entities.mt isDefined
     fields:
         MTState: REQUIRED
 
@@ -285,17 +284,19 @@ EntitiesPartMetadata:
     selectors:
     - entities.part == "phase"
     fields:
-        # Can we require Units to be either "rad" or "arbitrary" here?
-        Units: REQUIRED
+        Units:
+            level: REQUIRED
+            rules:
+            - value in ["rad", "arbitrary"]
 
 EntitiesResMetadata:
     selectors:
-    - entities.res != "n/a"
+    - entities.res isDefined
     fields:
         Resolution: REQUIRED
 
 EntitiesDenMetadata:
     selectors:
-    - entities.den != "n/a"
+    - entities.den isDefined
     fields:
         Density: REQUIRED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -9,7 +9,7 @@
 # MRI Common metadata fields
 MRIScannerHardware:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         Manufacturer:
             level: RECOMMENDED
@@ -38,7 +38,7 @@ MRIScannerHardware:
 
 MRISequenceSpecifics:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         PulseSequenceType: RECOMMENDED
         ScanningSequence: RECOMMENDED
@@ -46,7 +46,8 @@ MRISequenceSpecifics:
         ScanOptions: RECOMMENDED
         SequenceName: RECOMMENDED
         PulseSequenceDetails: RECOMMENDED
-        NonlinearGradientCorrection: RECOMMENDED, but REQUIRED if [PET](./09-positron-emission-tomography.md) data are present
+        NonlinearGradientCorrection: |
+            RECOMMENDED, but REQUIRED if [PET](./09-positron-emission-tomography.md) data are present
         MRAcquisitionType: RECOMMENDED, but REQUIRED for Arterial Spin Labeling
         MTState: RECOMMENDED
         MTOffsetFrequency: OPTIONAL
@@ -62,21 +63,21 @@ MRISequenceSpecifics:
 
 PETMRISequenceSpecifics:
     selectors:
-        - modality == "MRI"
-        - "PET" in dataset.modalities
+    - modality == "MRI"
+    - PET in dataset.modalities
     fields:
         NonLinearGradientCorrection: REQUIRED
 
 ASLMRISequenceSpecifics:
     selectors:
-        - modality == "MRI"
-        - datatype == "perf"
+    - modality == "MRI"
+    - datatype == "perf"
     fields:
         MRAcquisitionType: REQUIRED
 
 MTParameters:
     selectors:
-        - sidecar.MTState == True
+    - sidecar.MTState == True
     fields:
         MTOffsetFrequency: RECOMMENDED
         MTPulseBandwidth: RECOMMENDED
@@ -86,26 +87,26 @@ MTParameters:
 
 SpoilingType:
     selectors:
-        - sidecar.SpoilingState == True
+    - sidecar.SpoilingState == True
     fields:
         SpoilingType: RECOMMENDED
 
 SpoilingRF:
     selectors:
-        - sidecar.SpoilingType in ["RF", "COMBINED"]
+    - sidecar.SpoilingType in ["RF", "COMBINED"]
     fields:
         SpoilingRFPhaseIncrement: RECOMMENDED
 
 SpoilingGradient:
     selectors:
-        - sidecar.SpoilingType in ["GRADIENT", "COMBINED"]
+    - sidecar.SpoilingType in ["GRADIENT", "COMBINED"]
     fields:
         SpoilingGradientMoment: RECOMMENDED
         SpoilingGradientDuration: RECOMMENDED
 
 MRISpatialEncoding:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         NumberShots: RECOMMENDED
         ParallelReductionFactorInPlane: RECOMMENDED
@@ -134,7 +135,7 @@ MRISpatialEncoding:
 
 MRITimingParameters:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         EchoTime:
             level: RECOMMENDED
@@ -152,25 +153,25 @@ MRITimingParameters:
 
 SliceTimingASL:
     selectors:
-        - modality == "MRI"
-        - datatype == "perf"
-        - suffix in ["asl", "m0scan"]
-        - sidecar.MRAcquisitionType == "2D"
+    - modality == "MRI"
+    - datatype == "perf"
+    - suffix in ["asl", "m0scan"]
+    - sidecar.MRAcquisitionType == "2D"
     fields:
         SliceTiming: REQUIRED
 
 # This is technically for sparse sequences only, but I don't know how to encode that.
 SliceTimingSparse:
     selectors:
-        - modality == "MRI"
-        # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
-        - sidecar.DelayTime != "n/a"
+    - modality == "MRI"
+    # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
+    - sidecar.DelayTime != "n/a"
     fields:
         SliceTiming: REQUIRED
 
 MRIRFandContrast:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         FlipAngle:
             level: RECOMMENDED
@@ -179,33 +180,33 @@ MRIRFandContrast:
 
 MRIFlipAngleLookLocker:
     selectors:
-        - modality == "MRI"
-        - sidecar.LookLocker == "true"
+    - modality == "MRI"
+    - sidecar.LookLocker == "true"
     fields:
         FlipAngle: REQUIRED
 
 MRISliceAcceleration:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         MultibandAccelerationFactor: RECOMMENDED
 
 MRIAnatomicalLandmarks:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         AnatomicalLandmarkCoordinates__mri: RECOMMENDED
 
 MRIEchoPlanarImagingAndB0Mapping:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         B0FieldIdentifier: RECOMMENDED
         B0FieldSource: RECOMMENDED
 
 MRIInstitutionInformation:
     selectors:
-        - modality == "MRI"
+    - modality == "MRI"
     fields:
         InstitutionName:
             level: RECOMMENDED
@@ -221,8 +222,8 @@ MRIInstitutionInformation:
 
 MRIAnatomyCommonMetadataFields:
     selectors:
-        - modality == "MRI"
-        - datatype == "anat"
+    - modality == "MRI"
+    - datatype == "anat"
     fields:
         ContrastBolusIngredient: OPTIONAL
         RepetitionTimeExcitation: OPTIONAL
@@ -232,25 +233,25 @@ MRIAnatomyCommonMetadataFields:
 
 EntitiesTaskMetadata:
     selectors:
-        - entities.task != "n/a"
+    - entities.task != "n/a"
     fields:
         TaskName: RECOMMENDED
 
 EntitiesCeMetadata:
     selectors:
-        - entities.ce != "n/a"
+    - entities.ce != "n/a"
     fields:
         ContrastBolusIngredient: OPTIONAL
 
 EntitiesTrcMetadata:
     selectors:
-        - entities.trc != "n/a"
+    - entities.trc != "n/a"
     fields:
         TracerName: REQUIRED
 
 EntitiesStainMetadata:
     selectors:
-        - entities.stain != "n/a"
+    - entities.stain != "n/a"
     fields:
         SampleStaining: RECOMMENDED
         SamplePrimaryAntibodies: RECOMMENDED
@@ -258,43 +259,43 @@ EntitiesStainMetadata:
 
 EntitiesEchoMetadata:
     selectors:
-        - entities.echo != "n/a"
+    - entities.echo != "n/a"
     fields:
         EchoTime: REQUIRED
 
 EntitiesFlipMetadata:
     selectors:
-        - entities.flip != "n/a"
+    - entities.flip != "n/a"
     fields:
         FlipAngle: REQUIRED
 
 EntitiesInvMetadata:
     selectors:
-        - entities.inv != "n/a"
+    - entities.inv != "n/a"
     fields:
         InversionTime: REQUIRED
 
 EntitiesMTMetadata:
     selectors:
-        - entities.mt != "n/a"
+    - entities.mt != "n/a"
     fields:
         MTState: REQUIRED
 
 EntitiesPartMetadata:
     selectors:
-        - entities.part == "phase"
+    - entities.part == "phase"
     fields:
         # Can we require Units to be either "rad" or "arbitrary" here?
         Units: REQUIRED
 
 EntitiesResMetadata:
     selectors:
-        - entities.res != "n/a"
+    - entities.res != "n/a"
     fields:
         Resolution: REQUIRED
 
 EntitiesDenMetadata:
     selectors:
-        - entities.den != "n/a"
+    - entities.den != "n/a"
     fields:
         Density: REQUIRED

--- a/src/schema/rules/sidecars.yml
+++ b/src/schema/rules/sidecars.yml
@@ -6,6 +6,7 @@
 
 
 ---
+# MRI Common metadata fields
 MRIScannerHardware:
     selectors:
         - modality == "MRI"
@@ -101,3 +102,118 @@ SpoilingGradient:
     fields:
         SpoilingGradientMoment: RECOMMENDED
         SpoilingGradientDuration: RECOMMENDED
+
+MRISpatialEncoding:
+    selectors:
+        - modality == "MRI"
+    fields:
+        NumberShots: RECOMMENDED
+        ParallelReductionFactorInPlane: RECOMMENDED
+        ParallelAcquisitionTechnique: RECOMMENDED
+        PartialFourier: RECOMMENDED
+        PartialFourierDirection: RECOMMENDED
+        PhaseEncodingDirection:
+            level: RECOMMENDED
+            level_addendum: |
+                This parameter is REQUIRED if corresponding fieldmap data is present
+                or when using multiple runs with different phase encoding directions
+                (which can be later used for field inhomogeneity correction).
+        EffectiveEchoSpacing:
+            level: RECOMMENDED
+            level_addendum: |
+                <sup>2</sup> This parameter is REQUIRED if corresponding fieldmap data
+                is present.
+        TotalReadoutTime:
+            level: RECOMMENDED
+            level_addendum: |
+                <sup>3</sup> This parameter is REQUIRED if corresponding 'field/distortion' maps
+                acquired with opposing phase encoding directions are present
+                (see [Case 4: Multiple phase encoded
+                directions](#case-4-multiple-phase-encoded-directions-pepolar)).
+        MixingTime: RECOMMENDED
+
+MRITimingParameters:
+    selectors:
+        - modality == "MRI"
+    fields:
+        EchoTime:
+            level: RECOMMENDED
+            level_addendum: |
+                REQUIRED if corresponding fieldmap data is present,
+                or the data comes from a multi-echo sequence or Arterial Spin Labeling.
+        InversionTime: RECOMMENDED
+        SliceTiming:
+            level: RECOMMENDED
+            level_addendum: |
+                REQUIRED for sparse sequences that do not have the `DelayTime` field set,
+                and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.
+        SliceEncodingDirection: RECOMMENDED
+        DwellTime: RECOMMENDED
+
+SliceTimingASL:
+    selectors:
+        - modality == "MRI"
+        - datatype == "perf"
+        - suffix in ["asl", "m0scan"]
+        - sidecar.MRAcquisitionType == "2D"
+    fields:
+        SliceTiming: REQUIRED
+
+# This is technically for sparse sequences only, but I don't know how to encode that.
+SliceTimingSparse:
+    selectors:
+        - modality == "MRI"
+        # NOTE: This is my idea for "field is defined", but I don't know if it's the best approach.
+        - sidecar.DelayTime != "n/a"
+    fields:
+        SliceTiming: REQUIRED
+
+MRIRFandContrast:
+    selectors:
+        - modality == "MRI"
+    fields:
+        FlipAngle:
+            level: RECOMMENDED
+            level_addendum: REQUIRED if LookLocker is set to `true`.
+        NegativeContrast: OPTIONAL
+
+MRIFlipAngleLookLocker:
+    selectors:
+        - modality == "MRI"
+        - sidecar.LookLocker == "true"
+    fields:
+        FlipAngle: REQUIRED
+
+MRISliceAcceleration:
+    selectors:
+        - modality == "MRI"
+    fields:
+        MultibandAccelerationFactor: RECOMMENDED
+
+MRIAnatomicalLandmarks:
+    selectors:
+        - modality == "MRI"
+    fields:
+        AnatomicalLandmarkCoordinates__mri: RECOMMENDED
+
+MRIEchoPlanarImagingAndB0Mapping:
+    selectors:
+        - modality == "MRI"
+    fields:
+        B0FieldIdentifier: RECOMMENDED
+        B0FieldSource: RECOMMENDED
+
+MRIInstitutionInformation:
+    selectors:
+        - modality == "MRI"
+    fields:
+        InstitutionName:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
+        InstitutionAddress:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
+        InstitutionalDepartmentName:
+            level: RECOMMENDED
+            addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
+


### PR DESCRIPTION
References [#1014](https://github.com/bids-standard/bids-specification/issues/1014) and [#1002](https://github.com/bids-standard/bids-specification/pull/1002).

Aped from tsalo's PR #[1017](https://github.com/bids-standard/bids-specification/pull/1017) but just PET fields.

Changes proposed:

    Add YAML definitions for PET page's common metadata sections.