### PR TITLE
[INFRA] fix spec-internal links from schema entries

### DIFF
--- a/macros_doc.md
+++ b/macros_doc.md
@@ -78,7 +78,7 @@ consistency.
 ## What macros are available?
 
 All the macros we use are in listed in this
-[python file](https://github.com/bids-standard/bids-specification/blob/master/tools/mkdocs_macros_bids/macros.py).
+[Python file](https://github.com/bids-standard/bids-specification/blob/master/tools/mkdocs_macros_bids/macros.py).
 
 | Name                    | Purpose                                                                                | Uses schema | Example                                                                                                                                                                                     |
 | ----------------------- | -------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/pdf_build_src/process_markdowns.py
+++ b/pdf_build_src/process_markdowns.py
@@ -562,6 +562,13 @@ def edit_titlepage():
         file.writelines(data)
 
 
+class MockPage:
+    pass
+
+class MockFile:
+    pass
+
+
 def process_macros(duplicated_src_dir_path):
     """Search for mkdocs macros in the specification, run the embedded
     functions, and replace the macros with their outputs.
@@ -593,6 +600,15 @@ def process_macros(duplicated_src_dir_path):
             filename = os.path.join(root, name)
             with open(filename, "r") as fo:
                 contents = fo.read()
+
+            # Create a mock MkDocs Page object that has a "file" attribute,
+            # which is a mock MkDocs File object with a str "src_path" attribute
+            # The src_path
+            mock_file = MockFile()
+            mock_file.src_path = os.sep.join(filename.split(os.sep)[1::])
+
+            page = MockPage()
+            page.file = mock_file
 
             # Replace code snippets in the text with their outputs
             matches = re.findall(re_code_snippets, contents)

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -486,7 +486,8 @@ and a guide for using macros can be found at
         "Units": "RECOMMENDED",
         "TermURL": "RECOMMENDED",
         "HED": "OPTIONAL",
-   }
+   },
+   "."
 ) }}
 
 Please note that while both `Units` and `Levels` are RECOMMENDED, typically only one

--- a/src/02-common-principles.md
+++ b/src/02-common-principles.md
@@ -487,7 +487,7 @@ and a guide for using macros can be found at
         "TermURL": "RECOMMENDED",
         "HED": "OPTIONAL",
    },
-   "."
+   page.file
 ) }}
 
 Please note that while both `Units` and `Levels` are RECOMMENDED, typically only one

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -468,8 +468,6 @@ and a guide for using macros can be found at
    "."
 ) }}
 
-{{ MACROS___make_path_relative() }}
-
 Additional fields can include external behavioral measures relevant to the
 scan.
 For example vigilance questionnaire score administered after a resting

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -36,7 +36,8 @@ and a guide for using macros can be found at
       "DatasetDOI": "OPTIONAL",
       "GeneratedBy": "RECOMMENDED",
       "SourceDatasets": "RECOMMENDED",
-   }
+   },
+   "."
 ) }}
 
 Each object in the `GeneratedBy` array includes the following REQUIRED, RECOMMENDED
@@ -114,7 +115,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "GeneratedBy": "REQUIRED"
-   }
+   },
+   "."
 ) }}
 
 If a derived dataset is stored as a subdirectory of the raw dataset, then the `Name` field
@@ -394,7 +396,8 @@ and a guide for using macros can be found at
    {
       "MeasurementToolMetadata": "OPTIONAL",
       "Derivative": "OPTIONAL",
-   }
+   },
+   "."
 ) }}
 
 As an example, consider the contents of a file called

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -236,7 +236,8 @@ and a guide for using macros can be found at
       "handedness": "RECOMMENDED",
       "strain": "RECOMMENDED",
       "strain_rrid": "RECOMMENDED",
-   }
+   },
+   "."
 ) }}
 
 Throughout BIDS you can indicate missing values with `n/a` (for "not
@@ -319,7 +320,8 @@ and a guide for using macros can be found at
       "sample_type": "REQUIRED",
       "pathology": "RECOMMENDED",
       "derived_from": "RECOMMENDED",
-   }
+   },
+   "."
 ) }}
 
 `samples.tsv` example:
@@ -515,7 +517,8 @@ and a guide for using macros can be found at
       "session_id": ("REQUIRED", "There MUST be exactly one row for each session."),
       "acq_time__sessions": ("OPTIONAL"),
       "pathology": "RECOMMENDED",
-   }
+   },
+   "."
 ) }}
 
 `_sessions.tsv` example:

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -37,7 +37,7 @@ and a guide for using macros can be found at
       "GeneratedBy": "RECOMMENDED",
       "SourceDatasets": "RECOMMENDED",
    },
-   "."
+   page.file
 ) }}
 
 Each object in the `GeneratedBy` array includes the following REQUIRED, RECOMMENDED
@@ -116,7 +116,7 @@ and a guide for using macros can be found at
    {
       "GeneratedBy": "REQUIRED"
    },
-   "."
+   page.file
 ) }}
 
 If a derived dataset is stored as a subdirectory of the raw dataset, then the `Name` field
@@ -239,7 +239,7 @@ and a guide for using macros can be found at
       "strain": "RECOMMENDED",
       "strain_rrid": "RECOMMENDED",
    },
-   "."
+   page.file
 ) }}
 
 Throughout BIDS you can indicate missing values with `n/a` (for "not
@@ -323,7 +323,7 @@ and a guide for using macros can be found at
       "pathology": "RECOMMENDED",
       "derived_from": "RECOMMENDED",
    },
-   "."
+   page.file
 ) }}
 
 `samples.tsv` example:
@@ -397,7 +397,7 @@ and a guide for using macros can be found at
       "MeasurementToolMetadata": "OPTIONAL",
       "Derivative": "OPTIONAL",
    },
-   "."
+   page.file
 ) }}
 
 As an example, consider the contents of a file called
@@ -470,7 +470,7 @@ and a guide for using macros can be found at
       "filename": ("REQUIRED", "There MUST be exactly one row for each file."),
       "acq_time__scans": ("OPTIONAL"),
    },
-   "."
+   page.file
 ) }}
 
 Additional fields can include external behavioral measures relevant to the
@@ -521,7 +521,7 @@ and a guide for using macros can be found at
       "acq_time__sessions": ("OPTIONAL"),
       "pathology": "RECOMMENDED",
    },
-   "."
+   page.file
 ) }}
 
 `_sessions.tsv` example:

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -464,7 +464,8 @@ and a guide for using macros can be found at
    {
       "filename": ("REQUIRED", "There MUST be exactly one row for each file."),
       "acq_time__scans": ("OPTIONAL"),
-   }
+   },
+   "."
 ) }}
 
 {{ MACROS___make_path_relative() }}

--- a/src/03-modality-agnostic-files.md
+++ b/src/03-modality-agnostic-files.md
@@ -467,6 +467,8 @@ and a guide for using macros can be found at
    }
 ) }}
 
+{{ MACROS___make_path_relative() }}
+
 Additional fields can include external behavioral measures relevant to the
 scan.
 For example vigilance questionnaire score administered after a resting

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -36,7 +36,8 @@ and a guide for using macros can be found at
       "MRTransmitCoilSequence": "RECOMMENDED",
       "MatrixCoilMode": "RECOMMENDED",
       "CoilCombinationMethod": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Example for `ReceiveCoilActiveElements`:
@@ -83,7 +84,8 @@ and a guide for using macros can be found at
       "SpoilingRFPhaseIncrement": 'RECOMMENDED if the SpoilingType is `"RF"` or `"COMBINED"`.',
       "SpoilingGradientMoment": 'RECOMMENDED if the SpoilingType is `"GRADIENT"` or `"COMBINED"`.',
       "SpoilingGradientDuration": 'RECOMMENDED if the SpoilingType is `"GRADIENT"` or `"COMBINED"`.',
-   }
+   },
+   ".."
 ) }}
 
 ### In-Plane Spatial Encoding
@@ -119,7 +121,8 @@ and a guide for using macros can be found at
          "directions](#case-4-multiple-phase-encoded-directions-pepolar)).",
       ),
       "MixingTime": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 <sup>2</sup>Conveniently, for Siemens data, this value is easily obtained as
@@ -148,7 +151,8 @@ and a guide for using macros can be found at
       "SliceTiming": "RECOMMENDED, but REQUIRED for sparse sequences that do not have the `DelayTime` field set, and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.",
       "SliceEncodingDirection": "RECOMMENDED",
       "DwellTime": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 ### RF & Contrast
@@ -163,7 +167,8 @@ and a guide for using macros can be found at
    {
       "FlipAngle": "RECOMMENDED, but REQUIRED if `LookLocker` is set `true`",
       "NegativeContrast": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 ### Slice Acceleration
@@ -177,7 +182,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "MultibandAccelerationFactor": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 ### Anatomical landmarks
@@ -193,7 +199,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "AnatomicalLandmarkCoordinates__mri": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 ### Echo-Planar Imaging and *B<sub>0</sub>* mapping
@@ -220,7 +227,8 @@ and a guide for using macros can be found at
    {
       "B0FieldIdentifier": "RECOMMENDED",
       "B0FieldSource": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 ### Institution information
@@ -236,7 +244,8 @@ and a guide for using macros can be found at
       "InstitutionName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0080 `InstitutionName`."),
       "InstitutionAddress": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`."),
       "InstitutionalDepartmentName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.")
-   }
+   },
+   ".."
 ) }}
 
 When adding additional metadata please use the CamelCase version of
@@ -336,7 +345,8 @@ and a guide for using macros can be found at
       "ContrastBolusIngredient": "OPTIONAL",
       "RepetitionTimeExcitation": "OPTIONAL",
       "RepetitionTimePreparation": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 The [`part-<label>`](../99-appendices/09-entities.md#part) key/value pair is
@@ -607,7 +617,8 @@ and a guide for using macros can be found at
       "RepetitionTime": "REQUIRED",
       "VolumeTiming": "REQUIRED",
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`.")
-   }
+   },
+   ".."
 ) }}
 
 For the fields described above and in the following section, the term "Volume"
@@ -632,7 +643,8 @@ and a guide for using macros can be found at
       "DelayTime": "RECOMMENDED",
       "AcquisitionDuration": 'RECOMMENDED, but REQUIRED for sequences that are described with the `VolumeTiming` field and that do not have the `SliceTiming` field set to allow for accurate calculation of "acquisition time"',
       "DelayAfterTrigger": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 The following table recapitulates the different ways that specific fields have
@@ -668,7 +680,8 @@ and a guide for using macros can be found at
       "TaskDescription": "RECOMMENDED",
       "CogAtlasID": "RECOMMENDED",
       "CogPOID": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 See [Common metadata fields](#common-metadata-fields) for a list of
@@ -852,7 +865,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "MultipartID": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 JSON example:
@@ -1058,7 +1072,8 @@ and a guide for using macros can be found at
       "LabelingLocationDescription": "RECOMMENDED",
       "LookLocker": "OPTIONAL",
       "LabelingEfficiency": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 #### (P)CASL-specific metadata fields
@@ -1082,7 +1097,8 @@ and a guide for using macros can be found at
       "LabelingPulseDuration": "RECOMMENDED",
       "LabelingPulseFlipAngle": "RECOMMENDED",
       "LabelingPulseInterval": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 #### PASL-specific metadata fields
@@ -1102,7 +1118,8 @@ and a guide for using macros can be found at
       "LabelingSlabThickness": "RECOMMENDED",
       "BolusCutOffDelayTime": "OPTIONAL, REQUIRED if `BolusCutOffFlag` is `true`",
       "BolusCutOffTechnique": "OPTIONAL, REQUIRED if `BolusCutOffFlag` is `true`",
-   }
+   },
+   ".."
 ) }}
 
 ### `m0scan` metadata fields
@@ -1122,7 +1139,8 @@ and a guide for using macros can be found at
          "This is used to refer to the ASL time series for which the `*_m0scan.nii[.gz]` is intended."
       ),
       "AcquisitionVoxelSize": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 The following table recapitulates the ASL field dependencies. If Source field (column 1) contains the Value specified in column 2, then the Requirements in column 4 are
@@ -1226,7 +1244,8 @@ and a guide for using macros can be found at
          "This field is OPTIONAL, and in case the fieldmaps do not correspond "
          "to any particular scans, it does not have to be filled.",
       ),
-   }
+   },
+   ".."
 ) }}
 
 For example:
@@ -1277,7 +1296,8 @@ and a guide for using macros can be found at
    {
       "EchoTime1": "REQUIRED",
       "EchoTime2": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 In this particular case, the sidecar JSON file
@@ -1320,7 +1340,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "EchoTime__fmap": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 Each phase map has a corresponding sidecar JSON file to specify its corresponding `EchoTime`.
@@ -1361,7 +1382,8 @@ and a guide for using macros can be found at
          'Fieldmaps must be in units of Hertz (`"Hz"`), '
          'radians per second (`"rad/s"`), or Tesla (`"T"`).',
       ),
-   }
+   },
+   ".."
 ) }}
 
 For example:
@@ -1419,7 +1441,8 @@ and a guide for using macros can be found at
    {
       "PhaseEncodingDirection": "REQUIRED",
       "TotalReadoutTime": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 For example:

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -276,7 +276,8 @@ and a guide for using macros can be found at
          "PDT2",
          "UNIT1",
          "angio",
-      ]
+      ],
+      ".."
    )
 }}
 
@@ -412,7 +413,8 @@ and a guide for using macros can be found at
          "RB1map",
          "S0map",
          "M0map",
-      ]
+      ],
+      ".."
    )
 }}
 
@@ -449,7 +451,8 @@ and a guide for using macros can be found at
          "T2star",
          "FLASH",
          "PD",
-      ]
+      ],
+      ".."
    )
 }}
 
@@ -469,7 +472,8 @@ and a guide for using macros can be found at
          "bold",
          "cbv",
          "phase",
-      ]
+      ],
+      ".."
    )
 }}
 
@@ -736,7 +740,8 @@ and a guide for using macros can be found at
       [
          "dwi",
          "sbref",
-      ]
+      ],
+      ".."
    )
 }}
 
@@ -1172,7 +1177,8 @@ and a guide for using macros can be found at
          "phasediff",
          "fieldmap",
          "epi",
-      ]
+      ],
+      ".."
    )
 }}
 

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -37,7 +37,7 @@ and a guide for using macros can be found at
       "MatrixCoilMode": "RECOMMENDED",
       "CoilCombinationMethod": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Example for `ReceiveCoilActiveElements`:
@@ -85,7 +85,7 @@ and a guide for using macros can be found at
       "SpoilingGradientMoment": 'RECOMMENDED if the SpoilingType is `"GRADIENT"` or `"COMBINED"`.',
       "SpoilingGradientDuration": 'RECOMMENDED if the SpoilingType is `"GRADIENT"` or `"COMBINED"`.',
    },
-   ".."
+   page.file
 ) }}
 
 ### In-Plane Spatial Encoding
@@ -122,7 +122,7 @@ and a guide for using macros can be found at
       ),
       "MixingTime": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 <sup>2</sup>Conveniently, for Siemens data, this value is easily obtained as
@@ -152,7 +152,7 @@ and a guide for using macros can be found at
       "SliceEncodingDirection": "RECOMMENDED",
       "DwellTime": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 ### RF & Contrast
@@ -168,7 +168,7 @@ and a guide for using macros can be found at
       "FlipAngle": "RECOMMENDED, but REQUIRED if `LookLocker` is set `true`",
       "NegativeContrast": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 ### Slice Acceleration
@@ -183,7 +183,7 @@ and a guide for using macros can be found at
    {
       "MultibandAccelerationFactor": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 ### Anatomical landmarks
@@ -200,7 +200,7 @@ and a guide for using macros can be found at
    {
       "AnatomicalLandmarkCoordinates__mri": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 ### Echo-Planar Imaging and *B<sub>0</sub>* mapping
@@ -228,7 +228,7 @@ and a guide for using macros can be found at
       "B0FieldIdentifier": "RECOMMENDED",
       "B0FieldSource": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 ### Institution information
@@ -245,7 +245,7 @@ and a guide for using macros can be found at
       "InstitutionAddress": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`."),
       "InstitutionalDepartmentName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.")
    },
-   ".."
+   page.file
 ) }}
 
 When adding additional metadata please use the CamelCase version of
@@ -286,7 +286,7 @@ and a guide for using macros can be found at
          "UNIT1",
          "angio",
       ],
-      ".."
+      page.file
    )
 }}
 
@@ -346,7 +346,7 @@ and a guide for using macros can be found at
       "RepetitionTimeExcitation": "OPTIONAL",
       "RepetitionTimePreparation": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 The [`part-<label>`](../99-appendices/09-entities.md#part) key/value pair is
@@ -424,7 +424,7 @@ and a guide for using macros can be found at
          "S0map",
          "M0map",
       ],
-      ".."
+      page.file
    )
 }}
 
@@ -462,7 +462,7 @@ and a guide for using macros can be found at
          "FLASH",
          "PD",
       ],
-      ".."
+      page.file
    )
 }}
 
@@ -483,7 +483,7 @@ and a guide for using macros can be found at
          "cbv",
          "phase",
       ],
-      ".."
+      page.file
    )
 }}
 
@@ -618,7 +618,7 @@ and a guide for using macros can be found at
       "VolumeTiming": "REQUIRED",
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`.")
    },
-   ".."
+   page.file
 ) }}
 
 For the fields described above and in the following section, the term "Volume"
@@ -644,7 +644,7 @@ and a guide for using macros can be found at
       "AcquisitionDuration": 'RECOMMENDED, but REQUIRED for sequences that are described with the `VolumeTiming` field and that do not have the `SliceTiming` field set to allow for accurate calculation of "acquisition time"',
       "DelayAfterTrigger": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 The following table recapitulates the different ways that specific fields have
@@ -681,7 +681,7 @@ and a guide for using macros can be found at
       "CogAtlasID": "RECOMMENDED",
       "CogPOID": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 See [Common metadata fields](#common-metadata-fields) for a list of
@@ -754,7 +754,7 @@ and a guide for using macros can be found at
          "dwi",
          "sbref",
       ],
-      ".."
+      page.file
    )
 }}
 
@@ -866,7 +866,7 @@ and a guide for using macros can be found at
    {
       "MultipartID": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 JSON example:
@@ -1073,7 +1073,7 @@ and a guide for using macros can be found at
       "LookLocker": "OPTIONAL",
       "LabelingEfficiency": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 #### (P)CASL-specific metadata fields
@@ -1098,7 +1098,7 @@ and a guide for using macros can be found at
       "LabelingPulseFlipAngle": "RECOMMENDED",
       "LabelingPulseInterval": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 #### PASL-specific metadata fields
@@ -1119,7 +1119,7 @@ and a guide for using macros can be found at
       "BolusCutOffDelayTime": "OPTIONAL, REQUIRED if `BolusCutOffFlag` is `true`",
       "BolusCutOffTechnique": "OPTIONAL, REQUIRED if `BolusCutOffFlag` is `true`",
    },
-   ".."
+   page.file
 ) }}
 
 ### `m0scan` metadata fields
@@ -1140,7 +1140,7 @@ and a guide for using macros can be found at
       ),
       "AcquisitionVoxelSize": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 The following table recapitulates the ASL field dependencies. If Source field (column 1) contains the Value specified in column 2, then the Requirements in column 4 are
@@ -1196,7 +1196,7 @@ and a guide for using macros can be found at
          "fieldmap",
          "epi",
       ],
-      ".."
+      page.file
    )
 }}
 
@@ -1245,7 +1245,7 @@ and a guide for using macros can be found at
          "to any particular scans, it does not have to be filled.",
       ),
    },
-   ".."
+   page.file
 ) }}
 
 For example:
@@ -1297,7 +1297,7 @@ and a guide for using macros can be found at
       "EchoTime1": "REQUIRED",
       "EchoTime2": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 In this particular case, the sidecar JSON file
@@ -1341,7 +1341,7 @@ and a guide for using macros can be found at
    {
       "EchoTime__fmap": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 Each phase map has a corresponding sidecar JSON file to specify its corresponding `EchoTime`.
@@ -1383,7 +1383,7 @@ and a guide for using macros can be found at
          'radians per second (`"rad/s"`), or Tesla (`"T"`).',
       ),
    },
-   ".."
+   page.file
 ) }}
 
 For example:
@@ -1442,7 +1442,7 @@ and a guide for using macros can be found at
       "PhaseEncodingDirection": "REQUIRED",
       "TotalReadoutTime": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 For example:

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -286,7 +286,8 @@ and a guide for using macros can be found at
       "name__channels": "REQUIRED",
       "type__channels": "REQUIRED",
       "units": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present:
@@ -307,7 +308,8 @@ and a guide for using macros can be found at
       "software_filters": "OPTIONAL",
       "status": "OPTIONAL",
       "status_description": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 Example:

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -108,7 +108,7 @@ and a guide for using macros can be found at
    {
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`."),
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present: For consistency between studies and institutions, we
@@ -146,7 +146,7 @@ and a guide for using macros can be found at
       "CogPOID": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Specific MEG fields MUST be present:
@@ -166,7 +166,7 @@ and a guide for using macros can be found at
       "DigitizedLandmarks": "REQUIRED",
       "DigitizedHeadPoints": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present:
@@ -199,7 +199,7 @@ and a guide for using macros can be found at
       "AssociatedEmptyRoom": "RECOMMENDED",
       "HardwareFilters": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Specific EEG fields
@@ -219,7 +219,7 @@ and a guide for using macros can be found at
       "CapManufacturersModelName": "OPTIONAL",
       "EEGReference": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 Example:
@@ -292,7 +292,7 @@ and a guide for using macros can be found at
       "type__channels": "REQUIRED",
       "units": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present:
@@ -314,7 +314,7 @@ and a guide for using macros can be found at
       "status": "OPTIONAL",
       "status_description": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 Example:
@@ -412,7 +412,7 @@ and a guide for using macros can be found at
          "See [Recording EEG simultaneously with MEG](/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).",
       ),
    },
-   ".."
+   page.file
 ) }}
 
 Head localization coils:
@@ -430,7 +430,7 @@ and a guide for using macros can be found at
       "HeadCoilCoordinateUnits": "OPTIONAL",
       "HeadCoilCoordinateSystemDescription": "OPTIONAL, but REQUIRED if `HeadCoilCoordinateSystem` is `Other`",
    },
-   ".."
+   page.file
 ) }}
 
 Digitized head points:
@@ -448,7 +448,7 @@ and a guide for using macros can be found at
       "DigitizedHeadPointsCoordinateUnits": "OPTIONAL",
       "DigitizedHeadPointsCoordinateSystemDescription": "OPTIONAL, but REQUIRED if `DigitizedHeadPointsCoordinateSystem` is `Other`",
    },
-   ".."
+   page.file
 ) }}
 
 Anatomical MRI:
@@ -468,7 +468,7 @@ and a guide for using macros can be found at
          "to be used with the MEG recording.",
       )
    },
-   ".."
+   page.file
 ) }}
 
 Anatomical landmarks:
@@ -486,7 +486,7 @@ and a guide for using macros can be found at
       "AnatomicalLandmarkCoordinateUnits": "OPTIONAL",
       "AnatomicalLandmarkCoordinateSystemDescription": "OPTIONAL, but REQUIRED if `AnatomicalLandmarkCoordinateSystem` is `Other`",
    },
-   ".."
+   page.file
 ) }}
 
 It is also RECOMMENDED that the MRI voxel coordinates of the actual anatomical
@@ -517,7 +517,7 @@ and a guide for using macros can be found at
    {
       "FiducialsDescription": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 For more information on the definition of anatomical landmarks, please visit:

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -107,7 +107,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`."),
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present: For consistency between studies and institutions, we
@@ -144,7 +145,8 @@ and a guide for using macros can be found at
       "CogAtlasID": "RECOMMENDED",
       "CogPOID": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Specific MEG fields MUST be present:
@@ -163,7 +165,8 @@ and a guide for using macros can be found at
       "SoftwareFilters": "REQUIRED",
       "DigitizedLandmarks": "REQUIRED",
       "DigitizedHeadPoints": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present:
@@ -195,7 +198,8 @@ and a guide for using macros can be found at
       "SubjectArtefactDescription": "RECOMMENDED",
       "AssociatedEmptyRoom": "RECOMMENDED",
       "HardwareFilters": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Specific EEG fields
@@ -214,7 +218,8 @@ and a guide for using macros can be found at
       "CapManufacturer": "OPTIONAL",
       "CapManufacturersModelName": "OPTIONAL",
       "EEGReference": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 Example:
@@ -406,7 +411,8 @@ and a guide for using macros can be found at
          "OPTIONAL, but REQUIRED if `EEGCoordinateSystem` is `Other`",
          "See [Recording EEG simultaneously with MEG](/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).",
       ),
-   }
+   },
+   ".."
 ) }}
 
 Head localization coils:
@@ -423,7 +429,8 @@ and a guide for using macros can be found at
       "HeadCoilCoordinateSystem": "OPTIONAL",
       "HeadCoilCoordinateUnits": "OPTIONAL",
       "HeadCoilCoordinateSystemDescription": "OPTIONAL, but REQUIRED if `HeadCoilCoordinateSystem` is `Other`",
-   }
+   },
+   ".."
 ) }}
 
 Digitized head points:
@@ -440,7 +447,8 @@ and a guide for using macros can be found at
       "DigitizedHeadPointsCoordinateSystem": "OPTIONAL",
       "DigitizedHeadPointsCoordinateUnits": "OPTIONAL",
       "DigitizedHeadPointsCoordinateSystemDescription": "OPTIONAL, but REQUIRED if `DigitizedHeadPointsCoordinateSystem` is `Other`",
-   }
+   },
+   ".."
 ) }}
 
 Anatomical MRI:
@@ -459,7 +467,8 @@ and a guide for using macros can be found at
          "possibly of different types if a list is specified, "
          "to be used with the MEG recording.",
       )
-   }
+   },
+   ".."
 ) }}
 
 Anatomical landmarks:
@@ -476,7 +485,8 @@ and a guide for using macros can be found at
       "AnatomicalLandmarkCoordinateSystem": ("OPTIONAL", "Preferably the same as the `MEGCoordinateSystem`."),
       "AnatomicalLandmarkCoordinateUnits": "OPTIONAL",
       "AnatomicalLandmarkCoordinateSystemDescription": "OPTIONAL, but REQUIRED if `AnatomicalLandmarkCoordinateSystem` is `Other`",
-   }
+   },
+   ".."
 ) }}
 
 It is also RECOMMENDED that the MRI voxel coordinates of the actual anatomical
@@ -506,7 +516,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "FiducialsDescription": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 For more information on the definition of anatomical landmarks, please visit:

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -254,7 +254,8 @@ and a guide for using macros can be found at
       "name__channels": "REQUIRED",
       "type__channels": "REQUIRED",
       "units": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present:
@@ -275,7 +276,8 @@ and a guide for using macros can be found at
       "notch": "OPTIONAL",
       "status": "OPTIONAL",
       "status_description": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 Restricted keyword list for field `type` in alphabetic order (shared with the
@@ -350,7 +352,8 @@ and a guide for using macros can be found at
       "x": "REQUIRED",
       "y": "REQUIRED",
       "z": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present:
@@ -366,7 +369,8 @@ and a guide for using macros can be found at
       "type__electrodes": "RECOMMENDED",
       "material": "RECOMMENDED",
       "impedance": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 ### Example `electrodes.tsv`

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -96,7 +96,7 @@ and a guide for using macros can be found at
    {
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`."),
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present: For consistency between studies and institutions, we
@@ -123,7 +123,7 @@ and a guide for using macros can be found at
       "CogPOID": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Specific EEG fields MUST be present:
@@ -141,7 +141,7 @@ and a guide for using macros can be found at
       "PowerLineFrequency": "REQUIRED",
       "SoftwareFilters": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present:
@@ -171,7 +171,7 @@ and a guide for using macros can be found at
       "HardwareFilters": "RECOMMENDED",
       "SubjectArtefactDescription": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Example:
@@ -259,7 +259,7 @@ and a guide for using macros can be found at
       "type__channels": "REQUIRED",
       "units": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present:
@@ -281,7 +281,7 @@ and a guide for using macros can be found at
       "status": "OPTIONAL",
       "status_description": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 Restricted keyword list for field `type` in alphabetic order (shared with the
@@ -357,7 +357,7 @@ and a guide for using macros can be found at
       "y": "REQUIRED",
       "z": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present:
@@ -374,7 +374,7 @@ and a guide for using macros can be found at
       "material": "RECOMMENDED",
       "impedance": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 ### Example `electrodes.tsv`
@@ -458,7 +458,7 @@ and a guide for using macros can be found at
          "landmarks, and fiducials.",
       )
    },
-   ".."
+   page.file
 ) }}
 
 Fields relating to the EEG electrode positions:
@@ -475,7 +475,7 @@ and a guide for using macros can be found at
       "EEGCoordinateUnits": "REQUIRED",
       "EEGCoordinateSystemDescription": 'RECOMMENDED, but REQUIRED if `EEGCoordinateSystem` is `"Other"`',
    },
-   ".."
+   page.file
 ) }}
 
 Fields relating to the position of fiducials measured during an EEG session/run:
@@ -494,7 +494,7 @@ and a guide for using macros can be found at
       "FiducialsCoordinateUnits": "RECOMMENDED",
       "FiducialsCoordinateSystemDescription": 'RECOMMENDED, but REQUIRED if `FiducialsCoordinateSystem` is `"Other"`',
    },
-   ".."
+   page.file
 ) }}
 
 Fields relating to the position of anatomical landmark measured during an EEG session/run:
@@ -512,7 +512,7 @@ and a guide for using macros can be found at
       "AnatomicalLandmarkCoordinateUnits": "RECOMMENDED",
       "AnatomicalLandmarkCoordinateSystemDescription": 'RECOMMENDED, but REQUIRED if `AnatomicalLandmarkCoordinateSystem` is `"Other"`',
    },
-   ".."
+   page.file
 ) }}
 
 If the position of anatomical landmarks is measured using the same system or

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -95,7 +95,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`."),
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present: For consistency between studies and institutions, we
@@ -121,7 +122,8 @@ and a guide for using macros can be found at
       "CogAtlasID": "RECOMMENDED",
       "CogPOID": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Specific EEG fields MUST be present:
@@ -138,7 +140,8 @@ and a guide for using macros can be found at
       "SamplingFrequency": ("REQUIRED", "The sampling frequency of data channels that deviate from the main sampling frequency SHOULD be specified in the `channels.tsv` file."),
       "PowerLineFrequency": "REQUIRED",
       "SoftwareFilters": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present:
@@ -167,7 +170,8 @@ and a guide for using macros can be found at
       "EEGPlacementScheme": "RECOMMENDED",
       "HardwareFilters": "RECOMMENDED",
       "SubjectArtefactDescription": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Example:
@@ -453,7 +457,8 @@ and a guide for using macros can be found at
          "This identifies the MRI or CT scan associated with the electrodes, "
          "landmarks, and fiducials.",
       )
-   }
+   },
+   ".."
 ) }}
 
 Fields relating to the EEG electrode positions:
@@ -469,7 +474,8 @@ and a guide for using macros can be found at
       "EEGCoordinateSystem": "REQUIRED",
       "EEGCoordinateUnits": "REQUIRED",
       "EEGCoordinateSystemDescription": 'RECOMMENDED, but REQUIRED if `EEGCoordinateSystem` is `"Other"`',
-   }
+   },
+   ".."
 ) }}
 
 Fields relating to the position of fiducials measured during an EEG session/run:
@@ -487,7 +493,8 @@ and a guide for using macros can be found at
       "FiducialsCoordinateSystem": "RECOMMENDED",
       "FiducialsCoordinateUnits": "RECOMMENDED",
       "FiducialsCoordinateSystemDescription": 'RECOMMENDED, but REQUIRED if `FiducialsCoordinateSystem` is `"Other"`',
-   }
+   },
+   ".."
 ) }}
 
 Fields relating to the position of anatomical landmark measured during an EEG session/run:
@@ -504,7 +511,8 @@ and a guide for using macros can be found at
       "AnatomicalLandmarkCoordinateSystem": ("RECOMMENDED", "Preferably the same as the `EEGCoordinateSystem`."),
       "AnatomicalLandmarkCoordinateUnits": "RECOMMENDED",
       "AnatomicalLandmarkCoordinateSystemDescription": 'RECOMMENDED, but REQUIRED if `AnatomicalLandmarkCoordinateSystem` is `"Other"`',
-   }
+   },
+   ".."
 ) }}
 
 If the position of anatomical landmarks is measured using the same system or

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -280,7 +280,8 @@ and a guide for using macros can be found at
       "units": "REQUIRED",
       "low_cutoff": "REQUIRED",
       "high_cutoff": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present:
@@ -300,7 +301,8 @@ and a guide for using macros can be found at
       "notch": "OPTIONAL",
       "status": "OPTIONAL",
       "status_description": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 **Example** `sub-01_channels.tsv`:
@@ -417,7 +419,8 @@ and a guide for using macros can be found at
       "y": "REQUIRED",
       "z": ("REQUIRED", "If electrodes are in 2D space this should be a column of `n/a` values."),
       "size": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 SHOULD be present:
@@ -434,7 +437,8 @@ and a guide for using macros can be found at
       "manufacturer": "RECOMMENDED",
       "group": ("RECOMMENDED", "Note that any group specified here should match a group specified in `_channels.tsv`."),
       "hemisphere": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 MAY be present:
@@ -450,7 +454,8 @@ and a guide for using macros can be found at
       "type__electrodes": "OPTIONAL",
       "impedance": "OPTIONAL",
       "dimension": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 Example:

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -108,7 +108,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`."),
-   }
+   },
+   ".."
 ) }}
 
 Note that the `TaskName` field does not have to be a "behavioral task" that subjects perform, but can reflect some information about the conditions present when the data was acquired (for example, `"rest"`, `"sleep"`, or `"seizure"`).
@@ -136,7 +137,8 @@ and a guide for using macros can be found at
       "CogAtlasID": "RECOMMENDED",
       "CogPOID": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Specific iEEG fields MUST be present:
@@ -153,7 +155,8 @@ and a guide for using macros can be found at
       "SamplingFrequency": ("REQUIRED", "The sampling frequency of data channels that deviate from the main sampling frequency SHOULD be specified in the `channels.tsv` file."),
       "PowerLineFrequency": "REQUIRED",
       "SoftwareFilters": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 Specific iEEG fields SHOULD be present:
@@ -185,7 +188,8 @@ and a guide for using macros can be found at
       "iEEGPlacementScheme": "RECOMMENDED",
       "iEEGElectrodeGroups": "RECOMMENDED",
       "SubjectArtefactDescription": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Specific iEEG fields MAY be present:
@@ -200,7 +204,8 @@ and a guide for using macros can be found at
    {
       "ElectricalStimulation": "OPTIONAL",
       "ElectricalStimulationParameters": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 Example:
@@ -507,7 +512,8 @@ and a guide for using macros can be found at
          "**Talairach**: `'/derivatives/surfaces/sub-Talairach/ses-01/anat/"
          "sub-Talairach_hemi-R_pial.surf.gii'`",
       )
-   }
+   },
+   ".."
 ) }}
 
 Fields relating to the iEEG electrode positions:
@@ -525,7 +531,8 @@ and a guide for using macros can be found at
       "iEEGCoordinateSystemDescription": 'RECOMMENDED, but REQUIRED if `iEEGCoordinateSystem` is `"Other"`',
       "iEEGCoordinateProcessingDescription": "RECOMMENDED",
       "iEEGCoordinateProcessingReference": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 ### Recommended 3D coordinate systems

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -109,7 +109,7 @@ and a guide for using macros can be found at
    {
       "TaskName": ("REQUIRED", "A RECOMMENDED convention is to name resting state task using labels beginning with `rest`."),
    },
-   ".."
+   page.file
 ) }}
 
 Note that the `TaskName` field does not have to be a "behavioral task" that subjects perform, but can reflect some information about the conditions present when the data was acquired (for example, `"rest"`, `"sleep"`, or `"seizure"`).
@@ -138,7 +138,7 @@ and a guide for using macros can be found at
       "CogPOID": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Specific iEEG fields MUST be present:
@@ -156,7 +156,7 @@ and a guide for using macros can be found at
       "PowerLineFrequency": "REQUIRED",
       "SoftwareFilters": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 Specific iEEG fields SHOULD be present:
@@ -189,7 +189,7 @@ and a guide for using macros can be found at
       "iEEGElectrodeGroups": "RECOMMENDED",
       "SubjectArtefactDescription": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Specific iEEG fields MAY be present:
@@ -205,7 +205,7 @@ and a guide for using macros can be found at
       "ElectricalStimulation": "OPTIONAL",
       "ElectricalStimulationParameters": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 Example:
@@ -286,7 +286,7 @@ and a guide for using macros can be found at
       "low_cutoff": "REQUIRED",
       "high_cutoff": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present:
@@ -307,7 +307,7 @@ and a guide for using macros can be found at
       "status": "OPTIONAL",
       "status_description": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 **Example** `sub-01_channels.tsv`:
@@ -425,7 +425,7 @@ and a guide for using macros can be found at
       "z": ("REQUIRED", "If electrodes are in 2D space this should be a column of `n/a` values."),
       "size": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 SHOULD be present:
@@ -443,7 +443,7 @@ and a guide for using macros can be found at
       "group": ("RECOMMENDED", "Note that any group specified here should match a group specified in `_channels.tsv`."),
       "hemisphere": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 MAY be present:
@@ -460,7 +460,7 @@ and a guide for using macros can be found at
       "impedance": "OPTIONAL",
       "dimension": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 Example:
@@ -513,7 +513,7 @@ and a guide for using macros can be found at
          "sub-Talairach_hemi-R_pial.surf.gii'`",
       )
    },
-   ".."
+   page.file
 ) }}
 
 Fields relating to the iEEG electrode positions:
@@ -532,7 +532,7 @@ and a guide for using macros can be found at
       "iEEGCoordinateProcessingDescription": "RECOMMENDED",
       "iEEGCoordinateProcessingReference": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 ### Recommended 3D coordinate systems

--- a/src/04-modality-specific-files/05-task-events.md
+++ b/src/04-modality-specific-files/05-task-events.md
@@ -49,7 +49,8 @@ and a guide for using macros can be found at
       "response_time": "OPTIONAL",
       "value": "OPTIONAL",
       "HED": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 <sup>5</sup> Note for MRI data:
@@ -162,7 +163,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_columns_table(
    {
       "stim_file": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 ### Stimuli databases

--- a/src/04-modality-specific-files/05-task-events.md
+++ b/src/04-modality-specific-files/05-task-events.md
@@ -237,7 +237,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "StimulusPresentation": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 The object supplied for `StimulusPresentation` SHOULD include the following key-value pairs:
@@ -255,7 +256,8 @@ and a guide for using macros can be found at
       "SoftwareRRID": "RECOMMENDED",
       "SoftwareVersion": "RECOMMENDED",
       "Code": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 The operating system description SHOULD include the following attributes:

--- a/src/04-modality-specific-files/05-task-events.md
+++ b/src/04-modality-specific-files/05-task-events.md
@@ -50,7 +50,7 @@ and a guide for using macros can be found at
       "value": "OPTIONAL",
       "HED": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 <sup>5</sup> Note for MRI data:
@@ -164,7 +164,7 @@ and a guide for using macros can be found at
    {
       "stim_file": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 ### Stimuli databases
@@ -238,7 +238,7 @@ and a guide for using macros can be found at
    {
       "StimulusPresentation": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 The object supplied for `StimulusPresentation` SHOULD include the following key-value pairs:
@@ -257,7 +257,7 @@ and a guide for using macros can be found at
       "SoftwareVersion": "RECOMMENDED",
       "Code": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 The operating system description SHOULD include the following attributes:

--- a/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
+++ b/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
@@ -59,7 +59,8 @@ and a guide for using macros can be found at
       "SamplingFrequency": "REQUIRED",
       "StartTime": "REQUIRED",
       "Columns": "REQUIRED",
-   }
+   },
+   ".."
 ) }}
 
 Additional metadata may be included as in
@@ -195,7 +196,8 @@ and a guide for using macros can be found at
       "ManufacturersModelName": "RECOMMENDED",
       "SoftwareVersions": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 <!-- Link Definitions -->

--- a/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
+++ b/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
@@ -139,7 +139,8 @@ and a guide for using macros can be found at
       "cardiac": "OPTIONAL",
       "respiratory": "OPTIONAL",
       "trigger": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 For any other data to be specified in columns, the column names can be chosen

--- a/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
+++ b/src/04-modality-specific-files/06-physiological-and-other-continuous-recordings.md
@@ -60,7 +60,7 @@ and a guide for using macros can be found at
       "StartTime": "REQUIRED",
       "Columns": "REQUIRED",
    },
-   ".."
+   page.file
 ) }}
 
 Additional metadata may be included as in
@@ -141,7 +141,7 @@ and a guide for using macros can be found at
       "respiratory": "OPTIONAL",
       "trigger": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 For any other data to be specified in columns, the column names can be chosen
@@ -197,7 +197,7 @@ and a guide for using macros can be found at
       "SoftwareVersions": "RECOMMENDED",
       "DeviceSerialNumber": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 <!-- Link Definitions -->

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -59,7 +59,8 @@ and a guide for using macros can be found at
       "InstitutionName": "RECOMMENDED",
       "InstitutionAddress": "RECOMMENDED",
       "InstitutionalDepartmentName": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Example of the content of a `_beh.tsv` and its accompanying `_beh.json` sidecar file:

--- a/src/04-modality-specific-files/07-behavioral-experiments.md
+++ b/src/04-modality-specific-files/07-behavioral-experiments.md
@@ -60,7 +60,7 @@ and a guide for using macros can be found at
       "InstitutionAddress": "RECOMMENDED",
       "InstitutionalDepartmentName": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Example of the content of a `_beh.tsv` and its accompanying `_beh.json` sidecar file:

--- a/src/04-modality-specific-files/08-genetic-descriptor.md
+++ b/src/04-modality-specific-files/08-genetic-descriptor.md
@@ -39,7 +39,7 @@ and a guide for using macros can be found at
       "Genetics.Database": "OPTIONAL",
       "Genetics.Descriptors": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 Example:
@@ -112,7 +112,7 @@ and a guide for using macros can be found at
       "BrainLocation": "OPTIONAL",
       "CellType": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 To ensure dataset description consistency, we recommend following [Multi-omics approaches to disease](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1215-1) by Hasin et al. 2017 to determine the `GeneticLevel:`

--- a/src/04-modality-specific-files/08-genetic-descriptor.md
+++ b/src/04-modality-specific-files/08-genetic-descriptor.md
@@ -38,7 +38,8 @@ and a guide for using macros can be found at
       "Genetics.Dataset": "REQUIRED",
       "Genetics.Database": "OPTIONAL",
       "Genetics.Descriptors": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 Example:
@@ -110,7 +111,8 @@ and a guide for using macros can be found at
       "TissueOrigin": "OPTIONAL",
       "BrainLocation": "OPTIONAL",
       "CellType": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 To ensure dataset description consistency, we recommend following [Multi-omics approaches to disease](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1215-1) by Hasin et al. 2017 to determine the `GeneticLevel:`

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -429,7 +429,8 @@ and a guide for using macros can be found at
       "metabolite_polar_fraction": "RECOMMENDED if `MetaboliteAvail` is `true`",
       "hplc_recovery_fractions": "REQUIRED if `MetaboliteRecoveryCorrectionApplied` is `true`",
       "whole_blood_radioactivity": "REQUIRED if `WholeBloodAvail` is `true`",
-   }
+   },
+   ".."
 ) }}
 
 As with all [tabular files](../02-common-principles.md#tabular-files),

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -160,7 +160,8 @@ and a guide for using macros can be found at
       "InstitutionAddress": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`."),
       "InstitutionalDepartmentName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`."),
       "BodyPart": ("RECOMMENDED", "Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`."),
-   }
+   },
+   ".."
 ) }}
 
 #### Radiochemistry
@@ -198,7 +199,8 @@ and a guide for using macros can be found at
       "InfusionSpeedUnits": "RECOMMENDED, but REQUIRED if `ModeOfAdministration`  is `bolus-infusion`",
       "InjectedVolume": "RECOMMENDED, but REQUIRED if `ModeOfAdministration`  is `bolus-infusion`",
       "Purity": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 #### Pharmaceuticals
@@ -217,7 +219,8 @@ and a guide for using macros can be found at
       "PharmaceuticalDoseRegimen": "RECOMMENDED",
       "PharmaceuticalDoseTime": ("RECOMMENDED", "Corresponds to a combination of DICOM Tags (0008,0027) `Intervention Drug Stop Time` and (0008,0035) `Intervention Drug Start Time`."),
       "Anaesthesia": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 #### Time
@@ -237,7 +240,8 @@ and a guide for using macros can be found at
       "FrameDuration": "REQUIRED",
       "InjectionEnd": ("RECOMMENDED", "This corresponds to DICOM Tag (0018,1073) `Radiopharmaceutical Stop Time` converted to seconds relative to TimeZero."),
       "ScanDate": ("DEPRECATED", "This corresponds to DICOM Tag (0008,0022) `Acquisition Date`."),
-   }
+   },
+   ".."
 ) }}
 
 We refer to the common principles for the standards for describing dates and timestamps, including possibilities for anonymization (see [Units](../02-common-principles.md#units)).
@@ -271,7 +275,8 @@ and a guide for using macros can be found at
       "PromptRate": "RECOMMENDED",
       "RandomRate": "RECOMMENDED",
       "SinglesRate": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 All reconstruction-specific parameters that are not specified, but one wants to include, should go into the `ReconMethodParameterValues` field.
@@ -392,7 +397,8 @@ and a guide for using macros can be found at
       "DispersionConstant": "RECOMMENDED",
       "Haematocrit": "RECOMMENDED",
       "BloodDensity": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 The following metadata SHOULD or MUST be provided if corresponding flags are `true`.
@@ -409,7 +415,8 @@ and a guide for using macros can be found at
       "PlasmaFreeFractionMethod": "RECOMMENDED if `PlasmaAvail` is `true`",
       "MetaboliteMethod": "REQUIRED if `MetaboliteAvail` is `true`",
       "MetaboliteRecoveryCorrectionApplied": "REQUIRED if `MetaboliteAvail` is `true`",
-   }
+   },
+   ".."
 ) }}
 
 The following columns are defined for `_blood.tsv` files.

--- a/src/04-modality-specific-files/09-positron-emission-tomography.md
+++ b/src/04-modality-specific-files/09-positron-emission-tomography.md
@@ -161,7 +161,7 @@ and a guide for using macros can be found at
       "InstitutionalDepartmentName": ("RECOMMENDED", "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`."),
       "BodyPart": ("RECOMMENDED", "Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`."),
    },
-   ".."
+   page.file
 ) }}
 
 #### Radiochemistry
@@ -200,7 +200,7 @@ and a guide for using macros can be found at
       "InjectedVolume": "RECOMMENDED, but REQUIRED if `ModeOfAdministration`  is `bolus-infusion`",
       "Purity": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 #### Pharmaceuticals
@@ -220,7 +220,7 @@ and a guide for using macros can be found at
       "PharmaceuticalDoseTime": ("RECOMMENDED", "Corresponds to a combination of DICOM Tags (0008,0027) `Intervention Drug Stop Time` and (0008,0035) `Intervention Drug Start Time`."),
       "Anaesthesia": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 #### Time
@@ -241,7 +241,7 @@ and a guide for using macros can be found at
       "InjectionEnd": ("RECOMMENDED", "This corresponds to DICOM Tag (0018,1073) `Radiopharmaceutical Stop Time` converted to seconds relative to TimeZero."),
       "ScanDate": ("DEPRECATED", "This corresponds to DICOM Tag (0008,0022) `Acquisition Date`."),
    },
-   ".."
+   page.file
 ) }}
 
 We refer to the common principles for the standards for describing dates and timestamps, including possibilities for anonymization (see [Units](../02-common-principles.md#units)).
@@ -276,7 +276,7 @@ and a guide for using macros can be found at
       "RandomRate": "RECOMMENDED",
       "SinglesRate": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 All reconstruction-specific parameters that are not specified, but one wants to include, should go into the `ReconMethodParameterValues` field.
@@ -398,7 +398,7 @@ and a guide for using macros can be found at
       "Haematocrit": "RECOMMENDED",
       "BloodDensity": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 The following metadata SHOULD or MUST be provided if corresponding flags are `true`.
@@ -416,7 +416,7 @@ and a guide for using macros can be found at
       "MetaboliteMethod": "REQUIRED if `MetaboliteAvail` is `true`",
       "MetaboliteRecoveryCorrectionApplied": "REQUIRED if `MetaboliteAvail` is `true`",
    },
-   ".."
+   page.file
 ) }}
 
 The following columns are defined for `_blood.tsv` files.
@@ -437,7 +437,7 @@ and a guide for using macros can be found at
       "hplc_recovery_fractions": "REQUIRED if `MetaboliteRecoveryCorrectionApplied` is `true`",
       "whole_blood_radioactivity": "REQUIRED if `WholeBloodAvail` is `true`",
    },
-   ".."
+   page.file
 ) }}
 
 As with all [tabular files](../02-common-principles.md#tabular-files),

--- a/src/04-modality-specific-files/10-microscopy.md
+++ b/src/04-modality-specific-files/10-microscopy.md
@@ -91,7 +91,7 @@ and a guide for using macros can be found at
          "OCT",
          "SPIM",
       ],
-      ".."
+      page.file
    )
 }}
 
@@ -293,7 +293,7 @@ and a guide for using macros can be found at
       "InstitutionAddress": "RECOMMENDED",
       "InstitutionalDepartmentName": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 #### Image Acquisition
@@ -314,7 +314,7 @@ and a guide for using macros can be found at
       "ImageAcquisitionProtocol": "OPTIONAL",
       "OtherAcquisitionParameters": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 #### Sample
@@ -341,7 +341,7 @@ and a guide for using macros can be found at
       "SampleExtractionProtocol": "OPTIONAL",
       "SampleExtractionInstitution": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 #### Chunk Transformations
@@ -371,7 +371,7 @@ and a guide for using macros can be found at
       "ChunkTransformationMatrix": "RECOMMENDED if `<chunk-index>` is used in filenames",
       "ChunkTransformationMatrixAxis": "REQUIRED if `ChunkTransformationMatrix` is present",
    },
-   ".."
+   page.file
 ) }}
 
 An example of chunk transformations JSON metadata for `chunk-01` and `chunk-05` of Figure 2

--- a/src/04-modality-specific-files/10-microscopy.md
+++ b/src/04-modality-specific-files/10-microscopy.md
@@ -90,7 +90,8 @@ and a guide for using macros can be found at
          "NLO",
          "OCT",
          "SPIM",
-      ]
+      ],
+      ".."
    )
 }}
 

--- a/src/04-modality-specific-files/10-microscopy.md
+++ b/src/04-modality-specific-files/10-microscopy.md
@@ -292,7 +292,8 @@ and a guide for using macros can be found at
       "InstitutionName": "RECOMMENDED",
       "InstitutionAddress": "RECOMMENDED",
       "InstitutionalDepartmentName": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 #### Image Acquisition
@@ -312,7 +313,8 @@ and a guide for using macros can be found at
       "Magnification": "OPTIONAL",
       "ImageAcquisitionProtocol": "OPTIONAL",
       "OtherAcquisitionParameters": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 #### Sample
@@ -338,7 +340,8 @@ and a guide for using macros can be found at
       "TissueDeformationScaling": "OPTIONAL",
       "SampleExtractionProtocol": "OPTIONAL",
       "SampleExtractionInstitution": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 #### Chunk Transformations
@@ -367,7 +370,8 @@ and a guide for using macros can be found at
    {
       "ChunkTransformationMatrix": "RECOMMENDED if `<chunk-index>` is used in filenames",
       "ChunkTransformationMatrixAxis": "REQUIRED if `ChunkTransformationMatrix` is present",
-   }
+   },
+   ".."
 ) }}
 
 An example of chunk transformations JSON metadata for `chunk-01` and `chunk-05` of Figure 2

--- a/src/05-derivatives/02-common-data-types.md
+++ b/src/05-derivatives/02-common-data-types.md
@@ -24,7 +24,8 @@ and a guide for using macros can be found at
         ),
         "Sources": "OPTIONAL",
         "RawSources": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 ### Examples
@@ -104,7 +105,8 @@ and a guide for using macros can be found at
 {{ MACROS___make_metadata_table(
    {
       "SpatialReference": "RECOMMENDED if the derivative is aligned to a standard template listed in [Standard template identifiers][templates]. REQUIRED otherwise.",
-   }
+   },
+   ".."
 ) }}
 
 ### SpatialReference key allowed values

--- a/src/05-derivatives/02-common-data-types.md
+++ b/src/05-derivatives/02-common-data-types.md
@@ -25,7 +25,7 @@ and a guide for using macros can be found at
         "Sources": "OPTIONAL",
         "RawSources": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 ### Examples
@@ -106,7 +106,7 @@ and a guide for using macros can be found at
    {
       "SpatialReference": "RECOMMENDED if the derivative is aligned to a standard template listed in [Standard template identifiers][templates]. REQUIRED otherwise.",
    },
-   ".."
+   page.file
 ) }}
 
 ### SpatialReference key allowed values

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -63,7 +63,8 @@ and a guide for using macros can be found at
       "SkullStripped": "REQUIRED",
       "Resolution": "REQUIRED if `res` is present",
       "Density": "REQUIRED if `den` is present",
-   }
+   },
+   ".."
 ) }}
 
 Example JSON file corresponding to
@@ -173,7 +174,8 @@ and a guide for using macros can be found at
       "Atlas": "RECOMMENDED if `label` entity is defined",
       "Resolution": "REQUIRED if `res` is present",
       "Density": "REQUIRED if `den` is present",
-   }
+   },
+   ".."
 ) }}
 
 Examples:
@@ -253,7 +255,8 @@ and a guide for using macros can be found at
       "Atlas": "REQUIRED if `atlas` is present",
       "Resolution": "REQUIRED if `res` is present",
       "Density": "REQUIRED if `den` is present",
-   }
+   },
+   ".."
 ) }}
 
 ### Discrete Segmentations

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -532,7 +532,8 @@ and a guide for using macros can be found at
       "abbreviation": "OPTIONAL",
       "color": "OPTIONAL",
       "mapping": "OPTIONAL",
-   }
+   },
+   ".."
 ) }}
 
 An example, custom `dseg.tsv` that defines three labels:

--- a/src/05-derivatives/03-imaging.md
+++ b/src/05-derivatives/03-imaging.md
@@ -64,7 +64,7 @@ and a guide for using macros can be found at
       "Resolution": "REQUIRED if `res` is present",
       "Density": "REQUIRED if `den` is present",
    },
-   ".."
+   page.file
 ) }}
 
 Example JSON file corresponding to
@@ -175,7 +175,7 @@ and a guide for using macros can be found at
       "Resolution": "REQUIRED if `res` is present",
       "Density": "REQUIRED if `den` is present",
    },
-   ".."
+   page.file
 ) }}
 
 Examples:
@@ -256,7 +256,7 @@ and a guide for using macros can be found at
       "Resolution": "REQUIRED if `res` is present",
       "Density": "REQUIRED if `den` is present",
    },
-   ".."
+   page.file
 ) }}
 
 ### Discrete Segmentations
@@ -536,7 +536,7 @@ and a guide for using macros can be found at
       "color": "OPTIONAL",
       "mapping": "OPTIONAL",
    },
-   ".."
+   page.file
 ) }}
 
 An example, custom `dseg.tsv` that defines three labels:

--- a/src/99-appendices/11-qmri.md
+++ b/src/99-appendices/11-qmri.md
@@ -295,7 +295,7 @@ and a guide for using macros can be found at
       "EstimationAlgorithm": "RECOMMENDED",
       "Units": "RECOMMENDED",
    },
-   ".."
+   page.file
 ) }}
 
 Example:

--- a/src/99-appendices/11-qmri.md
+++ b/src/99-appendices/11-qmri.md
@@ -294,7 +294,8 @@ and a guide for using macros can be found at
       "EstimationReference": "RECOMMENDED",
       "EstimationAlgorithm": "RECOMMENDED",
       "Units": "RECOMMENDED",
-   }
+   },
+   ".."
 ) }}
 
 Example:

--- a/src/99-appendices/14-glossary.md
+++ b/src/99-appendices/14-glossary.md
@@ -8,4 +8,4 @@ This section compiles the object definitions in the schema.
   and a guide for using macros can be found at
   https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
-{{ MACROS___make_glossary("..") }}
+{{ MACROS___make_glossary(page.file) }}

--- a/src/99-appendices/14-glossary.md
+++ b/src/99-appendices/14-glossary.md
@@ -8,4 +8,4 @@ This section compiles the object definitions in the schema.
   and a guide for using macros can be found at
   https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
-{{ MACROS___make_glossary() }}
+{{ MACROS___make_glossary("..") }}

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -3,7 +3,7 @@ HED:
   name: HED
   description: |
     Hierarchical Event Descriptor (HED) Tag.
-    See [Appendix III](PATH_TO_SRC/99-appendices/03-hed.html) for details.
+    See [Appendix III](PATH_TO_SRC/99-appendices/03-hed.md) for details.
   type: string
 abbreviation:
   name: abbreviation
@@ -17,7 +17,7 @@ acq_time__scans:
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
     Datetime format and their anonymization are described in
-    [Units](PATH_TO_SRC/02-common-principles.html#units).
+    [Units](PATH_TO_SRC/02-common-principles.md#units).
   type: string
   format: datetime
 acq_time__sessions:
@@ -25,7 +25,7 @@ acq_time__sessions:
   description: |
     Acquisition time refers to when the first data point of the first run was acquired.
     Datetime format and their anonymization are described in
-    [Units](PATH_TO_SRC/02-common-principles.html#units).
+    [Units](PATH_TO_SRC/02-common-principles.md#units).
   type: string
   format: datetime
 age:
@@ -514,7 +514,7 @@ units:
   description: |
     Physical unit of the value represented in this channel,
     for example, `V` for Volt, or `fT/cm` for femto Tesla per centimeter
-    (see [Units](PATH_TO_SRC/02-common-principles.html#units)).
+    (see [Units](PATH_TO_SRC/02-common-principles.md#units)).
   type: string
   format: unit
 value:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -17,8 +17,8 @@ acq_time__scans:
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
     Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
-    {{ MACROS___make_path_relative() }} ... does this even work? REPLACEME ... and this? -->
-    [Units](REPLACEME/02-common-principles.md#units)
+    {{ MACROS___make_path_relative() }} ... does this even work? PATH_TO_SRC ... and this? -->
+    [Units](PATH_TO_SRC/02-common-principles.md#units)
   type: string
   format: datetime
 acq_time__sessions:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -3,7 +3,7 @@ HED:
   name: HED
   description: |
     Hierarchical Event Descriptor (HED) Tag.
-    See [Appendix III](PATH_TO_SRC/99-appendices/03-hed.md) for details.
+    See [Appendix III](SPEC_ROOT/99-appendices/03-hed.md) for details.
   type: string
 abbreviation:
   name: abbreviation
@@ -17,7 +17,7 @@ acq_time__scans:
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
     Datetime format and their anonymization are described in
-    [Units](PATH_TO_SRC/02-common-principles.md#units).
+    [Units](SPEC_ROOT/02-common-principles.md#units).
   type: string
   format: datetime
 acq_time__sessions:
@@ -25,7 +25,7 @@ acq_time__sessions:
   description: |
     Acquisition time refers to when the first data point of the first run was acquired.
     Datetime format and their anonymization are described in
-    [Units](PATH_TO_SRC/02-common-principles.md#units).
+    [Units](SPEC_ROOT/02-common-principles.md#units).
   type: string
   format: datetime
 age:
@@ -514,7 +514,7 @@ units:
   description: |
     Physical unit of the value represented in this channel,
     for example, `V` for Volt, or `fT/cm` for femto Tesla per centimeter
-    (see [Units](PATH_TO_SRC/02-common-principles.md#units)).
+    (see [Units](SPEC_ROOT/02-common-principles.md#units)).
   type: string
   format: unit
 value:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -3,7 +3,7 @@ HED:
   name: HED
   description: |
     Hierarchical Event Descriptor (HED) Tag.
-    See [Appendix III](/99-appendices/03-hed.html) for details.
+    See [Appendix III](PATH_TO_SRC/99-appendices/03-hed.html) for details.
   type: string
 abbreviation:
   name: abbreviation
@@ -16,16 +16,16 @@ acq_time__scans:
     Acquisition time refers to when the first data point in each run was acquired.
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
-    Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
-    see: PATH_TO_SRC ... try:
-    [Units](PATH_TO_SRC/02-common-principles.md#units)
+    Datetime format and their anonymization are described in
+    [Units](PATH_TO_SRC/02-common-principles.html#units).
   type: string
   format: datetime
 acq_time__sessions:
   name: acq_time
   description: |
     Acquisition time refers to when the first data point of the first run was acquired.
-    Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
+    Datetime format and their anonymization are described in
+    [Units](PATH_TO_SRC/02-common-principles.html#units).
   type: string
   format: datetime
 age:
@@ -514,7 +514,7 @@ units:
   description: |
     Physical unit of the value represented in this channel,
     for example, `V` for Volt, or `fT/cm` for femto Tesla per centimeter
-    (see [Units](/02-common-principles.html#units)).
+    (see [Units](PATH_TO_SRC/02-common-principles.html#units)).
   type: string
   format: unit
 value:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -17,7 +17,7 @@ acq_time__scans:
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
     Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
-    {{ MACROS___make_path_relative() }} ... does this even work? PATH_TO_SRC ... and this? -->
+    see: PATH_TO_SRC ... try:
     [Units](PATH_TO_SRC/02-common-principles.md#units)
   type: string
   format: datetime

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -17,6 +17,7 @@ acq_time__scans:
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
     Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
+    {{ MACROS___make_path_relative() }} ... does this even work?
   type: string
   format: datetime
 acq_time__sessions:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -17,7 +17,8 @@ acq_time__scans:
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
     Datetime format and their anonymization are described in [Units](/02-common-principles.html#units).
-    {{ MACROS___make_path_relative() }} ... does this even work?
+    {{ MACROS___make_path_relative() }} ... does this even work? REPLACEME ... and this? -->
+    [Units](REPLACEME/02-common-principles.md#units)
   type: string
   format: datetime
 acq_time__sessions:

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -61,7 +61,7 @@ AnatomicalLandmarkCoordinateSystem:
   name: AnatomicalLandmarkCoordinateSystem
   description: |
     Defines the coordinate system for the anatomical landmarks.
-    See [Appendix VIII](/99-appendices/08-coordinate-systems.html)
+    See [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"AnatomicalLandmarkCoordinateSystemDescription"`.
@@ -262,7 +262,7 @@ BodyPartDetails:
 BodyPartDetailsOntology:
   name: BodyPartDetailsOntology
   description: |
-    [URI](/02-common-principles.html#uniform-resource-indicator) of ontology used for
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator) of ontology used for
     BodyPartDetails (for example: `"https://www.ebi.ac.uk/ols/ontologies/uberon"`).
   type: string
   format: uri
@@ -378,7 +378,7 @@ ChunkTransformationMatrixAxis:
 Code:
   name: Code
   description: |
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     of the code used to present the stimuli.
     Persistent identifiers such as DOIs are preferred.
     If multiple versions of code may be hosted at the same location,
@@ -388,7 +388,7 @@ Code:
 CogAtlasID:
   name: CogAtlasID
   description: |
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     of the corresponding [Cognitive Atlas](https://www.cognitiveatlas.org/)
     Task term.
   type: string
@@ -396,7 +396,7 @@ CogAtlasID:
 CogPOID:
   name: CogPOID
   description: |
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     of the corresponding [CogPO](http://www.cogpo.org/) term.
   type: string
   format: uri
@@ -446,9 +446,9 @@ DatasetDOI:
   description: |
     The Digital Object Identifier of the dataset (not the corresponding paper).
     DOIs SHOULD be expressed as a valid
-    [URI](/02-common-principles.html#uniform-resource-indicator);
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator);
     bare DOIs such as `10.0.2.3/dfjj.10` are
-    [DEPRECATED](/02-common-principles.html#definitions).
+    [DEPRECATED](PATH_TO_SRC/02-common-principles.md#definitions).
   type: string
   format: uri
 DatasetType:
@@ -547,7 +547,7 @@ DigitizedHeadPointsCoordinateSystem:
   description: |
     Defines the coordinate system for the digitized head points.
     See
-    [Appendix VIII](/99-appendices/08-coordinate-systems.html)
+    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"DigitizedHeadPointsCoordinateSystemDescription"`.
@@ -637,7 +637,7 @@ EEGCoordinateSystem:
     Defines the coordinate system for the EEG sensors.
 
     See
-    [Appendix VIII](/99-appendices/08-coordinate-systems.html)
+    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `EEGCoordinateSystemDescription`.
@@ -706,13 +706,13 @@ EchoTime:
     (please note that the DICOM term is in milliseconds not seconds).
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
-    [file collection](/99-appendices/10-file-collections.html)
+    [file collection](PATH_TO_SRC/99-appendices/10-file-collections.md)
     where the value of this field is iterated using the
-    [echo entity](/99-appendices/09-entities.html#echo).
+    [echo entity](PATH_TO_SRC/99-appendices/09-entities.md#echo).
     The data type array provides a value for each volume in a 4D dataset and
     should only be used when the volume timing is critical for interpretation
     of the data, such as in
-    [ASL](/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#\
+    [ASL](PATH_TO_SRC/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\
     arterial-spin-labeling-perfusion-data)
     or variable echo time fMRI sequences.
   anyOf:
@@ -823,7 +823,7 @@ FiducialsCoordinateSystem:
     Defines the coordinate system for the fiducials.
     Preferably the same as the `"EEGCoordinateSystem"`.
     See
-    [Appendix VIII](/99-appendices/08-coordinate-systems.html)
+    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"FiducialsCoordinateSystemDescription"`.
@@ -881,13 +881,13 @@ FlipAngle:
     Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
-    [file collection](/99-appendices/10-file-collections.html)
+    [file collection](PATH_TO_SRC/99-appendices/10-file-collections.md)
     where the value of this field is iterated using the
-    [flip entity](/99-appendices/09-entities.html#flip).
+    [flip entity](PATH_TO_SRC/99-appendices/09-entities.md#flip).
     The data type array provides a value for each volume in a 4D dataset and
     should only be used when the volume timing is critical for interpretation of
     the data, such as in
-    [ASL](/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#\
+    [ASL](PATH_TO_SRC/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\
     arterial-spin-labeling-perfusion-data)
     or variable flip angle fMRI sequences.
   anyOf:
@@ -968,14 +968,14 @@ GeneticLevel:
 Genetics.Database:
   name: Genetics.Database
   description: |
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     of database where the dataset is hosted.
   type: string
   format: uri
 Genetics.Dataset:
   name: Genetics.Dataset
   description: |
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     where data can be retrieved.
   type: string
   format: uri
@@ -984,7 +984,7 @@ Genetics.Descriptors:
   description: |
     List of relevant descriptors (for example, journal articles) for dataset
     using a valid
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     when possible.
   anyOf:
   - type: string
@@ -1015,7 +1015,7 @@ HED:
   name: HED
   description: |
     Hierarchical Event Descriptor (HED) information,
-    see: [Appendix III](/99-appendices/03-hed.html) for details.
+    see: [Appendix III](PATH_TO_SRC/99-appendices/03-hed.md) for details.
   anyOf:
   - type: string
   - type: object
@@ -1067,7 +1067,7 @@ HeadCoilCoordinateSystem:
   description: |
     Defines the coordinate system for the head coils.
     See
-    [Appendix VIII](/99-appendices/08-coordinate-systems.html)
+    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `HeadCoilCoordinateSystemDescription`.
@@ -1139,7 +1139,7 @@ ImageAcquisitionProtocol:
   name: ImageAcquisitionProtocol
   description: |
     Description of the image acquisition protocol or
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     (for example from [protocols.io](https://www.protocols.io/)).
   type: string
 ImageDecayCorrected:
@@ -1440,7 +1440,7 @@ License:
   description: |
     The license for the dataset.
     The use of license name abbreviations is RECOMMENDED for specifying a license
-    (see [Appendix II](/99-appendices/02-licenses.html)).
+    (see [Appendix II](PATH_TO_SRC/99-appendices/02-licenses.md)).
     The corresponding full license text MAY be specified in an additional
     `LICENSE` file.
   type: string
@@ -1487,7 +1487,7 @@ MEGCoordinateSystem:
   name: MEGCoordinateSystem
   description: |
     Defines the coordinate system for the MEG sensors.
-    See [Appendix VIII](/99-appendices/08-coordinate-systems.html)
+    See [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"MEGCoordinateSystemDescription"`.
@@ -2119,7 +2119,7 @@ ReferencesAndLinks:
   description: |
     List of references to publications that contain information on the dataset.
     A reference may be textual or a
-    [URI](/02-common-principles.html#uniform-resource-indicator).
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator).
   items:
     type: string
   type: array
@@ -2175,7 +2175,7 @@ RepetitionTimePreparation:
     The data type array provides a value for each volume in a 4D dataset and
     should only be used when the volume timing is critical for interpretation of
     the data, such as in
-    [ASL](/04-modality-specific-files/01-magnetic-resonance-imaging-data.html\
+    [ASL](PATH_TO_SRC/04-modality-specific-files/01-magnetic-resonance-imaging-data.md\
     #arterial-spin-labeling-perfusion-data).
   anyOf:
   - type: number
@@ -2228,7 +2228,7 @@ SampleExtractionProtocol:
   name: SampleExtractionProtocol
   description: |
     Description of the sample extraction protocol or
-    [URI](/02-common-principles.html#uniform-resource-indicator)
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
     (for example from [protocols.io](https://www.protocols.io/)).
   type: string
 SampleFixation:
@@ -2313,7 +2313,7 @@ ScanDate:
   description: |
     Date of scan in the format `"YYYY-MM-DD[Z]"`.
     This field is DEPRECATED, and this metadata SHOULD be recorded in the `acq_time` column of the
-    corresponding [Scans file](/03-modality-agnostic-files.html#scans-file).
+    corresponding [Scans file](PATH_TO_SRC/03-modality-agnostic-files.md#scans-file).
   type: string
   format: date
 ScanOptions:
@@ -2477,7 +2477,7 @@ SourceDatasets:
   description: |
     Used to specify the locations and relevant attributes of all source datasets.
     Valid keys in each object include `"URL"`, `"DOI"` (see
-    [URI](/02-common-principles.html#uniform-resource-indicator)), and
+    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)), and
     `"Version"` with
     [string](https://www.w3schools.com/js/js_json_datatypes.asp)
     values.
@@ -2775,7 +2775,7 @@ Units:
   description: |
     Measurement units for the associated file.
     SI units in CMIXF formatting are RECOMMENDED
-    (see [Units](/02-common-principles.html#units)).
+    (see [Units](PATH_TO_SRC/02-common-principles.md#units)).
   type: string
   format: unit
 VascularCrushing:
@@ -2934,7 +2934,7 @@ iEEGCoordinateSystem:
   description: |
     Defines the coordinate system for the iEEG sensors.
     See
-    [Appendix VIII](/99-appendices/08-coordinate-systems.html)
+    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `iEEGCoordinateSystemDescription`.

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -61,7 +61,7 @@ AnatomicalLandmarkCoordinateSystem:
   name: AnatomicalLandmarkCoordinateSystem
   description: |
     Defines the coordinate system for the anatomical landmarks.
-    See [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
+    See [Appendix VIII](SPEC_ROOT/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"AnatomicalLandmarkCoordinateSystemDescription"`.
@@ -262,7 +262,7 @@ BodyPartDetails:
 BodyPartDetailsOntology:
   name: BodyPartDetailsOntology
   description: |
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator) of ontology used for
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator) of ontology used for
     BodyPartDetails (for example: `"https://www.ebi.ac.uk/ols/ontologies/uberon"`).
   type: string
   format: uri
@@ -378,7 +378,7 @@ ChunkTransformationMatrixAxis:
 Code:
   name: Code
   description: |
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     of the code used to present the stimuli.
     Persistent identifiers such as DOIs are preferred.
     If multiple versions of code may be hosted at the same location,
@@ -388,7 +388,7 @@ Code:
 CogAtlasID:
   name: CogAtlasID
   description: |
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     of the corresponding [Cognitive Atlas](https://www.cognitiveatlas.org/)
     Task term.
   type: string
@@ -396,7 +396,7 @@ CogAtlasID:
 CogPOID:
   name: CogPOID
   description: |
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     of the corresponding [CogPO](http://www.cogpo.org/) term.
   type: string
   format: uri
@@ -446,9 +446,9 @@ DatasetDOI:
   description: |
     The Digital Object Identifier of the dataset (not the corresponding paper).
     DOIs SHOULD be expressed as a valid
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator);
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator);
     bare DOIs such as `10.0.2.3/dfjj.10` are
-    [DEPRECATED](PATH_TO_SRC/02-common-principles.md#definitions).
+    [DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).
   type: string
   format: uri
 DatasetType:
@@ -547,7 +547,7 @@ DigitizedHeadPointsCoordinateSystem:
   description: |
     Defines the coordinate system for the digitized head points.
     See
-    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
+    [Appendix VIII](SPEC_ROOT/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"DigitizedHeadPointsCoordinateSystemDescription"`.
@@ -637,7 +637,7 @@ EEGCoordinateSystem:
     Defines the coordinate system for the EEG sensors.
 
     See
-    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
+    [Appendix VIII](SPEC_ROOT/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `EEGCoordinateSystemDescription`.
@@ -706,13 +706,13 @@ EchoTime:
     (please note that the DICOM term is in milliseconds not seconds).
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
-    [file collection](PATH_TO_SRC/99-appendices/10-file-collections.md)
+    [file collection](SPEC_ROOT/99-appendices/10-file-collections.md)
     where the value of this field is iterated using the
-    [echo entity](PATH_TO_SRC/99-appendices/09-entities.md#echo).
+    [echo entity](SPEC_ROOT/99-appendices/09-entities.md#echo).
     The data type array provides a value for each volume in a 4D dataset and
     should only be used when the volume timing is critical for interpretation
     of the data, such as in
-    [ASL](PATH_TO_SRC/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\
+    [ASL](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\
     arterial-spin-labeling-perfusion-data)
     or variable echo time fMRI sequences.
   anyOf:
@@ -823,7 +823,7 @@ FiducialsCoordinateSystem:
     Defines the coordinate system for the fiducials.
     Preferably the same as the `"EEGCoordinateSystem"`.
     See
-    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
+    [Appendix VIII](SPEC_ROOT/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"FiducialsCoordinateSystemDescription"`.
@@ -881,13 +881,13 @@ FlipAngle:
     Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
-    [file collection](PATH_TO_SRC/99-appendices/10-file-collections.md)
+    [file collection](SPEC_ROOT/99-appendices/10-file-collections.md)
     where the value of this field is iterated using the
-    [flip entity](PATH_TO_SRC/99-appendices/09-entities.md#flip).
+    [flip entity](SPEC_ROOT/99-appendices/09-entities.md#flip).
     The data type array provides a value for each volume in a 4D dataset and
     should only be used when the volume timing is critical for interpretation of
     the data, such as in
-    [ASL](PATH_TO_SRC/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\
+    [ASL](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\
     arterial-spin-labeling-perfusion-data)
     or variable flip angle fMRI sequences.
   anyOf:
@@ -968,14 +968,14 @@ GeneticLevel:
 Genetics.Database:
   name: Genetics.Database
   description: |
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     of database where the dataset is hosted.
   type: string
   format: uri
 Genetics.Dataset:
   name: Genetics.Dataset
   description: |
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     where data can be retrieved.
   type: string
   format: uri
@@ -984,7 +984,7 @@ Genetics.Descriptors:
   description: |
     List of relevant descriptors (for example, journal articles) for dataset
     using a valid
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     when possible.
   anyOf:
   - type: string
@@ -1015,7 +1015,7 @@ HED:
   name: HED
   description: |
     Hierarchical Event Descriptor (HED) information,
-    see: [Appendix III](PATH_TO_SRC/99-appendices/03-hed.md) for details.
+    see: [Appendix III](SPEC_ROOT/99-appendices/03-hed.md) for details.
   anyOf:
   - type: string
   - type: object
@@ -1067,7 +1067,7 @@ HeadCoilCoordinateSystem:
   description: |
     Defines the coordinate system for the head coils.
     See
-    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
+    [Appendix VIII](SPEC_ROOT/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `HeadCoilCoordinateSystemDescription`.
@@ -1139,7 +1139,7 @@ ImageAcquisitionProtocol:
   name: ImageAcquisitionProtocol
   description: |
     Description of the image acquisition protocol or
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     (for example from [protocols.io](https://www.protocols.io/)).
   type: string
 ImageDecayCorrected:
@@ -1440,7 +1440,7 @@ License:
   description: |
     The license for the dataset.
     The use of license name abbreviations is RECOMMENDED for specifying a license
-    (see [Appendix II](PATH_TO_SRC/99-appendices/02-licenses.md)).
+    (see [Appendix II](SPEC_ROOT/99-appendices/02-licenses.md)).
     The corresponding full license text MAY be specified in an additional
     `LICENSE` file.
   type: string
@@ -1487,7 +1487,7 @@ MEGCoordinateSystem:
   name: MEGCoordinateSystem
   description: |
     Defines the coordinate system for the MEG sensors.
-    See [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
+    See [Appendix VIII](SPEC_ROOT/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `"MEGCoordinateSystemDescription"`.
@@ -2119,7 +2119,7 @@ ReferencesAndLinks:
   description: |
     List of references to publications that contain information on the dataset.
     A reference may be textual or a
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator).
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator).
   items:
     type: string
   type: array
@@ -2175,7 +2175,7 @@ RepetitionTimePreparation:
     The data type array provides a value for each volume in a 4D dataset and
     should only be used when the volume timing is critical for interpretation of
     the data, such as in
-    [ASL](PATH_TO_SRC/04-modality-specific-files/01-magnetic-resonance-imaging-data.md\
+    [ASL](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md\
     #arterial-spin-labeling-perfusion-data).
   anyOf:
   - type: number
@@ -2228,7 +2228,7 @@ SampleExtractionProtocol:
   name: SampleExtractionProtocol
   description: |
     Description of the sample extraction protocol or
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
     (for example from [protocols.io](https://www.protocols.io/)).
   type: string
 SampleFixation:
@@ -2313,7 +2313,7 @@ ScanDate:
   description: |
     Date of scan in the format `"YYYY-MM-DD[Z]"`.
     This field is DEPRECATED, and this metadata SHOULD be recorded in the `acq_time` column of the
-    corresponding [Scans file](PATH_TO_SRC/03-modality-agnostic-files.md#scans-file).
+    corresponding [Scans file](SPEC_ROOT/03-modality-agnostic-files.md#scans-file).
   type: string
   format: date
 ScanOptions:
@@ -2477,7 +2477,7 @@ SourceDatasets:
   description: |
     Used to specify the locations and relevant attributes of all source datasets.
     Valid keys in each object include `"URL"`, `"DOI"` (see
-    [URI](PATH_TO_SRC/02-common-principles.md#uniform-resource-indicator)), and
+    [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)), and
     `"Version"` with
     [string](https://www.w3schools.com/js/js_json_datatypes.asp)
     values.
@@ -2775,7 +2775,7 @@ Units:
   description: |
     Measurement units for the associated file.
     SI units in CMIXF formatting are RECOMMENDED
-    (see [Units](PATH_TO_SRC/02-common-principles.md#units)).
+    (see [Units](SPEC_ROOT/02-common-principles.md#units)).
   type: string
   format: unit
 VascularCrushing:
@@ -2934,7 +2934,7 @@ iEEGCoordinateSystem:
   description: |
     Defines the coordinate system for the iEEG sensors.
     See
-    [Appendix VIII](PATH_TO_SRC/99-appendices/08-coordinate-systems.md)
+    [Appendix VIII](SPEC_ROOT/99-appendices/08-coordinate-systems.md)
     for a list of restricted keywords for coordinate systems.
     If `"Other"`, provide definition of the coordinate system in
     `iEEGCoordinateSystemDescription`.

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -463,7 +463,7 @@ blood:
   name: Blood recording data
   description: |
     Blood measurements of radioactivity stored in
-    [tabular files](PATH_TO_SRC/02-common-principles.md#tabular-files)
+    [tabular files](SPEC_ROOT/02-common-principles.md#tabular-files)
     and located in the `pet/` directory along with the corresponding PET data.
 bold:
   name: Blood-Oxygen-Level Dependent image
@@ -579,11 +579,11 @@ pet:
 phase:
   name: Phase image
   description: |
-    [DEPRECATED](PATH_TO_SRC/02-common-principles.md#definitions).
+    [DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).
     Phase information associated with magnitude information stored in BOLD
     contrast.
     This suffix should be replaced by the
-    [`part-phase`](PATH_TO_SRC/99-appendices/09-entities.md#part)
+    [`part-phase`](SPEC_ROOT/99-appendices/09-entities.md#part)
     in conjunction with the `bold` suffix.
   anyOf:
   - unit: arbitrary

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -463,7 +463,7 @@ blood:
   name: Blood recording data
   description: |
     Blood measurements of radioactivity stored in
-    [tabular files](/02-common-principles.html#tabular-files)
+    [tabular files](PATH_TO_SRC/02-common-principles.md#tabular-files)
     and located in the `pet/` directory along with the corresponding PET data.
 bold:
   name: Blood-Oxygen-Level Dependent image
@@ -579,11 +579,11 @@ pet:
 phase:
   name: Phase image
   description: |
-    [DEPRECATED](/02-common-principles.html#definitions).
+    [DEPRECATED](PATH_TO_SRC/02-common-principles.md#definitions).
     Phase information associated with magnitude information stored in BOLD
     contrast.
     This suffix should be replaced by the
-    [`part-phase`](/99-appendices/09-entities.html#part)
+    [`part-phase`](PATH_TO_SRC/99-appendices/09-entities.md#part)
     in conjunction with the `bold` suffix.
   anyOf:
   - unit: arbitrary

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -175,7 +175,3 @@ def make_filetree_example(filetree_info, use_pipe=True):
     """
     tree = example.DirectoryTree(filetree_info, use_pipe)
     return tree.generate()
-
-
-def make_path_relative():
-    return "This is a TEST"

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -71,12 +71,12 @@ def make_entity_definitions():
     return text
 
 
-def make_glossary(relpath=None):
+def make_glossary(page_file=None):
     """Generate glossary.
 
     Parameters
     ----------
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
 
     Returns
@@ -87,18 +87,18 @@ def make_glossary(relpath=None):
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    text = render.make_glossary(schema_obj, relpath)
+    text = render.make_glossary(schema_obj, page_file=page_file)
     return text
 
 
-def make_suffix_table(suffixes, relpath=None):
+def make_suffix_table(suffixes, page_file=None):
     """Generate a markdown table of suffix information.
 
     Parameters
     ----------
     suffixes : list of str
         A list of the suffixes to include in the table.
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
 
 
@@ -110,11 +110,11 @@ def make_suffix_table(suffixes, relpath=None):
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    table = render.make_suffix_table(schema_obj, suffixes, relpath)
+    table = render.make_suffix_table(schema_obj, suffixes, page_file=page_file)
     return table
 
 
-def make_metadata_table(field_info, relpath=None):
+def make_metadata_table(field_info, page_file=None):
     """Generate a markdown table of metadata field information.
 
     Parameters
@@ -126,7 +126,7 @@ def make_metadata_table(field_info, relpath=None):
         Until requirement levels can be codified in the schema,
         this argument will be dictionary, with the field names as keys and
         the requirement levels as values.
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
 
     Returns
@@ -137,11 +137,11 @@ def make_metadata_table(field_info, relpath=None):
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    table = render.make_metadata_table(schema_obj, field_info, relpath=relpath)
+    table = render.make_metadata_table(schema_obj, field_info, page_file=page_file)
     return table
 
 
-def make_columns_table(column_info, relpath=None):
+def make_columns_table(column_info, page_file=None):
     """Generate a markdown table of TSV column information.
 
     Parameters
@@ -153,7 +153,7 @@ def make_columns_table(column_info, relpath=None):
         Until requirement levels can be codified in the schema,
         this argument will be a dictionary, with the column names as keys and
         the requirement levels as values.
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
 
     Returns
@@ -164,7 +164,7 @@ def make_columns_table(column_info, relpath=None):
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    table = render.make_columns_table(schema_obj, column_info, relpath=relpath)
+    table = render.make_columns_table(schema_obj, column_info, page_file=page_file)
     return table
 
 

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -173,3 +173,7 @@ def make_filetree_example(filetree_info, use_pipe=True):
     """
     tree = example.DirectoryTree(filetree_info, use_pipe)
     return tree.generate()
+
+
+def make_path_relative():
+    return "This is a TEST"

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -76,8 +76,8 @@ def make_glossary(page_file=None):
 
     Parameters
     ----------
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
 
     Returns
     -------
@@ -98,8 +98,8 @@ def make_suffix_table(suffixes, page_file=None):
     ----------
     suffixes : list of str
         A list of the suffixes to include in the table.
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
 
 
     Returns
@@ -126,8 +126,8 @@ def make_metadata_table(field_info, page_file=None):
         Until requirement levels can be codified in the schema,
         this argument will be dictionary, with the field names as keys and
         the requirement levels as values.
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
 
     Returns
     -------
@@ -153,8 +153,8 @@ def make_columns_table(column_info, page_file=None):
         Until requirement levels can be codified in the schema,
         this argument will be a dictionary, with the column names as keys and
         the requirement levels as values.
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
 
     Returns
     -------

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -131,7 +131,7 @@ def make_metadata_table(field_info):
     return table
 
 
-def make_columns_table(column_info):
+def make_columns_table(column_info, relpath=None):
     """Generate a markdown table of TSV column information.
 
     Parameters
@@ -143,6 +143,8 @@ def make_columns_table(column_info):
         Until requirement levels can be codified in the schema,
         this argument will be a dictionary, with the column names as keys and
         the requirement levels as values.
+    relpath : str | None
+        path from file where this func is called to src/
 
     Returns
     -------
@@ -152,7 +154,7 @@ def make_columns_table(column_info):
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    table = render.make_columns_table(schema_obj, column_info)
+    table = render.make_columns_table(schema_obj, column_info, relpath=relpath)
     return table
 
 

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -114,7 +114,7 @@ def make_suffix_table(suffixes, relpath=None):
     return table
 
 
-def make_metadata_table(field_info):
+def make_metadata_table(field_info, relpath=None):
     """Generate a markdown table of metadata field information.
 
     Parameters
@@ -126,6 +126,8 @@ def make_metadata_table(field_info):
         Until requirement levels can be codified in the schema,
         this argument will be dictionary, with the field names as keys and
         the requirement levels as values.
+    relpath : str | None
+        path from file where this func is called to src/
 
     Returns
     -------
@@ -135,7 +137,7 @@ def make_metadata_table(field_info):
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    table = render.make_metadata_table(schema_obj, field_info)
+    table = render.make_metadata_table(schema_obj, field_info, relpath=relpath)
     return table
 
 

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -91,13 +91,16 @@ def make_glossary(relpath=None):
     return text
 
 
-def make_suffix_table(suffixes):
+def make_suffix_table(suffixes, relpath=None):
     """Generate a markdown table of suffix information.
 
     Parameters
     ----------
     suffixes : list of str
         A list of the suffixes to include in the table.
+    relpath : str | None
+        path from file where this func is called to src/
+
 
     Returns
     -------
@@ -107,7 +110,7 @@ def make_suffix_table(suffixes):
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    table = render.make_suffix_table(schema_obj, suffixes)
+    table = render.make_suffix_table(schema_obj, suffixes, relpath)
     return table
 
 

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -71,8 +71,13 @@ def make_entity_definitions():
     return text
 
 
-def make_glossary():
+def make_glossary(relpath=None):
     """Generate glossary.
+
+    Parameters
+    ----------
+    relpath : str | None
+        path from file where this func is called to src/
 
     Returns
     -------
@@ -82,7 +87,7 @@ def make_glossary():
     """
     schemapath = utils.get_schema_path()
     schema_obj = schema.load_schema(schemapath)
-    text = render.make_glossary(schema_obj)
+    text = render.make_glossary(schema_obj, relpath)
     return text
 
 

--- a/tools/mkdocs_macros_bids/main.py
+++ b/tools/mkdocs_macros_bids/main.py
@@ -40,4 +40,3 @@ def define_env(env):
     env.macro(macros.make_metadata_table, "MACROS___make_metadata_table")
     env.macro(macros.make_columns_table, "MACROS___make_columns_table")
     env.macro(macros.make_filetree_example, "MACROS___make_filetree_example")
-    env.macro(macros.make_path_relative, "MACROS___make_path_relative")

--- a/tools/mkdocs_macros_bids/main.py
+++ b/tools/mkdocs_macros_bids/main.py
@@ -40,3 +40,4 @@ def define_env(env):
     env.macro(macros.make_metadata_table, "MACROS___make_metadata_table")
     env.macro(macros.make_columns_table, "MACROS___make_columns_table")
     env.macro(macros.make_filetree_example, "MACROS___make_filetree_example")
+    env.macro(macros.make_path_relative, "MACROS___make_path_relative")

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -123,7 +123,9 @@ def make_glossary(schema, page_file=None):
         obj_desc = obj_desc.replace("\n", " ")
         # Spec internal links need to be replaced
         if page_file is not None:
-            obj_desc = obj_desc.replace("SPEC_ROOT", page_file)
+            relpath = os.sep.join([".."] * page_file.src_path.count(os.sep))
+            relpath = "." if not relpath else relpath
+            obj_desc = obj_desc.replace("SPEC_ROOT", relpath)
 
         text += f'\n<a name="{obj_marker}"></a>'
         text += f"\n## {obj_key}\n\n"
@@ -449,7 +451,9 @@ def make_suffix_table(schema, suffixes, page_file=None, tablefmt="github"):
         description = description.replace("\n", " ")
         # Spec internal links need to be replaced
         if page_file is not None:
-            description = description.replace("SPEC_ROOT", page_file)
+            relpath = os.sep.join([".."] * page_file.src_path.count(os.sep))
+            relpath = "." if not relpath else relpath
+            description = description.replace("SPEC_ROOT", relpath)
 
         df.loc[suffix] = [suffix_info["name"], description]
 
@@ -533,7 +537,9 @@ def make_metadata_table(schema, field_info, page_file=None, tablefmt="github"):
         description = description.replace("\n", " ")
         # Spec internal links need to be replaced
         if page_file is not None:
-            description = description.replace("SPEC_ROOT", page_file)
+            relpath = os.sep.join([".."] * page_file.src_path.count(os.sep))
+            relpath = "." if not relpath else relpath
+            description = description.replace("SPEC_ROOT", relpath)
 
         df.loc[field_name] = [requirement_info, type_string, description]
 
@@ -601,7 +607,9 @@ def make_columns_table(schema, column_info, page_file=None, tablefmt="github"):
         description = column_schema[field]["description"] + " " + description_addendum
 
         if page_file is not None:
-            description = description.replace("SPEC_ROOT", page_file)
+            relpath = os.sep.join([".."] * page_file.src_path.count(os.sep))
+            relpath = "." if not relpath else relpath
+            description = description.replace("SPEC_ROOT", relpath)
 
         # Try to add info about valid values
         valid_values_str = utils.describe_valid_values(column_schema[field])

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -64,8 +64,8 @@ def make_glossary(schema, page_file=None):
     schema : dict
         The schema object, which is a dictionary with nested dictionaries and
         lists stored within it.
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
 
     Returns
     -------
@@ -417,8 +417,8 @@ def make_suffix_table(schema, suffixes, page_file=None, tablefmt="github"):
     ----------
     schema : dict
     suffixes : list of str
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
     tablefmt : str
 
     Returns
@@ -482,8 +482,8 @@ def make_metadata_table(schema, field_info, page_file=None, tablefmt="github"):
         and the second string is additional table-specific information
         about the metadata field that will be appended to the field's base
         definition from the schema.
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
     tablefmt : string, optional
         The target table format. The default is "github" (GitHub format).
 
@@ -564,8 +564,8 @@ def make_columns_table(schema, column_info, page_file=None, tablefmt="github"):
         and the second string is additional table-specific information
         about the column that will be appended to the column's base
         definition from the schema.
-    page_file : File object | None
-        path from file where this func is called to src/
+    page_file : MkDocs File object | None
+        The file where this macro is called, provided by the "page.file" variable.
     tablefmt : string, optional
         The target table format. The default is "github" (GitHub format).
 

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -542,7 +542,7 @@ def make_metadata_table(schema, field_info, relpath=None, tablefmt="github"):
     return table_str
 
 
-def make_columns_table(schema, column_info, tablefmt="github", relpath=None):
+def make_columns_table(schema, column_info, relpath=None, tablefmt="github"):
     """Produce columns table (markdown) based on requested fields.
 
     Parameters
@@ -558,10 +558,10 @@ def make_columns_table(schema, column_info, tablefmt="github", relpath=None):
         and the second string is additional table-specific information
         about the column that will be appended to the column's base
         definition from the schema.
-    tablefmt : string, optional
-        The target table format. The default is "github" (GitHub format).
     relpath : str | None
         path from file where this func is called to src/
+    tablefmt : string, optional
+        The target table format. The default is "github" (GitHub format).
 
     Returns
     -------

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -408,13 +408,15 @@ def make_entity_table(schema, tablefmt="github", **kwargs):
     return table_str
 
 
-def make_suffix_table(schema, suffixes, tablefmt="github"):
+def make_suffix_table(schema, suffixes, relpath=None, tablefmt="github"):
     """Produce suffix table (markdown) based on requested suffixes.
 
     Parameters
     ----------
     schema : dict
     suffixes : list of str
+    relpath : str | None
+        path from file where this func is called to src/
     tablefmt : str
 
     Returns
@@ -445,6 +447,9 @@ def make_suffix_table(schema, suffixes, tablefmt="github"):
         description = description.replace("\n\n", "<br>")
         # Otherwise a newline corresponds to a space
         description = description.replace("\n", " ")
+        # Spec internal links need to be replaced
+        if relpath is not None:
+            description = description.replace("PATH_TO_SRC", relpath)
 
         df.loc[suffix] = [suffix_info["name"], description]
 

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -56,7 +56,7 @@ def make_entity_definitions(schema):
     return text
 
 
-def make_glossary(schema):
+def make_glossary(schema, relpath):
     """Generate glossary.
 
     Parameters
@@ -64,6 +64,8 @@ def make_glossary(schema):
     schema : dict
         The schema object, which is a dictionary with nested dictionaries and
         lists stored within it.
+    relpath : str | None
+        path from file where this func is called to src/
 
     Returns
     -------
@@ -119,6 +121,9 @@ def make_glossary(schema):
         obj_desc = obj_desc.replace("\n\n", "<br>")
         # Otherwise a newline corresponds to a space
         obj_desc = obj_desc.replace("\n", " ")
+        # Spec internal links need to be replaced
+        if relpath is not None:
+            obj_desc = obj_desc.replace("PATH_TO_SRC", relpath)
 
         text += f'\n<a name="{obj_marker}"></a>'
         text += f"\n## {obj_key}\n\n"
@@ -545,6 +550,8 @@ def make_columns_table(schema, column_info, tablefmt="github", relpath=None):
         definition from the schema.
     tablefmt : string, optional
         The target table format. The default is "github" (GitHub format).
+    relpath : str | None
+        path from file where this func is called to src/
 
     Returns
     -------

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -56,7 +56,7 @@ def make_entity_definitions(schema):
     return text
 
 
-def make_glossary(schema, relpath=None):
+def make_glossary(schema, page_file=None):
     """Generate glossary.
 
     Parameters
@@ -64,7 +64,7 @@ def make_glossary(schema, relpath=None):
     schema : dict
         The schema object, which is a dictionary with nested dictionaries and
         lists stored within it.
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
 
     Returns
@@ -122,8 +122,8 @@ def make_glossary(schema, relpath=None):
         # Otherwise a newline corresponds to a space
         obj_desc = obj_desc.replace("\n", " ")
         # Spec internal links need to be replaced
-        if relpath is not None:
-            obj_desc = obj_desc.replace("SPEC_ROOT", relpath)
+        if page_file is not None:
+            obj_desc = obj_desc.replace("SPEC_ROOT", page_file)
 
         text += f'\n<a name="{obj_marker}"></a>'
         text += f"\n## {obj_key}\n\n"
@@ -408,14 +408,14 @@ def make_entity_table(schema, tablefmt="github", **kwargs):
     return table_str
 
 
-def make_suffix_table(schema, suffixes, relpath=None, tablefmt="github"):
+def make_suffix_table(schema, suffixes, page_file=None, tablefmt="github"):
     """Produce suffix table (markdown) based on requested suffixes.
 
     Parameters
     ----------
     schema : dict
     suffixes : list of str
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
     tablefmt : str
 
@@ -448,8 +448,8 @@ def make_suffix_table(schema, suffixes, relpath=None, tablefmt="github"):
         # Otherwise a newline corresponds to a space
         description = description.replace("\n", " ")
         # Spec internal links need to be replaced
-        if relpath is not None:
-            description = description.replace("SPEC_ROOT", relpath)
+        if page_file is not None:
+            description = description.replace("SPEC_ROOT", page_file)
 
         df.loc[suffix] = [suffix_info["name"], description]
 
@@ -462,7 +462,7 @@ def make_suffix_table(schema, suffixes, relpath=None, tablefmt="github"):
     return table_str
 
 
-def make_metadata_table(schema, field_info, relpath=None, tablefmt="github"):
+def make_metadata_table(schema, field_info, page_file=None, tablefmt="github"):
     """Produce metadata table (markdown) based on requested fields.
 
     Parameters
@@ -478,7 +478,7 @@ def make_metadata_table(schema, field_info, relpath=None, tablefmt="github"):
         and the second string is additional table-specific information
         about the metadata field that will be appended to the field's base
         definition from the schema.
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
     tablefmt : string, optional
         The target table format. The default is "github" (GitHub format).
@@ -532,8 +532,8 @@ def make_metadata_table(schema, field_info, relpath=None, tablefmt="github"):
         # Otherwise a newline corresponds to a space
         description = description.replace("\n", " ")
         # Spec internal links need to be replaced
-        if relpath is not None:
-            description = description.replace("SPEC_ROOT", relpath)
+        if page_file is not None:
+            description = description.replace("SPEC_ROOT", page_file)
 
         df.loc[field_name] = [requirement_info, type_string, description]
 
@@ -542,7 +542,7 @@ def make_metadata_table(schema, field_info, relpath=None, tablefmt="github"):
     return table_str
 
 
-def make_columns_table(schema, column_info, relpath=None, tablefmt="github"):
+def make_columns_table(schema, column_info, page_file=None, tablefmt="github"):
     """Produce columns table (markdown) based on requested fields.
 
     Parameters
@@ -558,7 +558,7 @@ def make_columns_table(schema, column_info, relpath=None, tablefmt="github"):
         and the second string is additional table-specific information
         about the column that will be appended to the column's base
         definition from the schema.
-    relpath : str | None
+    page_file : File object | None
         path from file where this func is called to src/
     tablefmt : string, optional
         The target table format. The default is "github" (GitHub format).
@@ -600,8 +600,8 @@ def make_columns_table(schema, column_info, relpath=None, tablefmt="github"):
 
         description = column_schema[field]["description"] + " " + description_addendum
 
-        if relpath is not None:
-            description = description.replace("SPEC_ROOT", relpath)
+        if page_file is not None:
+            description = description.replace("SPEC_ROOT", page_file)
 
         # Try to add info about valid values
         valid_values_str = utils.describe_valid_values(column_schema[field])

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -56,7 +56,7 @@ def make_entity_definitions(schema):
     return text
 
 
-def make_glossary(schema, relpath):
+def make_glossary(schema, relpath=None):
     """Generate glossary.
 
     Parameters

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -527,7 +527,7 @@ def make_metadata_table(schema, field_info, tablefmt="github"):
     return table_str
 
 
-def make_columns_table(schema, column_info, tablefmt="github"):
+def make_columns_table(schema, column_info, tablefmt="github", relpath=None):
     """Produce columns table (markdown) based on requested fields.
 
     Parameters
@@ -582,6 +582,9 @@ def make_columns_table(schema, column_info, tablefmt="github"):
         type_string = utils.resolve_metadata_type(column_schema[field])
 
         description = column_schema[field]["description"] + " " + description_addendum
+
+        if relpath is not None:
+            description = description.replace("REPLACEME", relpath)
 
         # Try to add info about valid values
         valid_values_str = utils.describe_valid_values(column_schema[field])

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -123,7 +123,7 @@ def make_glossary(schema, relpath=None):
         obj_desc = obj_desc.replace("\n", " ")
         # Spec internal links need to be replaced
         if relpath is not None:
-            obj_desc = obj_desc.replace("PATH_TO_SRC", relpath)
+            obj_desc = obj_desc.replace("SPEC_ROOT", relpath)
 
         text += f'\n<a name="{obj_marker}"></a>'
         text += f"\n## {obj_key}\n\n"
@@ -449,7 +449,7 @@ def make_suffix_table(schema, suffixes, relpath=None, tablefmt="github"):
         description = description.replace("\n", " ")
         # Spec internal links need to be replaced
         if relpath is not None:
-            description = description.replace("PATH_TO_SRC", relpath)
+            description = description.replace("SPEC_ROOT", relpath)
 
         df.loc[suffix] = [suffix_info["name"], description]
 
@@ -533,7 +533,7 @@ def make_metadata_table(schema, field_info, relpath=None, tablefmt="github"):
         description = description.replace("\n", " ")
         # Spec internal links need to be replaced
         if relpath is not None:
-            description = description.replace("PATH_TO_SRC", relpath)
+            description = description.replace("SPEC_ROOT", relpath)
 
         df.loc[field_name] = [requirement_info, type_string, description]
 
@@ -601,7 +601,7 @@ def make_columns_table(schema, column_info, tablefmt="github", relpath=None):
         description = column_schema[field]["description"] + " " + description_addendum
 
         if relpath is not None:
-            description = description.replace("PATH_TO_SRC", relpath)
+            description = description.replace("SPEC_ROOT", relpath)
 
         # Try to add info about valid values
         valid_values_str = utils.describe_valid_values(column_schema[field])

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -584,7 +584,7 @@ def make_columns_table(schema, column_info, tablefmt="github", relpath=None):
         description = column_schema[field]["description"] + " " + description_addendum
 
         if relpath is not None:
-            description = description.replace("REPLACEME", relpath)
+            description = description.replace("PATH_TO_SRC", relpath)
 
         # Try to add info about valid values
         valid_values_str = utils.describe_valid_values(column_schema[field])

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -462,7 +462,7 @@ def make_suffix_table(schema, suffixes, relpath=None, tablefmt="github"):
     return table_str
 
 
-def make_metadata_table(schema, field_info, tablefmt="github"):
+def make_metadata_table(schema, field_info, relpath=None, tablefmt="github"):
     """Produce metadata table (markdown) based on requested fields.
 
     Parameters
@@ -478,6 +478,8 @@ def make_metadata_table(schema, field_info, tablefmt="github"):
         and the second string is additional table-specific information
         about the metadata field that will be appended to the field's base
         definition from the schema.
+    relpath : str | None
+        path from file where this func is called to src/
     tablefmt : string, optional
         The target table format. The default is "github" (GitHub format).
 
@@ -529,6 +531,9 @@ def make_metadata_table(schema, field_info, tablefmt="github"):
         description = description.replace("\n\n", "<br>")
         # Otherwise a newline corresponds to a space
         description = description.replace("\n", " ")
+        # Spec internal links need to be replaced
+        if relpath is not None:
+            description = description.replace("PATH_TO_SRC", relpath)
 
         df.loc[field_name] = [requirement_info, type_string, description]
 

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -67,9 +67,7 @@ def test_make_glossary(schema_obj, schema_dir):
             # Are all objects objects?
             assert any([line.startswith(f'<a name="objects.{i}') for i in object_files])
             # Are rules loaded incorrectly?
-            assert not any(
-                [line.startswith(f'<a name="objects.{i}') for i in rules_only]
-            )
+            assert not any([line.startswith(f'<a name="objects.{i}') for i in rules_only])
 
 
 def test_make_filename_template(schema_obj, schema_dir):
@@ -154,9 +152,7 @@ def test_make_suffix_table(schema_obj):
         "cbv",
         "dwi",
     ]
-    suffix_table = render.make_suffix_table(
-        schema_obj, target_suffixes, page_file=test_file
-    )
+    suffix_table = render.make_suffix_table(schema_obj, target_suffixes, page_file=test_file)
 
     expected_names = [
         "Behavioral recording",
@@ -179,9 +175,7 @@ def test_make_metadata_table(schema_obj):
         "BIDSVersion": "required",
         "DatasetDOI": "optional",
     }
-    metadata_table = render.make_metadata_table(
-        schema_obj, target_metadata, page_file=test_file
-    )
+    metadata_table = render.make_metadata_table(schema_obj, target_metadata, page_file=test_file)
 
     metadata_tracking = list(target_metadata.keys())
 
@@ -208,9 +202,7 @@ def test_make_columns_table(schema_obj):
         "trial_type": "required",
         "units": "optional",
     }
