### PR TITLE
ENH: allow for .png and .tif in eeg/ieeg/meg as allowed for micr

### DIFF
--- a/src/schema/rules/datatypes/eeg.yaml
+++ b/src/schema/rules/datatypes/eeg.yaml
@@ -66,6 +66,8 @@
   - photo
   extensions:
   - .jpg
+  - .png
+  - .tif
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/ieeg.yaml
+++ b/src/schema/rules/datatypes/ieeg.yaml
@@ -67,6 +67,8 @@
   - photo
   extensions:
   - .jpg
+  - .png
+  - .tif
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/meg.yaml
+++ b/src/schema/rules/datatypes/meg.yaml
@@ -119,6 +119,8 @@
   - photo
   extensions:
   - .jpg
+  - .png
+  - .tif
   entities:
     subject: required
     session: optional


### PR DESCRIPTION
Discovered while working on https://github.com/bids-standard/bids-specification/issues/1047

I guess it could be argued against but I feel that such unification makes sense.  There might be other common suffixes where we might want to introduce similar unification. 

- [ ] validator support implemented: https://github.com/bids-standard/bids-validator/pull/1443