### PR TITLE
[SCHEMA] Add internal validation test for schema

### DIFF
--- a/tools/schemacode/schemacode/tests/test_rules.py
+++ b/tools/schemacode/schemacode/tests/test_rules.py
@@ -40,4 +40,3 @@ def test_rule_objects(schema_obj):
 
             for use in instance:
                 assert use in schema_obj["objects"][object_type].keys(), path
-

--- a/tools/schemacode/schemacode/tests/test_rules.py
+++ b/tools/schemacode/schemacode/tests/test_rules.py
@@ -1,0 +1,39 @@
+"""Simple validation tests on schema rules."""
+
+
+def _dict_key_lookup(_dict, key, path=[]):
+    """Look up any uses of a key in a nested dictionary.
+
+    Adapted from https://stackoverflow.com/a/60377584/2589328.
+    """
+    results = []
+    if isinstance(_dict, dict):
+        if key in _dict:
+            results.append((path+[key], _dict[key]))
+
+        for k, v in _dict.items():
+            results.extend(_dict_key_lookup(v, key, path= path+[k]))
+
+    elif isinstance(_dict, list):
+        for index, item in enumerate(_dict):
+            results.extend(_dict_key_lookup(item, key, path= path+[index]))
+
+    return results
+
+
+def test_rule_objects(schema_obj):
+    """Ensure that all objects referenced in the schema rules are defined in its object portion."""
+    object_types = list(schema_obj["objects"].keys())
+    for object_type in object_types:
+        type_instances_in_rules = _dict_key_lookup(schema_obj["rules"], object_type)
+        if not type_instances_in_rules:
+            continue
+
+        for type_instance in type_instances_in_rules:
+            path, instance = type_instance
+            if isinstance(instance, dict):
+                instance = list(instance.keys())
+
+            for use in instance:
+                assert use in schema_obj["objects"][object_type].keys(), path
+

--- a/tools/schemacode/schemacode/tests/test_rules.py
+++ b/tools/schemacode/schemacode/tests/test_rules.py
@@ -9,23 +9,27 @@ def _dict_key_lookup(_dict, key, path=[]):
     results = []
     if isinstance(_dict, dict):
         if key in _dict:
-            results.append((path+[key], _dict[key]))
+            results.append((path + [key], _dict[key]))
 
         for k, v in _dict.items():
-            results.extend(_dict_key_lookup(v, key, path= path+[k]))
+            results.extend(_dict_key_lookup(v, key, path=path + [k]))
 
     elif isinstance(_dict, list):
         for index, item in enumerate(_dict):
-            results.extend(_dict_key_lookup(item, key, path= path+[index]))
+            results.extend(_dict_key_lookup(item, key, path=path + [index]))
 
     return results
 
 
 def test_rule_objects(schema_obj):
-    """Ensure that all objects referenced in the schema rules are defined in its object portion."""
+    """Ensure that all objects referenced in the schema rules are defined in
+    its object portion.
+    """
     object_types = list(schema_obj["objects"].keys())
     for object_type in object_types:
-        type_instances_in_rules = _dict_key_lookup(schema_obj["rules"], object_type)
+        type_instances_in_rules = _dict_key_lookup(
+            schema_obj["rules"], object_type
+        )
         if not type_instances_in_rules:
             continue
 

--- a/tools/schemacode/schemacode/tests/test_rules.py
+++ b/tools/schemacode/schemacode/tests/test_rules.py
@@ -27,9 +27,7 @@ def test_rule_objects(schema_obj):
     """
     object_types = list(schema_obj["objects"].keys())
     for object_type in object_types:
-        type_instances_in_rules = _dict_key_lookup(
-            schema_obj["rules"], object_type
-        )
+        type_instances_in_rules = _dict_key_lookup(schema_obj["rules"], object_type)
         if not type_instances_in_rules:
             continue
 


### PR DESCRIPTION
References #1037.

Changes proposed:

- Add a test that checks that all objects referenced in the schema rules are also defined as schema objects.

To do:

- [ ] Add test for order of entity definitions in `objects/entities.yaml` (#1071).
