### PR TITLE
Start drafting validation rules for ASL data

### DIFF
--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -8,9 +8,11 @@ ASLLabelingDurationNiftiLength:
         The number of values for 'LabelingDuration' for this file does not match the 4th dimension of the NIfTI header.
         'LabelingDuration' is the total duration of the labeling pulse train, in seconds,
         corresponding to the temporal width of the labeling bolus for `(P)CASL`.
-        In case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`, a scalar must be specified.
+        In case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`, a scalar must be
+        specified.
         In case the control-label volumes (or deltam or cbf) have a different `LabelingDuration`,
-        an array of numbers must be specified, for which any `m0scan` in the timeseries has a `LabelingDuration` of zero.
+        an array of numbers must be specified, for which any `m0scan` in the timeseries has a `LabelingDuration` of
+        zero.
         In case an array of numbers is provided, its length should be equal to the number of volumes specified in
         `*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
     level: error
@@ -78,13 +80,15 @@ ASLFlipAngleASLContextLength:
 ASLPostLabelingDelayNiftiLength:
     code: POST_LABELING_DELAY_NOT_MATCHING_NIFTI
     description: |
-        The number of values for 'PostLabelingDelay' for this file does not match the 4th dimension of the NIfTI header.
+        The number of values for 'PostLabelingDelay' for this file does not match the 4th dimension of the NIfTI
+        header.
         'PostLabelingDelay' is the time, in seconds, after the end of the labeling (for (P)CASL) or middle of the
         labeling pulse (for PASL) until the middle of the excitation pulse applied to the imaging slab
         (for 3D acquisition) or first slice (for 2D acquisition).
         Can be a number (for a single-PLD time series) or an array of numbers (for multi-PLD and Look-Locker).
         In the latter case, the array of numbers contains the PLD of each volume (i.e. each 'control' and 'label')
-        in the acquisition order. Any image within the time-series without a PLD (e.g. an 'm0scan') is indicated by a zero.
+        in the acquisition order. Any image within the time-series without a PLD (e.g. an 'm0scan') is indicated by a
+        zero.
         Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
     level: error
     selectors:
@@ -166,7 +170,8 @@ ASLRepetitionTimePreparationASLContextLength:
 ASLBackgroundSuppressionNumberPulses:
     code: BACKGROUND_SUPPRESSION_PULSE_NUMBER_NOT_CONSISTENT
     description: |
-        The 'BackgroundSuppressionNumberPulses' field is not consistent with the length of 'BackgroundSuppressionPulseTime'.
+        The 'BackgroundSuppressionNumberPulses' field is not consistent with the length of
+        'BackgroundSuppressionPulseTime'.
         'BackgroundSuppressionNumberPulses' is the number of background suppression pulses used.
         Note that this excludes any effect of background suppression pulses applied before the labeling.
     level: warning

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -15,9 +15,9 @@ ASLLabelingDurationNiftiLength:
         `*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
     level: error
     selectors:
+    - suffix == "asl"
     - sidecar contains "LabelingDuration"
     - type(sidecar.LabelingDuration) == "array"
-    - suffix == "asl"
     checks:
     - data.shape[3] == sidecar.LabelingDuration.size
 
@@ -30,6 +30,7 @@ ASLContextConsistent:
     level: error
     selectors:
     - suffix == "asl"
+    - associated contains "aslcontext"
     checks:
     - data.shape[3] == associated["aslcontext"].shape[0]
 
@@ -46,9 +47,9 @@ ASLFlipAngleNiftiLength:
         volume timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
     level: error
     selectors:
+    - suffix == "asl"
     - sidecar contains "FlipAngle"
     - type(sidecar.FlipAngle) == "array"
-    - suffix == "asl"
     checks:
     - data.shape[3] == sidecar.FlipAngle.size
 
@@ -66,9 +67,10 @@ ASLFlipAngleASLContextLength:
        timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
     level: error
     selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
     - sidecar contains "FlipAngle"
     - type(sidecar.FlipAngle) == "array"
-    - suffix == "asl"
     checks:
     - associated["aslcontext"].shape[0] == sidecar.FlipAngle.size
 
@@ -86,9 +88,9 @@ ASLPostLabelingDelayNiftiLength:
         Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
     level: error
     selectors:
+    - suffix == "asl"
     - sidecar contains "PostLabelingDelay"
     - type(sidecar.PostLabelingDelay) == "array"
-    - suffix == "asl"
     checks:
     - data.shape[3] == sidecar.PostLabelingDelay.size
 
@@ -108,9 +110,10 @@ ASLPostLabelingDelayASLContextLength:
         Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
     level: error
     selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
     - sidecar contains "PostLabelingDelay"
     - type(sidecar.PostLabelingDelay) == "array"
-    - suffix == "asl"
     checks:
     - associated["aslcontext"].shape[0] == sidecar.PostLabelingDelay.size
 
@@ -132,9 +135,10 @@ ASLLabelingDurationASLContextLength:
         Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
     level: error
     selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
     - sidecar contains "LabelingDuration"
     - type(sidecar.LabelingDuration) == "array"
-    - suffix == "asl"
     checks:
     - associated["aslcontext"].shape[0] == sidecar.LabelingDuration.size
 
@@ -151,9 +155,10 @@ ASLRepetitionTimePreparationASLContextLength:
         volume timing is critical for interpretation of the data, such as in ASL.
     level: error
     selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
     - sidecar contains "RepetitionTimePreparation"
     - type(sidecar.RepetitionTimePreparation) == "array"
-    - suffix == "asl"
     checks:
     - associated["aslcontext"].shape[0] == sidecar.RepetitionTimePreparation.size
 
@@ -166,10 +171,10 @@ ASLBackgroundSuppressionNumberPulses:
         Note that this excludes any effect of background suppression pulses applied before the labeling.
     level: warning
     selectors:
+    - suffix == "asl"
     - sidecar contains "BackgroundSuppressionNumberPulses"
     - sidecar contains "BackgroundSuppressionPulseTime"
     - type(sidecar.BackgroundSuppressionPulseTime) == "array"
-    - suffix == "asl"
     checks:
     - sidecar.BackgroundSuppressionPulseTime.size == sidecar.BackgroundSuppressionNumberPulses
 
@@ -183,7 +188,24 @@ ASLTotalAcquiredVolumesASLContextLength:
         'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
     level: warning
     selectors:
-    - sidecar contains "TotalAcquiredVolumes"
     - suffix == "asl"
+    - associated contains "aslcontext"
+    - sidecar contains "TotalAcquiredVolumes"
     checks:
     - associated["aslcontext"].shape[0] == sidecar.TotalAcquiredVolumes
