### PR TITLE
[FIX] Clarify that BIDS standard template data is to be in scanner coordinates (MEG, iEEG, EEG)

### DIFF
--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -112,7 +112,7 @@ Restricted keywords for the `<CoordSysType>CoordinateSystem` field in the
 -   `4DBti`: ALS orientation and the origin between the ears
 -   `KitYokogawa`: ALS orientation and the origin between the ears
 -   `ChietiItab`: RAS orientation and the origin between the ears
--   Any keyword from the list of [Standard template identifiers](#standard-template-identifiers)
+-   Any keyword from the list of [Standard template identifiers](#standard-template-identifiers): RAS orientation and the origin at the center of the gradient coil for template NifTI images
 
 In the case that MEG was recorded simultaneously with EEG,
 the restricted keywords for
@@ -138,7 +138,7 @@ Restricted keywords for the `<CoordSysType>CoordinateSystem` field in the
     For more information, see the
     [EEGLAB wiki page](https://eeglab.org/tutorials/ConceptsGuide/coordinateSystem.html#eeglab-hj-coordinate-system).
 
--   Any keyword from the list of [Standard template identifiers](#standard-template-identifiers)
+-   Any keyword from the list of [Standard template identifiers](#standard-template-identifiers): RAS orientation and the origin at the center of the gradient coil for template NifTI images
 
 In the case that EEG was recorded simultaneously with MEG,
 the restricted keywords for
@@ -182,7 +182,7 @@ Restricted keywords for the `<CoordSysType>CoordinateSystem` field in the
     is not aligned to ACPC, `ScanRAS` should be used.
 
 -   Any keyword from the list of
-    [Standard template identifiers](#standard-template-identifiers)
+    [Standard template identifiers](#standard-template-identifiers): RAS orientation and the origin at the center of the gradient coil for template NifTI images
 
 ## Image-based Coordinate Systems
 
@@ -194,11 +194,6 @@ Unless specified explicitly in the sidecar file in the
 `<CoordSysType>CoordinateUnits` field, the units are assumed to be mm.
 
 ### Standard template identifiers
-
-When using any of the below templates, coordinates should be in "world" (RAS+) space,
-and not voxel indices.
-If `<CoordSysType>CoordinateUnits` is not defined or applicable, then the units SHALL
-be assumed to be millimeters (mm).
 
 | **Coordinate System**              | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | **Used by**              | **Reference**                                                                                                                      |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -195,7 +195,10 @@ Unless specified explicitly in the sidecar file in the
 
 ### Standard template identifiers
 
-All BIDS standard template coordinate system data should be in ``scanner`` coordinates of the T1w template image with units corresponding to `<CoordSysType>CoordinateUnits`.
+When using any of the below templates, coordinates should be in "world" (RAS+) space,
+and not voxel indices.
+If `<CoordSysType>CoordinateUnits` is not defined or applicable, then the units SHALL
+be assumed to be millimeters (mm).
 
 | **Coordinate System**              | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | **Used by**              | **Reference**                                                                                                                      |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/99-appendices/08-coordinate-systems.md
+++ b/src/99-appendices/08-coordinate-systems.md
@@ -37,7 +37,7 @@ units are expressed in mm.
 
 The coordinate systems below all relate to neuroscience and therefore to the
 head or brain coordinates.
-$Please be aware that all data acquisition starts with
+Please be aware that all data acquisition starts with
 "device coordinates" (scanner), which does not have to be identical to the
 initial "file format coordinates" (DICOM), which are again different from the
 "head" coordinates (for example, NIFTI).
@@ -194,6 +194,8 @@ Unless specified explicitly in the sidecar file in the
 `<CoordSysType>CoordinateUnits` field, the units are assumed to be mm.
 
 ### Standard template identifiers
+
+All BIDS standard template coordinate system data should be in ``scanner`` coordinates of the T1w template image with units corresponding to `<CoordSysType>CoordinateUnits`.
 
 | **Coordinate System**              | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | **Used by**              | **Reference**                                                                                                                      |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fixes https://github.com/bids-standard/bids-specification/issues/1025 (most basic part).