### PR TITLE
[MISC] Rewrite and update html build instructions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_docs:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       # checkout code to default ~/project
       - checkout
@@ -25,7 +25,7 @@ jobs:
 
   linkchecker:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       # checkout code to default ~/project
       - checkout
@@ -123,7 +123,7 @@ jobs:
   # Run remark on the auto generated changes.md file
   remark:
     docker:
-      - image: node:latest
+      - image: cimg/node:lts
     steps:
       # checkout code to default ~/project
       - checkout
@@ -156,7 +156,7 @@ jobs:
   # Push built changelog to repo
   Changelog-bot:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/node:lts
     steps:
       - setup_remote_docker:
           version: 17.11.0-ce

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,16 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            python -m venv env
+            source env/bin/activate
             python -m pip install --upgrade pip
             pip install -r requirements.txt
-            pip install ~/project/tools/schemacode/
+            pip install -e ~/project/tools/schemacode/
       - run:
           name: generate docs
-          command: mkdocs build --clean --strict --verbose
+          command: |
+            source env/bin/activate
+            mkdocs build --clean --strict --verbose
       - persist_to_workspace:
           # the mkdocs build outputs are in ~/project/site
           root: ~/project
@@ -35,11 +39,14 @@ jobs:
       - run:
           name: install linkchecker
           command: |
-            python -m ensurepip
+            python -m venv env
+            source env/bin/activate
+            python -m pip install --upgrade pip
             python -m pip install linkchecker
       - run:
           name: check links
           command: |
+            source env/bin/activate
             git status
             if (! git log -1 --pretty=oneline | grep REL:) ; then
               chmod a+rX -R ~
@@ -156,7 +163,7 @@ jobs:
   # Push built changelog to repo
   Changelog-bot:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/base:stable
     steps:
       - setup_remote_docker:
           version: 17.11.0-ce

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,10 +372,14 @@ is to use the `requirements.txt` file contained in this repository as follows:
 ```bash
 pip install -U pip
 pip install -r requirements.txt
+pip install -e tools/schemacode/
 ```
 
 The first command ensures you are using an up to date version of `pip`,
 and the second command installs all dependencies.
+The third command ensures to install the BIDS schema code as an "editable" install,
+so that if you make changes to the schema files,
+these are automatically reflected in the sourcecode.
 
 #### 4. Ready to build!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,7 +306,20 @@ before you insert the macro call into the markdown document.
 We are using mkdocs to render our specification.
 Please follow these instructions if you would like to build the specification locally.
 