+
+# 196
+ASLEchoTimeASLContextLength:
+    code: ECHO_TIME_NOT_CONSISTENT
+    description: |
+        The number of values for 'EchoTime' for this file does not match number of volumes in the
+        'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+        'EchoTime' is the echo time (TE) for the acquisition, specified in seconds.
+    level: warning
+    selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
+    - sidecar contains "EchoTime"
+    - type(sidecar.EchoTime) == "array"
+    checks:
+    - associated["aslcontext"].shape[0] == sidecar.EchoTime.size

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -1,5 +1,98 @@
 # Rules for ASL data that are not defined in tables.
 ---
+
+# 157
+ASLLabelingDurationNiftiLength:
+    code: LABELING_DURATION_LENGTH_NOT_MATCHING_NIFTI
+    description: |
+        The number of values for 'LabelingDuration' for this file does not match the 4th dimension of the NIfTI header.
+        'LabelingDuration' is the total duration of the labeling pulse train, in seconds,
+        corresponding to the temporal width of the labeling bolus for `(P)CASL`.
+        In case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`, a scalar must be specified.
+        In case the control-label volumes (or deltam or cbf) have a different `LabelingDuration`,
+        an array of numbers must be specified, for which any `m0scan` in the timeseries has a `LabelingDuration` of zero.
+        In case an array of numbers is provided, its length should be equal to the number of volumes specified in
+        `*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
+    level: error
+    selectors:
+    - sidecar contains "LabelingDuration"
+    - type(sidecar.LabelingDuration) == "array"
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == sidecar.LabelingDuration.size
+
+# 165
+ASLContextConsistent:
+    code: ASLCONTEXT_TSV_NOT_CONSISTENT
+    description: |
+        The number of volumes in the '*_aslcontext.tsv' for this file does not match the number of
+        values in the NIfTI header.
+    level: error
+    selectors:
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == associated["aslcontext"].shape[0]
+
+# 168
+ASLFlipAngleNiftiLength:
+    code: FLIP_ANGLE_NOT_MATCHING_NIFTI
+    description: |
+        The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
+        'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
+        Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
+        The data type number may apply to files from any MRI modality concerned with a single value for this field,
+        or to the files in a file collection where the value of this field is iterated using the flip entity.
+        The data type array provides a value for each volume in a 4D dataset and should only be used when the
+        volume timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
+    level: error
+    selectors:
+    - sidecar contains "FlipAngle"
+    - type(sidecar.FlipAngle) == "array"
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == sidecar.FlipAngle.size
+
+# 172
+ASLFlipAngleASLContextLength:
+    code: FLIP_ANGLE_NOT_MATCHING_ASLCONTEXT_TSV
+    description: |
+       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
+       'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
+       Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
+       The data type number may apply to files from any MRI modality concerned with a single value for this field,
+       or to the files in a file collection where the value of this field is iterated using the flip entity.
+       The data type array provides a value for each volume in a 4D dataset and should only be used when the volume
+       timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
+    level: error
+    selectors:
+    - sidecar contains "FlipAngle"
+    - type(sidecar.FlipAngle) == "array"
+    - suffix == "asl"
+    checks:
+    - associated["aslcontext"].shape[0] == sidecar.FlipAngle.size
+
+# 173
+ASLPostLabelingDelayNiftiLength:
+    code: POST_LABELING_DELAY_NOT_MATCHING_NIFTI
+    description: |
+        The number of values for 'PostLabelingDelay' for this file does not match the 4th dimension of the NIfTI header.
+        'PostLabelingDelay' is the time, in seconds, after the end of the labeling (for (P)CASL) or middle of the
+        labeling pulse (for PASL) until the middle of the excitation pulse applied to the imaging slab
+        (for 3D acquisition) or first slice (for 2D acquisition).
+        Can be a number (for a single-PLD time series) or an array of numbers (for multi-PLD and Look-Locker).
+        In the latter case, the array of numbers contains the PLD of each volume (i.e. each 'control' and 'label')
+        in the acquisition order. Any image within the time-series without a PLD (e.g. an 'm0scan') is indicated by a zero.
+        Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
+    level: error
+    selectors:
+    - sidecar contains "PostLabelingDelay"
+    - type(sidecar.PostLabelingDelay) == "array"
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == sidecar.PostLabelingDelay.size
+
+# 174
 ASLPostLabelingDelayASLContextLength:
     code: POST_LABELING_DELAY_NOT_MATCHING_ASLCONTEXT_TSV
     description: |
@@ -21,6 +114,7 @@ ASLPostLabelingDelayASLContextLength:
     checks:
     - associated["aslcontext"].shape[0] == sidecar.PostLabelingDelay.size
 
+# 175
 ASLLabelingDurationASLContextLength:
     code: LABELLING_DURATION_NOT_MATCHING_ASLCONTEXT_TSV
     description: |
@@ -44,6 +138,7 @@ ASLLabelingDurationASLContextLength:
     checks:
     - associated["aslcontext"].shape[0] == sidecar.LabelingDuration.size
 
+# 177
 ASLRepetitionTimePreparationASLContextLength:
     code: REPETITIONTIMEPREPARATION_NOT_MATCHING_ASLCONTEXT_TSV
     description: |
@@ -62,87 +157,7 @@ ASLRepetitionTimePreparationASLContextLength:
     checks:
     - associated["aslcontext"].shape[0] == sidecar.RepetitionTimePreparation.size
 