-    columns_table = render.make_columns_table(
-        schema_obj, target_columns, page_file=test_file
-    )
+    columns_table = render.make_columns_table(schema_obj, target_columns, page_file=test_file)
 
     columns_tracking = list(target_columns.keys())
 

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -4,6 +4,14 @@ import os
 from schemacode import render
 
 
+class TestFile:
+    pass
+
+
+test_file = TestFile()
+test_file.src_path = os.sep.join(["try", "this", "dict"])
+
+
 def test_make_entity_definitions(schema_obj):
     """
     Test whether expected format strings are present.
@@ -53,13 +61,15 @@ def test_make_glossary(schema_obj, schema_dir):
                 rule_files.append(rule_base)
     rules_only = list(filter(lambda a: a not in object_files, rule_files))
 
-    glossary = render.make_glossary(schema_obj, page_file=".")
+    glossary = render.make_glossary(schema_obj, page_file=test_file)
     for line in glossary.split("\n"):
         if line.startswith('<a name="objects.'):
             # Are all objects objects?
             assert any([line.startswith(f'<a name="objects.{i}') for i in object_files])
             # Are rules loaded incorrectly?
-            assert not any([line.startswith(f'<a name="objects.{i}') for i in rules_only])
+            assert not any(
+                [line.startswith(f'<a name="objects.{i}') for i in rules_only]
+            )
 
 
 def test_make_filename_template(schema_obj, schema_dir):
@@ -144,7 +154,9 @@ def test_make_suffix_table(schema_obj):
         "cbv",
         "dwi",
     ]
-    suffix_table = render.make_suffix_table(schema_obj, target_suffixes, page_file=".")
+    suffix_table = render.make_suffix_table(
+        schema_obj, target_suffixes, page_file=test_file
+    )
 
     expected_names = [
         "Behavioral recording",
@@ -167,7 +179,9 @@ def test_make_metadata_table(schema_obj):
         "BIDSVersion": "required",
         "DatasetDOI": "optional",
     }
-    metadata_table = render.make_metadata_table(schema_obj, target_metadata, page_file=".")
+    metadata_table = render.make_metadata_table(
+        schema_obj, target_metadata, page_file=test_file
+    )
 
     metadata_tracking = list(target_metadata.keys())
 
@@ -194,7 +208,9 @@ def test_make_columns_table(schema_obj):
         "trial_type": "required",
         "units": "optional",
     }
-    columns_table = render.make_columns_table(schema_obj, target_columns, page_file=".")
+    columns_table = render.make_columns_table(
+        schema_obj, target_columns, page_file=test_file
+    )
 
     columns_tracking = list(target_columns.keys())
 

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -53,7 +53,7 @@ def test_make_glossary(schema_obj, schema_dir):
                 rule_files.append(rule_base)
     rules_only = list(filter(lambda a: a not in object_files, rule_files))
 
-    glossary = render.make_glossary(schema_obj)
+    glossary = render.make_glossary(schema_obj, relpath=None)
     for line in glossary.split("\n"):
         if line.startswith('<a name="objects.'):
             # Are all objects objects?

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -144,8 +144,7 @@ def test_make_suffix_table(schema_obj):
         "cbv",
         "dwi",
     ]
-    suffix_table = render.make_suffix_table(schema_obj, target_suffixes,
-                                            relpath=".")
+    suffix_table = render.make_suffix_table(schema_obj, target_suffixes, relpath=".")
 
     expected_names = [
         "Behavioral recording",

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -53,7 +53,7 @@ def test_make_glossary(schema_obj, schema_dir):
                 rule_files.append(rule_base)
     rules_only = list(filter(lambda a: a not in object_files, rule_files))
 
-    glossary = render.make_glossary(schema_obj, relpath=".")
+    glossary = render.make_glossary(schema_obj, page_file=".")
     for line in glossary.split("\n"):
         if line.startswith('<a name="objects.'):
             # Are all objects objects?
@@ -144,7 +144,7 @@ def test_make_suffix_table(schema_obj):
         "cbv",
         "dwi",
     ]
-    suffix_table = render.make_suffix_table(schema_obj, target_suffixes, relpath=".")
+    suffix_table = render.make_suffix_table(schema_obj, target_suffixes, page_file=".")
 
     expected_names = [
         "Behavioral recording",
@@ -167,7 +167,7 @@ def test_make_metadata_table(schema_obj):
         "BIDSVersion": "required",
         "DatasetDOI": "optional",
     }
-    metadata_table = render.make_metadata_table(schema_obj, target_metadata, relpath=".")
+    metadata_table = render.make_metadata_table(schema_obj, target_metadata, page_file=".")
 
     metadata_tracking = list(target_metadata.keys())
 
@@ -194,7 +194,7 @@ def test_make_columns_table(schema_obj):
         "trial_type": "required",
         "units": "optional",
     }
-    columns_table = render.make_columns_table(schema_obj, target_columns, relpath=".")
+    columns_table = render.make_columns_table(schema_obj, target_columns, page_file=".")
 
     columns_tracking = list(target_columns.keys())
 

--- a/tools/schemacode/schemacode/tests/test_render.py
+++ b/tools/schemacode/schemacode/tests/test_render.py
@@ -53,7 +53,7 @@ def test_make_glossary(schema_obj, schema_dir):
                 rule_files.append(rule_base)
     rules_only = list(filter(lambda a: a not in object_files, rule_files))
 
-    glossary = render.make_glossary(schema_obj, relpath=None)
+    glossary = render.make_glossary(schema_obj, relpath=".")
     for line in glossary.split("\n"):
         if line.startswith('<a name="objects.'):
             # Are all objects objects?
@@ -144,7 +144,8 @@ def test_make_suffix_table(schema_obj):
         "cbv",
         "dwi",
     ]
-    suffix_table = render.make_suffix_table(schema_obj, target_suffixes)
+    suffix_table = render.make_suffix_table(schema_obj, target_suffixes,
+                                            relpath=".")
 
     expected_names = [
         "Behavioral recording",
@@ -167,11 +168,11 @@ def test_make_metadata_table(schema_obj):
         "BIDSVersion": "required",
         "DatasetDOI": "optional",
     }
-    metadata_table = render.make_metadata_table(schema_obj, target_metadata).split("\n")
+    metadata_table = render.make_metadata_table(schema_obj, target_metadata, relpath=".")
 
     metadata_tracking = list(target_metadata.keys())
 
-    for line in metadata_table:
+    for line in metadata_table.split("\n"):
         for i in metadata_tracking:
             if i in line:
                 # Is the requirement level displayed correctly?
@@ -194,11 +195,11 @@ def test_make_columns_table(schema_obj):
         "trial_type": "required",
         "units": "optional",
     }
-    columns_table = render.make_columns_table(schema_obj, target_columns).split("\n")
+    columns_table = render.make_columns_table(schema_obj, target_columns, relpath=".")
 
     columns_tracking = list(target_columns.keys())
 
-    for line in columns_table:
+    for line in columns_table.split("\n"):
         for i in columns_tracking:
             if i in line:
                 # Is the requirement level displayed correctly?


### PR DESCRIPTION
**update** the new way works, see comments further below.

- closes #974 
- closes #1034
- closes #1011
- closes #1095

fixed for:

- [x] `env.macro(macros.make_glossary, "MACROS___make_glossary")`
- [x] `env.macro(macros.make_suffix_table, "MACROS___make_suffix_table")`
- [x] `env.macro(macros.make_metadata_table, "MACROS___make_metadata_table")`
- [x] `env.macro(macros.make_columns_table, "MACROS___make_columns_table")`

---

attempt to implement solution for #974 

This doesn't work as I expected, because (I think) two passes to render macros would be needed:

1. to paste a schema entry into a table
2. to change a link within that pasted table

Currently only step 1. happens, and step 2. remains unresolved, with the `{{ xxx }}` schema syntax in the table. I guess this was to be expected - do you have an idea how to circumvent this with the existing infrastructure @tsalo?

Another way I can think of is to make this "link fixing" a special citizen in the form of a python script that we run on the built files (after `mkdocs build`).