-#### 1. Install mkdocs, the material theme and the required extensions
+#### 1. Download the BIDS specification [repository](https://github.com/bids-standard/bids-specification/tree/master) onto your computer
+
+This can be done by clicking the green button on the right titled "Clone or
+download"
+or using [this link](https://github.com/bids-standard/bids-specification/archive/master.zip).
+
+#### 2. In the terminal (command line) navigate to your local version of the specification
+
+This location will have the same files you see on our
+[main specification page](https://github.com/bids-standard/bids-specification).
+Note that a file browser window may not show the hidden files
+(those that start with a period, like `.remarkrc`).
+
+#### 3. Install mkdocs, the material theme and the required extensions
 
 In the following links, you can find more information about
 
@@ -318,40 +331,21 @@ You will also need several other mkdocs plugins, like `branchcustomization` and 
 To install all of this make sure you have a recent version of Python on your computer.
 The [DataLad Handbook](http://handbook.datalad.org/en/latest/intro/installation.html#python-3-all-operating-systems) provides helpful instructions for setting up Python.
 
-An easy way to install the correct version of mkdocs and all the other required extensions
-is to use the `requirements.txt` file contained in this repository,
-by using the following command:
+In general, we strongly recommend that you install all dependencies in an isolated Python environment.
+For example using `conda`, as described in the section on Python in the DataLad Handbook, linked above.
+Or alternatively using `venv`, as described in this [Real Python tutorial](https://realpython.com/python-virtual-environments-a-primer/).
+
+Once you have activated your isolated Python environment,
+an easy way to install the correct version of mkdocs and all the other required extensions
+is to use the `requirements.txt` file contained in this repository as follows:
 
 ```bash
+pip install -U pip
 pip install -r requirements.txt
 ```
 
-However this will also install some other packages you might not want to have (like `numpy`).
-So if you only want to install what you need to build the specification,
-use the following command:
-
-```bash
-pip install \
- mkdocs \
- mkdocs-material \
- pymdown-extensions \
- mkdocs-branchcustomization-plugin \
- mkdocs-macros-plugin \
- tabulate
-```
-
-#### 2. Download the BIDS specification [repository](https://github.com/bids-standard/bids-specification/tree/master) onto your computer
-
-This can be done by clicking the green button on the right titled "Clone or
-download"
-or using [this link](https://github.com/bids-standard/bids-specification/archive/master.zip).
-
-#### 3. In the terminal (command line) navigate to your local version of the specification
-
-This location will have the same files you see on our
-[main specification page](https://github.com/bids-standard/bids-specification).
-Note: A finder window may not show the hidden files (those that start with a
-period, like `.remarkrc`)
+The first command ensures you are using an up to date version of `pip`,
+and the second command installs all dependencies.
 
 #### 4. Ready to build!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,7 +312,11 @@ This can be done by clicking the green button on the right titled "Clone or
 download"
 or using [this link](https://github.com/bids-standard/bids-specification/archive/master.zip).
 
-Or you can use the following git command in a terminal: `git clone https://github.com/bids-standard/bids-specification.git`.
+Or you can use the following `git` command in a terminal:
+
+```bash
+git clone https://github.com/bids-standard/bids-specification.git
+```
 
 #### 2. In the terminal (command line) navigate to your local version of the specification
 
@@ -321,7 +325,11 @@ This location will have the same files you see on our
 Note that a file browser window may not show the hidden files
 (those that start with a period, like `.remarkrc`).
 
-If you cloned the repository using the git command above, you can then just do: `cd bids-specification`.
+If you cloned the repository using the `git` command above, you can then just do:
+
+```bash
+cd bids-specification
+```
 
 Enter all commands below from the command line prompt located at the root of the local version of the specification.
 
@@ -343,7 +351,7 @@ For example using `conda`, as described in the section on Python in the DataLad 
 ```bash
 conda create --name bids-spec
 conda activate bids-spec
-.```
+```
 
 Or alternatively using `venv`, as described in this [Real Python tutorial](https://realpython.com/python-virtual-environments-a-primer/).
 
@@ -352,8 +360,11 @@ A short version of the commands needed to create and activate your `venv` virtua
 ```bash
 python3 -m venv env
 source env/bin/activate
-.```
+```
 
+Note however, that this will create a local directory called `env` within the bids-specification directory.
+Make sure not to commit that directory (your environment) when adding  and committing your changes via `git`
+(this is not a problem when using `conda`, because `conda` saves the environment in a different place).
 
 Once you have activated your isolated Python environment,
 an easy way to install the correct version of mkdocs and all the other required extensions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,6 +319,8 @@ This location will have the same files you see on our
 Note that a file browser window may not show the hidden files
 (those that start with a period, like `.remarkrc`).
 
+Enter all commands below from the command line prompt located at the root of the local version of the specification.
+
 #### 3. Install mkdocs, the material theme and the required extensions
 
 In the following links, you can find more information about

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,9 +362,8 @@ python3 -m venv env
 source env/bin/activate
 ```
 
-Note however, that this will create a local directory called `env` within the bids-specification directory.
-Make sure not to commit that directory (your environment) when adding and committing your changes via `git`
-(this is not a problem when using `conda`, because `conda` saves the environment in a different place).
+Note that this will create a local directory called `env` within the bids-specification directory
+but that its content will not be tracked by `git` because it is listed in the `.gitignore` file.
 
 Once you have activated your isolated Python environment,
 an easy way to install the correct version of mkdocs and all the other required extensions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,7 +363,7 @@ source env/bin/activate
 ```
 
 Note however, that this will create a local directory called `env` within the bids-specification directory.
-Make sure not to commit that directory (your environment) when adding  and committing your changes via `git`
+Make sure not to commit that directory (your environment) when adding and committing your changes via `git`
 (this is not a problem when using `conda`, because `conda` saves the environment in a different place).
 
 Once you have activated your isolated Python environment,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,7 +358,7 @@ Or alternatively using `venv`, as described in this [Real Python tutorial](https
 A short version of the commands needed to create and activate your `venv` virtual environment would look like:
 
 ```bash
-python3 -m venv env
+python -m venv env
 source env/bin/activate
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,12 +312,16 @@ This can be done by clicking the green button on the right titled "Clone or
 download"
 or using [this link](https://github.com/bids-standard/bids-specification/archive/master.zip).
 
+Or you can use the following git command in a terminal: `git clone https://github.com/bids-standard/bids-specification.git`.
+
 #### 2. In the terminal (command line) navigate to your local version of the specification
 
 This location will have the same files you see on our
 [main specification page](https://github.com/bids-standard/bids-specification).
 Note that a file browser window may not show the hidden files
 (those that start with a period, like `.remarkrc`).
+
+If you cloned the repository using the git command above, you can then just do: `cd bids-specification`.
 
 Enter all commands below from the command line prompt located at the root of the local version of the specification.
 
@@ -335,7 +339,21 @@ The [DataLad Handbook](http://handbook.datalad.org/en/latest/intro/installation.
 
 In general, we strongly recommend that you install all dependencies in an isolated Python environment.
 For example using `conda`, as described in the section on Python in the DataLad Handbook, linked above.
+
+```bash
+conda create --name bids-spec
+conda activate bids-spec
+.```
+
 Or alternatively using `venv`, as described in this [Real Python tutorial](https://realpython.com/python-virtual-environments-a-primer/).
+
+A short version of the commands needed to create and activate your `venv` virtual environment would look like:
+
+```bash
+python3 -m venv env
+source env/bin/activate
+.```
+
 
 Once you have activated your isolated Python environment,
 an easy way to install the correct version of mkdocs and all the other required extensions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,7 +346,7 @@ To install all of this make sure you have a recent version of Python on your com
 The [DataLad Handbook](http://handbook.datalad.org/en/latest/intro/installation.html#python-3-all-operating-systems) provides helpful instructions for setting up Python.
 
 In general, we strongly recommend that you install all dependencies in an isolated Python environment.
-For example using `conda`, as described in the section on Python in the DataLad Handbook, linked above.
+For example using `conda`, as described in this [Geohackweek tutorial](https://geohackweek.github.io/Introductory/01-conda-tutorial/).
 
 ```bash
 conda create --name bids-spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ mkdocs-branchcustomization-plugin~=0.1.3
 mkdocs-macros-plugin
 numpy
 tools/schemacode/
+
+# see https://github.com/bids-standard/bids-specification/pull/1032#issuecomment-1077707688
+jinja2<3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,3 @@ mkdocs-branchcustomization-plugin~=0.1.3
 mkdocs-macros-plugin
 numpy
 tools/schemacode/
-
-# see https://github.com/bids-standard/bids-specification/pull/1032#issuecomment-1077707688
-jinja2<3.1


### PR DESCRIPTION
closes #1030

This is changing the order of instructions:

- first clone
- then navigate to the spec
- then install python via requirements.txt

that's important because we have the schema package, which is local -- so navigating to the local dir of the spec ensures success.

Furthermore I recommend using an isolated python environment -- that way we can do without the "special instructions" in case somebody doesn't want numpy (in an isolated env it doesn't really matter if they have numpy or not).