-ASLTotalAcquiredVolumesASLContextLength:
-    code: TOTAL_ACQUIRED_VOLUMES_NOT_CONSISTENT
-    description: |
-        The number of values for 'TotalAcquiredVolumes' for this file does not match number of
-        volumes in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
-        'TotalAcquiredVolumes' is the original number of 3D volumes acquired for each volume defined in the
-        'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
-    level: warning
-    selectors:
-    - sidecar contains "TotalAcquiredVolumes"
-    - suffix == "asl"
-    checks:
-    - associated["aslcontext"].shape[0] == sidecar.TotalAcquiredVolumes
-
-ASLFlipAngleASLContextLength:
-    code: FLIP_ANGLE_NOT_MATCHING_ASLCONTEXT_TSV
-    description: |
-       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
-       'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
-       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-       Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
-       The data type number may apply to files from any MRI modality concerned with a single value for this field,
-       or to the files in a file collection where the value of this field is iterated using the flip entity.
-       The data type array provides a value for each volume in a 4D dataset and should only be used when the volume
-       timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
-    level: error
-    selectors:
-    - sidecar contains "FlipAngle"
-    - type(sidecar.FlipAngle) == "array"
-    - suffix == "asl"
-    checks:
-    - associated["aslcontext"].shape[0] == sidecar.FlipAngle.size
-
-ASLFlipAngleNiftiLength:
-    code: FLIP_ANGLE_NOT_MATCHING_NIFTI
-    description: |
-        The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
-        'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-        Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
-        The data type number may apply to files from any MRI modality concerned with a single value for this field,
-        or to the files in a file collection where the value of this field is iterated using the flip entity.
-        The data type array provides a value for each volume in a 4D dataset and should only be used when the
-        volume timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
-    level: error
-    selectors:
-    - sidecar contains "FlipAngle"
-    - type(sidecar.FlipAngle) == "array"
-    - suffix == "asl"
-    checks:
-    - data.shape[3] == sidecar.FlipAngle.size
-
-ASLPostLabelingDelayNiftiLength:
-    code: POST_LABELING_DELAY_NOT_MATCHING_NIFTI
-    description: |
-        The number of values for 'PostLabelingDelay' for this file does not match the 4th dimension of the NIfTI header.
-        'PostLabelingDelay' is the time, in seconds, after the end of the labeling (for (P)CASL) or middle of the
-        labeling pulse (for PASL) until the middle of the excitation pulse applied to the imaging slab
-        (for 3D acquisition) or first slice (for 2D acquisition).
-        Can be a number (for a single-PLD time series) or an array of numbers (for multi-PLD and Look-Locker).
-        In the latter case, the array of numbers contains the PLD of each volume (i.e. each 'control' and 'label')
-        in the acquisition order. Any image within the time-series without a PLD (e.g. an 'm0scan') is indicated by a zero.
-        Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
-    level: error
-    selectors:
-    - sidecar contains "PostLabelingDelay"
-    - type(sidecar.PostLabelingDelay) == "array"
-    - suffix == "asl"
-    checks:
-    - data.shape[3] == sidecar.PostLabelingDelay.size
-
-ASLContextConsistent:
-    code: ASLCONTEXT_TSV_NOT_CONSISTENT
-    description: |
-        The number of volumes in the '*_aslcontext.tsv' for this file does not match the number of
-        values in the NIfTI header.
-    level: error
-    selectors:
-    - suffix == "asl"
-    checks:
-    - data.shape[3] == associated["aslcontext"].shape[0]
-
+# 180
 ASLBackgroundSuppressionNumberPulses:
     code: BACKGROUND_SUPPRESSION_PULSE_NUMBER_NOT_CONSISTENT
     description: |
@@ -158,21 +173,17 @@ ASLBackgroundSuppressionNumberPulses:
     checks:
     - sidecar.BackgroundSuppressionPulseTime.size == sidecar.BackgroundSuppressionNumberPulses
 
-ASLLabelingDurationNiftiLength:
-    code: LABELING_DURATION_LENGTH_NOT_MATCHING_NIFTI
+# 181
+ASLTotalAcquiredVolumesASLContextLength:
+    code: TOTAL_ACQUIRED_VOLUMES_NOT_CONSISTENT
     description: |
-        The number of values for 'LabelingDuration' for this file does not match the 4th dimension of the NIfTI header.
-        'LabelingDuration' is the total duration of the labeling pulse train, in seconds,
-        corresponding to the temporal width of the labeling bolus for `(P)CASL`.
-        In case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`, a scalar must be specified.
-        In case the control-label volumes (or deltam or cbf) have a different `LabelingDuration`,
-        an array of numbers must be specified, for which any `m0scan` in the timeseries has a `LabelingDuration` of zero.
-        In case an array of numbers is provided, its length should be equal to the number of volumes specified in
-        `*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
-    level: error
+        The number of values for 'TotalAcquiredVolumes' for this file does not match number of
+        volumes in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+        'TotalAcquiredVolumes' is the original number of 3D volumes acquired for each volume defined in the
+        'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+    level: warning
     selectors:
-    - sidecar contains "LabelingDuration"
-    - type(sidecar.LabelingDuration) == "array"
+    - sidecar contains "TotalAcquiredVolumes"
     - suffix == "asl"
     checks:
-    - data.shape[3] == sidecar.LabelingDuration.size
+    - associated["aslcontext"].shape[0] == sidecar.TotalAcquiredVolumes

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -19,7 +19,7 @@ ASLLabelingDurationNiftiLength:
     selectors:
     - suffix == "asl"
     - sidecar contains "LabelingDuration"
-    - type(sidecar.LabelingDuration) == "array"
+    - type(sidecar.LabelingDuration) == "seq"
     checks:
     - nifti_header.pixdim[4] == sidecar.LabelingDuration.size
 
@@ -51,7 +51,7 @@ ASLFlipAngleNiftiLength:
     selectors:
     - suffix == "asl"
     - sidecar contains "FlipAngle"
-    - type(sidecar.FlipAngle) == "array"
+    - type(sidecar.FlipAngle) == "seq"
     checks:
     - nifti_header.pixdim[4] == sidecar.FlipAngle.size
 
@@ -72,7 +72,7 @@ ASLFlipAngleASLContextLength:
     - suffix == "asl"
     - associated contains "aslcontext"
     - sidecar contains "FlipAngle"
-    - type(sidecar.FlipAngle) == "array"
+    - type(sidecar.FlipAngle) == "seq"
     checks:
     - aslcontext.n_rows == sidecar.FlipAngle.size
 
@@ -94,7 +94,7 @@ ASLPostLabelingDelayNiftiLength:
     selectors:
     - suffix == "asl"
     - sidecar contains "PostLabelingDelay"
-    - type(sidecar.PostLabelingDelay) == "array"
+    - type(sidecar.PostLabelingDelay) == "seq"
     checks:
     - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.size
 
@@ -117,7 +117,7 @@ ASLPostLabelingDelayASLContextLength:
     - suffix == "asl"
     - associated contains "aslcontext"
     - sidecar contains "PostLabelingDelay"
-    - type(sidecar.PostLabelingDelay) == "array"
+    - type(sidecar.PostLabelingDelay) == "seq"
     checks:
     - aslcontext.n_rows == sidecar.PostLabelingDelay.size
 
@@ -142,7 +142,7 @@ ASLLabelingDurationASLContextLength:
     - suffix == "asl"
     - associated contains "aslcontext"
     - sidecar contains "LabelingDuration"
-    - type(sidecar.LabelingDuration) == "array"
+    - type(sidecar.LabelingDuration) == "seq"
     checks:
     - aslcontext.n_rows == sidecar.LabelingDuration.size
 
@@ -162,7 +162,7 @@ ASLRepetitionTimePreparationASLContextLength:
     - suffix == "asl"
     - associated contains "aslcontext"
     - sidecar contains "RepetitionTimePreparation"
-    - type(sidecar.RepetitionTimePreparation) == "array"
+    - type(sidecar.RepetitionTimePreparation) == "seq"
     checks:
     - aslcontext.n_rows == sidecar.RepetitionTimePreparation.size
 
