### PR TITLE
[SCHEMA] Add a new `file_relative` format

### DIFF
--- a/src/schema/objects/formats.yaml
+++ b/src/schema/objects/formats.yaml
@@ -67,6 +67,15 @@ datetime:
     where [.000000] is an optional subsecond resolution between 1 and 6 decimal points,
     and [Z] is an optional, valid timezone code.
   pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2}T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9](\.[0-9]{1,6})?([A-Z]{2,4})?'
+file_relative:
+  name: Path relative to the parent file
+  description: |
+    A path to a file, relative to the file in which the field is defined.
+
+    The validation for this format is minimal.
+    It simply ensures that the value is a string with any characters that may appear in a valid path,
+    without starting with "/" (an absolute path).
+  pattern: '(?!/)[0-9a-zA-Z/\_\-\.]+'
 participant_relative:
   name: Path relative to the participant folder
   description: |

--- a/tools/schemacode/schemacode/tests/test_schema.py
+++ b/tools/schemacode/schemacode/tests/test_schema.py
@@ -62,6 +62,11 @@ def test_formats(schema_obj):
             "9:00:00",  # leading zeros are not required for hours
         ],
         "unit": ["any string is valid."],
+        "file_relative": [
+            "file_in_same_directory.txt",
+            "../../relative/path/file.txt",
+            "sub-01/path/file.txt",
+        ],
         "stimuli_relative": ["any/arbitrary/path/file.txt"],
         "dataset_relative": ["any/arbitrary/path/file.txt"],
         "participant_relative": ["any/arbitrary/path/file.txt"],
@@ -108,6 +113,9 @@ def test_formats(schema_obj):
             "01:23",  # lacks either hours or seconds
         ],
         "unit": [],
+        "file_relative": [
+            "/path/with/starting/slash/file.txt",
+        ],
         "stimuli_relative": [
             "/path/with/starting/slash/file.txt",
             "stimuli/path/file.txt",


### PR DESCRIPTION
Closes None, but is relevant for #1023.

Changes proposed:
- Add a `file_relative` format to `schema/objects/formats.yaml`.
- Add tests for the new format. 