@@ -179,7 +179,7 @@ ASLBackgroundSuppressionNumberPulses:
     - suffix == "asl"
     - sidecar contains "BackgroundSuppressionNumberPulses"
     - sidecar contains "BackgroundSuppressionPulseTime"
-    - type(sidecar.BackgroundSuppressionPulseTime) == "array"
+    - type(sidecar.BackgroundSuppressionPulseTime) == "seq"
     checks:
     - sidecar.BackgroundSuppressionPulseTime.size == sidecar.BackgroundSuppressionNumberPulses
 
@@ -211,7 +211,7 @@ ASLEchoTimeASLContextLength:
     - suffix == "asl"
     - associated contains "aslcontext"
     - sidecar contains "EchoTime"
-    - type(sidecar.EchoTime) == "array"
+    - type(sidecar.EchoTime) == "seq"
     checks:
     - aslcontext.n_rows == sidecar.EchoTime.size
 

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -34,7 +34,7 @@ ASLContextConsistent:
     - suffix == "asl"
     - associated contains "aslcontext"
     checks:
-    - data.shape[3] == associated["aslcontext"].shape[0]
+    - nifti_header.pixdim[4] == aslcontext.n_rows
 
 # 168
 ASLFlipAngleNiftiLength:

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -1,0 +1,178 @@
+# Rules for ASL data that are not defined in tables.
+---
+ASLPostLabelingDelayASLContextLength:
+    code: POST_LABELING_DELAY_NOT_MATCHING_ASLCONTEXT_TSV
+    description: |
+        The number of values for 'PostLabelingDelay' for this file does not match the number of volumes
+        in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+        'PostLabelingDelay' is the time, in seconds, after the end of the labeling (for (P)CASL) or
+        middle of the labeling pulse (for PASL) until the middle of the excitation pulse applied to
+        the imaging slab (for 3D acquisition) or first slice (for 2D acquisition).
+        Can be a number (for a single-PLD time series) or an array of numbers (for multi-PLD and Look-Locker).
+        In the latter case, the array of numbers contains the PLD of each volume (i.e. each 'control' and 'label')
+        in the acquisition order.
+        Any image within the time-series without a PLD (e.g. an 'm0scan') is indicated by a zero.
+        Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
+    level: error
+    selectors:
+    - sidecar contains "PostLabelingDelay"
+    - type(sidecar.PostLabelingDelay) == "array"
+    - suffix == "asl"
+    checks:
+    - associated["aslcontext"].shape[0] == sidecar.PostLabelingDelay.size
+
+ASLLabelingDurationASLContextLength:
+    code: LABELLING_DURATION_NOT_MATCHING_ASLCONTEXT_TSV
+    description: |
+        The number of values for 'LabelingDuration' for this file does not match the number of volumes
+        in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+        'LabelingDuration' is the total duration of the labeling pulse train, in seconds,
+        corresponding to the temporal width of the labeling bolus for `(P)CASL`.
+        In case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`,
+        a scalar must be specified.
+        In case the control-label volumes (or deltam or cbf) have a different `LabelingDuration`,
+        an array of numbers must be specified, for which any `m0scan` in the timeseries has a
+        `LabelingDuration` of zero.
+        In case an array of numbers is provided, its length should be equal to the number of volumes
+        specified in `*_aslcontext.tsv`.
+        Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
+    level: error
+    selectors:
+    - sidecar contains "LabelingDuration"
+    - type(sidecar.LabelingDuration) == "array"
+    - suffix == "asl"
+    checks:
+    - associated["aslcontext"].shape[0] == sidecar.LabelingDuration.size
+
+ASLRepetitionTimePreparationASLContextLength:
+    code: REPETITIONTIMEPREPARATION_NOT_MATCHING_ASLCONTEXT_TSV
+    description: |
+        The number of values of 'RepetitionTimePreparation' for this file does not match the number of
+        volumes in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+        'RepetitionTimePreparation' is the interval, in seconds, that it takes a preparation pulse block to
+        re-appear at the beginning of the succeeding (essentially identical) pulse sequence block.
+        The data type number may apply to files from any MRI modality concerned with a single value for this field.
+        The data type array provides a value for each volume in a 4D dataset and should only be used when the
+        volume timing is critical for interpretation of the data, such as in ASL.
+    level: error
+    selectors:
+    - sidecar contains "RepetitionTimePreparation"
+    - type(sidecar.RepetitionTimePreparation) == "array"
+    - suffix == "asl"
+    checks:
+    - associated["aslcontext"].shape[0] == sidecar.RepetitionTimePreparation.size
+
+ASLTotalAcquiredVolumesASLContextLength:
+    code: TOTAL_ACQUIRED_VOLUMES_NOT_CONSISTENT
+    description: |
+        The number of values for 'TotalAcquiredVolumes' for this file does not match number of
+        volumes in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+        'TotalAcquiredVolumes' is the original number of 3D volumes acquired for each volume defined in the
+        'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+    level: error
+    selectors:
+    - sidecar contains "TotalAcquiredVolumes"
+    - suffix == "asl"
+    checks:
+    - associated["aslcontext"].shape[0] == sidecar.TotalAcquiredVolumes
+
+ASLFlipAngleASLContextLength:
+    code: FLIP_ANGLE_NOT_MATCHING_ASLCONTEXT_TSV
+    description: |
+       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
+       'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
+       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
+       Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
+       The data type number may apply to files from any MRI modality concerned with a single value for this field,
+       or to the files in a file collection where the value of this field is iterated using the flip entity.
+       The data type array provides a value for each volume in a 4D dataset and should only be used when the volume
+       timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
+    level: error
+    selectors:
+    - sidecar contains "FlipAngle"
+    - type(sidecar.FlipAngle) == "array"
+    - suffix == "asl"
+    checks:
+    - associated["aslcontext"].shape[0] == sidecar.FlipAngle.size
+
+ASLFlipAngleNiftiLength:
+    code: FLIP_ANGLE_NOT_MATCHING_NIFTI
+    description: |
+        The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
+        'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
+        Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
+        The data type number may apply to files from any MRI modality concerned with a single value for this field,
+        or to the files in a file collection where the value of this field is iterated using the flip entity.
+        The data type array provides a value for each volume in a 4D dataset and should only be used when the
+        volume timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
+    level: error
+    selectors:
+    - sidecar contains "FlipAngle"
+    - type(sidecar.FlipAngle) == "array"
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == sidecar.FlipAngle.size
+
+ASLPostLabelingDelayNiftiLength:
+    code: POST_LABELING_DELAY_NOT_MATCHING_NIFTI
+    description: |
+        The number of values for 'PostLabelingDelay' for this file does not match the 4th dimension of the NIfTI header.
+        'PostLabelingDelay' is the time, in seconds, after the end of the labeling (for (P)CASL) or middle of the
+        labeling pulse (for PASL) until the middle of the excitation pulse applied to the imaging slab
+        (for 3D acquisition) or first slice (for 2D acquisition).
+        Can be a number (for a single-PLD time series) or an array of numbers (for multi-PLD and Look-Locker).
+        In the latter case, the array of numbers contains the PLD of each volume (i.e. each 'control' and 'label')
+        in the acquisition order. Any image within the time-series without a PLD (e.g. an 'm0scan') is indicated by a zero.
+        Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
+    level: error
+    selectors:
+    - sidecar contains "PostLabelingDelay"
+    - type(sidecar.PostLabelingDelay) == "array"
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == sidecar.PostLabelingDelay.size
+
+ASLContextConsistent:
+    code: ASLCONTEXT_TSV_NOT_CONSISTENT
+    description: |
+        The number of volumes in the '*_aslcontext.tsv' for this file does not match the number of
+        values in the NIfTI header.
+    level: error
+    selectors:
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == associated["aslcontext"].shape[0]
+
+ASLBackgroundSuppressionNumberPulses:
+    code: BACKGROUND_SUPPRESSION_PULSE_NUMBER_NOT_CONSISTENT
+    description: |
+        The 'BackgroundSuppressionNumberPulses' field is not consistent with the length of 'BackgroundSuppressionPulseTime'.
+        'BackgroundSuppressionNumberPulses' is the number of background suppression pulses used.
+        Note that this excludes any effect of background suppression pulses applied before the labeling.
+    level: warning
+    selectors:
+    - sidecar contains "BackgroundSuppressionNumberPulses"
+    - sidecar contains "BackgroundSuppressionPulseTime"
+    - type(sidecar.BackgroundSuppressionPulseTime) == "array"
+    - suffix == "asl"
+    checks:
+    - sidecar.BackgroundSuppressionPulseTime.size == sidecar.BackgroundSuppressionNumberPulses
+
+ASLLabelingDurationNiftiLength:
+    code: LABELING_DURATION_LENGTH_NOT_MATCHING_NIFTI
+    description: |
+        The number of values for 'LabelingDuration' for this file does not match the 4th dimension of the NIfTI header.
+        'LabelingDuration' is the total duration of the labeling pulse train, in seconds,
+        corresponding to the temporal width of the labeling bolus for `(P)CASL`.
+        In case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`, a scalar must be specified.
+        In case the control-label volumes (or deltam or cbf) have a different `LabelingDuration`,
+        an array of numbers must be specified, for which any `m0scan` in the timeseries has a `LabelingDuration` of zero.
+        In case an array of numbers is provided, its length should be equal to the number of volumes specified in
+        `*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
+    level: error
+    selectors:
+    - sidecar contains "LabelingDuration"
+    - type(sidecar.LabelingDuration) == "array"
+    - suffix == "asl"
+    checks:
+    - data.shape[3] == sidecar.LabelingDuration.size

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -21,7 +21,7 @@ ASLLabelingDurationNiftiLength:
     - sidecar contains "LabelingDuration"
     - type(sidecar.LabelingDuration) == "array"
     checks:
-    - data.shape[3] == sidecar.LabelingDuration.size
+    - nifti_header.pixdim[4] == sidecar.LabelingDuration.size
 
 # 165
 ASLContextConsistent:
@@ -53,7 +53,7 @@ ASLFlipAngleNiftiLength:
     - sidecar contains "FlipAngle"
     - type(sidecar.FlipAngle) == "array"
     checks:
-    - data.shape[3] == sidecar.FlipAngle.size
+    - nifti_header.pixdim[4] == sidecar.FlipAngle.size
 
 # 172
 ASLFlipAngleASLContextLength:
@@ -74,7 +74,7 @@ ASLFlipAngleASLContextLength:
     - sidecar contains "FlipAngle"
     - type(sidecar.FlipAngle) == "array"
     checks:
-    - associated["aslcontext"].shape[0] == sidecar.FlipAngle.size
+    - associated["aslcontext"].n_rows == sidecar.FlipAngle.size
 
 # 173
 ASLPostLabelingDelayNiftiLength:
@@ -96,7 +96,7 @@ ASLPostLabelingDelayNiftiLength:
     - sidecar contains "PostLabelingDelay"
     - type(sidecar.PostLabelingDelay) == "array"
     checks:
-    - data.shape[3] == sidecar.PostLabelingDelay.size
+    - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.size
 
 # 174
 ASLPostLabelingDelayASLContextLength:
@@ -119,7 +119,7 @@ ASLPostLabelingDelayASLContextLength:
     - sidecar contains "PostLabelingDelay"
     - type(sidecar.PostLabelingDelay) == "array"
     checks:
-    - associated["aslcontext"].shape[0] == sidecar.PostLabelingDelay.size
+    - associated["aslcontext"].n_rows == sidecar.PostLabelingDelay.size
 
 # 175
 ASLLabelingDurationASLContextLength:
@@ -144,7 +144,7 @@ ASLLabelingDurationASLContextLength:
     - sidecar contains "LabelingDuration"
     - type(sidecar.LabelingDuration) == "array"
     checks:
-    - associated["aslcontext"].shape[0] == sidecar.LabelingDuration.size
+    - associated["aslcontext"].n_rows == sidecar.LabelingDuration.size
 
 # 177
 ASLRepetitionTimePreparationASLContextLength:
@@ -164,7 +164,7 @@ ASLRepetitionTimePreparationASLContextLength:
     - sidecar contains "RepetitionTimePreparation"
     - type(sidecar.RepetitionTimePreparation) == "array"
     checks:
-    - associated["aslcontext"].shape[0] == sidecar.RepetitionTimePreparation.size
+    - associated["aslcontext"].n_rows == sidecar.RepetitionTimePreparation.size
 
 # 180
 ASLBackgroundSuppressionNumberPulses:
@@ -197,7 +197,7 @@ ASLTotalAcquiredVolumesASLContextLength:
     - associated contains "aslcontext"
     - sidecar contains "TotalAcquiredVolumes"
     checks:
-    - associated["aslcontext"].shape[0] == sidecar.TotalAcquiredVolumes
+    - associated["aslcontext"].n_rows == sidecar.TotalAcquiredVolumes
 
 # 196
 ASLEchoTimeASLContextLength:
@@ -213,7 +213,7 @@ ASLEchoTimeASLContextLength:
     - sidecar contains "EchoTime"
     - type(sidecar.EchoTime) == "array"
     checks:
-    - associated["aslcontext"].shape[0] == sidecar.EchoTime.size
+    - associated["aslcontext"].n_rows == sidecar.EchoTime.size
 
 # 198
 ASLM0TypeAbsentScan:

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -32,7 +32,7 @@ ASLContextConsistent:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     checks:
     - nifti_header.pixdim[4] == aslcontext.n_rows
 
@@ -70,7 +70,7 @@ ASLFlipAngleASLContextLength:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - sidecar contains "FlipAngle"
     - type(sidecar.FlipAngle) == "seq"
     checks:
@@ -115,7 +115,7 @@ ASLPostLabelingDelayASLContextLength:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - sidecar contains "PostLabelingDelay"
     - type(sidecar.PostLabelingDelay) == "seq"
     checks:
@@ -140,7 +140,7 @@ ASLLabelingDurationASLContextLength:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - sidecar contains "LabelingDuration"
     - type(sidecar.LabelingDuration) == "seq"
     checks:
@@ -160,7 +160,7 @@ ASLRepetitionTimePreparationASLContextLength:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - sidecar contains "RepetitionTimePreparation"
     - type(sidecar.RepetitionTimePreparation) == "seq"
     checks:
@@ -194,7 +194,7 @@ ASLTotalAcquiredVolumesASLContextLength:
     level: warning
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - sidecar contains "TotalAcquiredVolumes"
     checks:
     - aslcontext.n_rows == sidecar.TotalAcquiredVolumes
@@ -209,7 +209,7 @@ ASLEchoTimeASLContextLength:
     level: warning
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - sidecar contains "EchoTime"
     - type(sidecar.EchoTime) == "seq"
     checks:
@@ -225,8 +225,8 @@ ASLM0TypeAbsentScan:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
-    - associated contains "m0scan"
+    - associations contains "aslcontext"
+    - associations contains "m0scan"
     checks:
     - sidecar.M0Type != "absent"
 
@@ -239,7 +239,7 @@ ASLM0TypeAbsentASLContext:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - aslcontext.volume_type contains "m0scan"
     checks:
     - sidecar.M0Type != "absent"
@@ -253,7 +253,7 @@ ASLM0TypeIncorrect:
     level: error
     selectors:
     - suffix == "asl"
-    - associated contains "aslcontext"
+    - associations contains "aslcontext"
     - sidecar.M0Type == "separate"
     checks:
-    - associated contains "m0scan"
+    - associations contains "m0scan"

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -19,7 +19,7 @@ ASLLabelingDurationNiftiLength:
     selectors:
     - suffix == "asl"
     - sidecar contains "LabelingDuration"
-    - type(sidecar.LabelingDuration) == "seq"
+    - type(sidecar.LabelingDuration) == "array"
     checks:
     - nifti_header.pixdim[4] == sidecar.LabelingDuration.size
 
@@ -51,7 +51,7 @@ ASLFlipAngleNiftiLength:
     selectors:
     - suffix == "asl"
     - sidecar contains "FlipAngle"
-    - type(sidecar.FlipAngle) == "seq"
+    - type(sidecar.FlipAngle) == "array"
     checks:
     - nifti_header.pixdim[4] == sidecar.FlipAngle.size
 
@@ -72,7 +72,7 @@ ASLFlipAngleASLContextLength:
     - suffix == "asl"
     - associations contains "aslcontext"
     - sidecar contains "FlipAngle"
-    - type(sidecar.FlipAngle) == "seq"
+    - type(sidecar.FlipAngle) == "array"
     checks:
     - aslcontext.n_rows == sidecar.FlipAngle.size
 
@@ -94,7 +94,7 @@ ASLPostLabelingDelayNiftiLength:
     selectors:
     - suffix == "asl"
     - sidecar contains "PostLabelingDelay"
-    - type(sidecar.PostLabelingDelay) == "seq"
+    - type(sidecar.PostLabelingDelay) == "array"
     checks:
     - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.size
 
@@ -117,7 +117,7 @@ ASLPostLabelingDelayASLContextLength:
     - suffix == "asl"
     - associations contains "aslcontext"
     - sidecar contains "PostLabelingDelay"
-    - type(sidecar.PostLabelingDelay) == "seq"
+    - type(sidecar.PostLabelingDelay) == "array"
     checks:
     - aslcontext.n_rows == sidecar.PostLabelingDelay.size
 
@@ -142,7 +142,7 @@ ASLLabelingDurationASLContextLength:
     - suffix == "asl"
     - associations contains "aslcontext"
     - sidecar contains "LabelingDuration"
-    - type(sidecar.LabelingDuration) == "seq"
+    - type(sidecar.LabelingDuration) == "array"
     checks:
     - aslcontext.n_rows == sidecar.LabelingDuration.size
 
@@ -162,7 +162,7 @@ ASLRepetitionTimePreparationASLContextLength:
     - suffix == "asl"
     - associations contains "aslcontext"
     - sidecar contains "RepetitionTimePreparation"
-    - type(sidecar.RepetitionTimePreparation) == "seq"
+    - type(sidecar.RepetitionTimePreparation) == "array"
     checks:
     - aslcontext.n_rows == sidecar.RepetitionTimePreparation.size
 
@@ -179,7 +179,7 @@ ASLBackgroundSuppressionNumberPulses:
     - suffix == "asl"
     - sidecar contains "BackgroundSuppressionNumberPulses"
     - sidecar contains "BackgroundSuppressionPulseTime"
-    - type(sidecar.BackgroundSuppressionPulseTime) == "seq"
+    - type(sidecar.BackgroundSuppressionPulseTime) == "array"
     checks:
     - sidecar.BackgroundSuppressionPulseTime.size == sidecar.BackgroundSuppressionNumberPulses
 
@@ -211,7 +211,7 @@ ASLEchoTimeASLContextLength:
     - suffix == "asl"
     - associations contains "aslcontext"
     - sidecar contains "EchoTime"
-    - type(sidecar.EchoTime) == "seq"
+    - type(sidecar.EchoTime) == "array"
     checks:
     - aslcontext.n_rows == sidecar.EchoTime.size
 

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -214,3 +214,46 @@ ASLEchoTimeASLContextLength:
     - type(sidecar.EchoTime) == "array"
     checks:
     - associated["aslcontext"].shape[0] == sidecar.EchoTime.size
+
+# 198
+ASLM0TypeAbsentScan:
+    code: M0Type_SET_INCORRECTLY_TO_ABSENT
+    description: |
+        You defined M0Type as 'absent' while including a separate '*_m0scan.nii[.gz]' and
+        '*_m0scan.json', or defining the 'M0Estimate' field.
+        This is not allowed, please check that this field are filled correctly.
+    level: error
+    selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
+    - associated contains "m0scan"
+    checks:
+    - sidecar.M0Type != "absent"
+
+# 199
+ASLM0TypeAbsentASLContext:
+    code: M0Type_SET_INCORRECTLY_TO_ABSENT_IN_ASLCONTEXT
+    description: |
+        You defined M0Type as 'absent' while including an m0scan volume within the '*_aslcontext.tsv'.
+        This is not allowed, please check that this field are filled correctly.
+    level: error
+    selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
+    - associated["aslcontext"]["volume_type"] contains "m0scan"
+    checks:
+    - sidecar.M0Type != "absent"
+
+# 202
+ASLM0TypeIncorrect:
+    code: M0Type_SET_INCORRECTLY
+    description: |
+        M0Type was not defined correctly.
+        If 'M0Type' is equal to 'separate', the dataset should include a *_m0scan.nii[.gz] and *_m0scan.json file.
+    level: error
+    selectors:
+    - suffix == "asl"
+    - associated contains "aslcontext"
+    - sidecar.M0Type == "separate"
+    checks:
+    - associated contains "m0scan"

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -69,7 +69,7 @@ ASLTotalAcquiredVolumesASLContextLength:
         volumes in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
         'TotalAcquiredVolumes' is the original number of 3D volumes acquired for each volume defined in the
         'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
-    level: error
+    level: warning
     selectors:
     - sidecar contains "TotalAcquiredVolumes"
     - suffix == "asl"

--- a/src/schema/rules/sidecars/asl_validation.yaml
+++ b/src/schema/rules/sidecars/asl_validation.yaml
@@ -74,7 +74,7 @@ ASLFlipAngleASLContextLength:
     - sidecar contains "FlipAngle"
     - type(sidecar.FlipAngle) == "array"
     checks:
-    - associated["aslcontext"].n_rows == sidecar.FlipAngle.size
+    - aslcontext.n_rows == sidecar.FlipAngle.size
 
 # 173
 ASLPostLabelingDelayNiftiLength:
@@ -119,7 +119,7 @@ ASLPostLabelingDelayASLContextLength:
     - sidecar contains "PostLabelingDelay"
     - type(sidecar.PostLabelingDelay) == "array"
     checks:
-    - associated["aslcontext"].n_rows == sidecar.PostLabelingDelay.size
+    - aslcontext.n_rows == sidecar.PostLabelingDelay.size
 
 # 175
 ASLLabelingDurationASLContextLength:
@@ -144,7 +144,7 @@ ASLLabelingDurationASLContextLength:
     - sidecar contains "LabelingDuration"
     - type(sidecar.LabelingDuration) == "array"
     checks:
-    - associated["aslcontext"].n_rows == sidecar.LabelingDuration.size
+    - aslcontext.n_rows == sidecar.LabelingDuration.size
 
 # 177
 ASLRepetitionTimePreparationASLContextLength:
@@ -164,7 +164,7 @@ ASLRepetitionTimePreparationASLContextLength:
     - sidecar contains "RepetitionTimePreparation"
     - type(sidecar.RepetitionTimePreparation) == "array"
     checks:
-    - associated["aslcontext"].n_rows == sidecar.RepetitionTimePreparation.size
+    - aslcontext.n_rows == sidecar.RepetitionTimePreparation.size
 
 # 180
 ASLBackgroundSuppressionNumberPulses:
@@ -197,7 +197,7 @@ ASLTotalAcquiredVolumesASLContextLength:
     - associated contains "aslcontext"
     - sidecar contains "TotalAcquiredVolumes"
     checks:
-    - associated["aslcontext"].n_rows == sidecar.TotalAcquiredVolumes
+    - aslcontext.n_rows == sidecar.TotalAcquiredVolumes
 
 # 196
 ASLEchoTimeASLContextLength:
@@ -213,7 +213,7 @@ ASLEchoTimeASLContextLength:
     - sidecar contains "EchoTime"
     - type(sidecar.EchoTime) == "array"
     checks:
-    - associated["aslcontext"].n_rows == sidecar.EchoTime.size
+    - aslcontext.n_rows == sidecar.EchoTime.size
 
 # 198
 ASLM0TypeAbsentScan:
@@ -240,7 +240,7 @@ ASLM0TypeAbsentASLContext:
     selectors:
     - suffix == "asl"
     - associated contains "aslcontext"
-    - associated["aslcontext"]["volume_type"] contains "m0scan"
+    - aslcontext.volume_type contains "m0scan"
     checks:
     - sidecar.M0Type != "absent"
 

--- a/src/schema/rules/sidecars/dwi_validation.yaml
+++ b/src/schema/rules/sidecars/dwi_validation.yaml
@@ -13,8 +13,8 @@ DWIVolumeCount:
     - associated contains "bval"
     - associated contains "bvec"
     checks:
-    - associated["bval"].shape[0] == data.shape[3]
-    - associated["bvec"].shape[0] == data.shape[3]
+    - associated["bval"].n_rows == nifti_header.pixdim[4]
+    - associated["bvec"].n_rows == nifti_header.pixdim[4]
 
 # 30
 DWIBvalRows:

--- a/src/schema/rules/sidecars/dwi_validation.yaml
+++ b/src/schema/rules/sidecars/dwi_validation.yaml
@@ -16,6 +16,28 @@ DWIVolumeCount:
     - associated["bval"].shape[0] == data.shape[3]
     - associated["bvec"].shape[0] == data.shape[3]
 
+# 30
+DWIBvalRows:
+    code: BVAL_MULTIPLE_ROWS
+    description: |
+        '.bval' files should contain exactly one row of volumes.
+    level: error
+    selectors:
+    - extension == "bval"
+    checks:
+    - data.n_rows == 1
+
+# 31
+DWIBvecRows:
+    code: BVEC_NUMBER_ROWS
+    description: |
+        '.bvec' files should contain exactly three rows of volumes.
+    level: error
+    selectors:
+    - extension == "bvec"
+    checks:
+    - data.n_rows == 3
+
 # 32
 DWIMissingBvec:
     code: DWI_MISSING_BVEC

--- a/src/schema/rules/sidecars/dwi_validation.yaml
+++ b/src/schema/rules/sidecars/dwi_validation.yaml
@@ -13,8 +13,8 @@ DWIVolumeCount:
     - associated contains "bval"
     - associated contains "bvec"
     checks:
-    - associated["bval"].n_rows == nifti_header.pixdim[4]
-    - associated["bvec"].n_rows == nifti_header.pixdim[4]
+    - bval.n_rows == nifti_header.pixdim[4]
+    - bvec.n_rows == nifti_header.pixdim[4]
 
 # 30
 DWIBvalRows:

--- a/src/schema/rules/sidecars/dwi_validation.yaml
+++ b/src/schema/rules/sidecars/dwi_validation.yaml
@@ -10,8 +10,8 @@ DWIVolumeCount:
     level: error
     selectors:
     - suffix == "dwi"
-    - associated contains "bval"
-    - associated contains "bvec"
+    - associations contains "bval"
+    - associations contains "bvec"
     checks:
     - bval.n_rows == nifti_header.pixdim[4]
     - bvec.n_rows == nifti_header.pixdim[4]
@@ -47,7 +47,7 @@ DWIMissingBvec:
     selectors:
     - suffix == "dwi"
     checks:
-    - associated contains "bvec"
+    - associations contains "bvec"
 
 # 33
 DWIMissingBval:
@@ -58,4 +58,4 @@ DWIMissingBval:
     selectors:
     - suffix == "dwi"
     checks:
-    - associated contains "bval"
+    - associations contains "bval"

--- a/src/schema/rules/sidecars/dwi_validation.yaml
+++ b/src/schema/rules/sidecars/dwi_validation.yaml
@@ -1,0 +1,39 @@
+# Rules for DWI data that are not defined in tables.
+---
+
+# 29
+DWIVolumeCount:
+    code: VOLUME_COUNT_MISMATCH
+    description: |
+        The number of volumes in this scan does not match the number of volumes in the
+        corresponding .bvec and .bval files.
+    level: error
+    selectors:
+    - suffix == "dwi"
+    - associated contains "bval"
+    - associated contains "bvec"
+    checks:
+    - associated["bval"].shape[0] == data.shape[3]
+    - associated["bvec"].shape[0] == data.shape[3]
+
+# 32
+DWIMissingBvec:
+    code: DWI_MISSING_BVEC
+    description: |
+        DWI scans must have a corresponding .bvec file.
+    level: error
+    selectors:
+    - suffix == "dwi"
+    checks:
+    - associated contains "bvec"
+
+# 33
+DWIMissingBval:
+    code: DWI_MISSING_BVAL
+    description: |
+        DWI scans must have a corresponding .bval file.
+    level: error
+    selectors:
+    - suffix == "dwi"
+    checks:
+    - associated contains "bval"

--- a/src/schema/rules/sidecars/eeg.yaml
+++ b/src/schema/rules/sidecars/eeg.yaml
@@ -89,7 +89,7 @@ EEGCoordsystemGeneral:
         IntendedFor:
             level: OPTIONAL
             addendum: |
-                This identifies the MRI or CT scan associations with the electrodes,
+                This identifies the MRI or CT scan associated with the electrodes,
                 landmarks, and fiducials.
 
 # Fields relating to the EEG electrode positions

--- a/src/schema/rules/sidecars/eeg.yaml
+++ b/src/schema/rules/sidecars/eeg.yaml
@@ -89,7 +89,7 @@ EEGCoordsystemGeneral:
         IntendedFor:
             level: OPTIONAL
             addendum: |
-                This identifies the MRI or CT scan associated with the electrodes,
+                This identifies the MRI or CT scan associations with the electrodes,
                 landmarks, and fiducials.
 
 # Fields relating to the EEG electrode positions

--- a/src/schema/rules/sidecars/events_validation.yaml
+++ b/src/schema/rules/sidecars/events_validation.yaml
@@ -11,6 +11,6 @@ EventsMissing:
     selectors:
     - entities contains "task"
     - entities.task != "rest"
-    - "rest" not in entities.task  # Alternative for including the word "rest"
+    - entities.task not contains "rest"  # Alternative for including the word "rest"
     checks:
     - associated contains "events"

--- a/src/schema/rules/sidecars/events_validation.yaml
+++ b/src/schema/rules/sidecars/events_validation.yaml
@@ -1,0 +1,16 @@
+# Rules for events data that are not defined in tables.
+---
+
+# 25
+EventsMissing:
+    code: EVENTS_TSV_MISSING
+    description: |
+        Task scans should have a corresponding events.tsv file.
+        If this is a resting state scan you can ignore this warning or rename the task to include the word "rest".
+    level: warning  # could be an error with the proper selectors, I think
+    selectors:
+    - entities contains "task"
+    - entities.task != "rest"
+    - "rest" not in entities.task  # Alternative for including the word "rest"
+    checks:
+    - associated contains "events"

--- a/src/schema/rules/sidecars/events_validation.yaml
+++ b/src/schema/rules/sidecars/events_validation.yaml
@@ -13,4 +13,4 @@ EventsMissing:
     - entities.task != "rest"
     - entities.task not contains "rest"  # Alternative for including the word "rest"
     checks:
-    - associated contains "events"
+    - associations contains "events"

--- a/src/schema/rules/sidecars/fmap_validation.yaml
+++ b/src/schema/rules/sidecars/fmap_validation.yaml
@@ -10,15 +10,15 @@ FmapFieldmapWithoutMagnitude:
     selectors:
     - suffix == "fieldmap"
     checks:
-    - associated contains "magnitude"
+    - associations contains "magnitude"
 
 # 92
 FmapPhasediffWithoutMagnitude:
     code: MISSING_MAGNITUDE1_FILE
     description: |
-        Each '_phasediff.nii[.gz]' file should be associated with a '_magnitude1.nii[.gz]' file.
+        Each '_phasediff.nii[.gz]' file should be associations with a '_magnitude1.nii[.gz]' file.
     level: warning
     selectors:
     - suffix == "phasediff"
     checks:
-    - associated contains "magnitude1"
+    - associations contains "magnitude1"

--- a/src/schema/rules/sidecars/fmap_validation.yaml
+++ b/src/schema/rules/sidecars/fmap_validation.yaml
@@ -1,0 +1,24 @@
+# Rules for fieldmap data that are not defined in tables.
+---
+
+# 91
+FmapFieldmapWithoutMagnitude:
+    code: _FIELDMAP_WITHOUT_MAGNITUDE_FILE
+    description: |
+        '_fieldmap.nii[.gz]' file does not have accompanying '_magnitude.nii[.gz]' file.
+    level: error
+    selectors:
+    - suffix == "fieldmap"
+    checks:
+    - associated contains "magnitude"
+
+# 92
+FmapPhasediffWithoutMagnitude:
+    code: MISSING_MAGNITUDE1_FILE
+    description: |
+        Each '_phasediff.nii[.gz]' file should be associated with a '_magnitude1.nii[.gz]' file.
+    level: warning
+    selectors:
+    - suffix == "phasediff"
+    checks:
+    - associated contains "magnitude1"


### PR DESCRIPTION
This PR tackles validation rules for the following error codes:

- 25
- 29
- 30
- 31
- 32
- 33
- 91
- 92
- 157
- 165
- 168
- 172
- 173
- 174
- 175
- 177
- 180
- 181
- 196
- 198
- 199
- 202