### PR TITLE
[RTM] SCHEMA: Encode requirement levels for dataset_description and genetic_info

### DIFF
--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -6,7 +6,7 @@ dataset_description:
         BIDSVersion: REQUIRED
         DatasetType: RECOMMENDED
         License: RECOMMENDED
-        Authors: OPTIONAL
+        Authors: RECOMMENDED
         Acknowledgements: OPTIONAL
         HowToAcknowledge: OPTIONAL
         Funding: OPTIONAL

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -26,9 +26,9 @@ dataset_description:
     GeneratedBy[].Description: OPTIONAL
     GeneratedBy[].CodeURL: OPTIONAL
     GeneratedBy[].Container: OPTIONAL
-    GeneratedBy[].Container.Type: RECOMMENDED
-    GeneratedBy[].Container.Tag: RECOMMENDED
-    GeneratedBy[].Container.URI: RECOMMENDED
+    GeneratedBy[].Container{}.Type: RECOMMENDED
+    GeneratedBy[].Container{}.Tag: RECOMMENDED
+    GeneratedBy[].Container{}.URI: RECOMMENDED
     SourceDatasets: RECOMMENDED
 
 derivative_description:
@@ -44,15 +44,15 @@ dataset_description_with_genetics:
   - dataset.files contains "/genetic_info.json"
   fields:
     Genetics: REQUIRED
-    Genetics.Dataset: REQUIRED
+    Genetics{}.Dataset: REQUIRED
       level: REQUIRED
       issue:
         name: NO_GENETIC_DATABASE
         message: |
           A genetic_info.json file is present but no Database field present in Genetics
           object in dataset_description.json.
-    Genetics.Database: OPTIONAL
-    Genetics.Descriptors: OPTIONAL
+    Genetics{}.Database: OPTIONAL
+    Genetics{}.Descriptors: OPTIONAL
 
 genetic_info:
   selectors:

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -1,53 +1,53 @@
 dataset_description:
-    selectors:
-    - path == "/dataset_description.json"
-    fields:
-        Name: REQUIRED
-        BIDSVersion: REQUIRED
-        DatasetType: RECOMMENDED
-        License: RECOMMENDED
-        Authors: RECOMMENDED
-        Acknowledgements: OPTIONAL
-        HowToAcknowledge: OPTIONAL
-        Funding: OPTIONAL
-        EthicsApprovals: OPTIONAL
-        ReferencesAndLinks: OPTIONAL
-        DatasetDOI: OPTIONAL
-        GeneratedBy: RECOMMENDED
-        GeneratedBy[].Name: REQUIRED
-        GeneratedBy[].Version: RECOMMENDED
-        GeneratedBy[].Description: OPTIONAL
-        GeneratedBy[].CodeURL: OPTIONAL
-        GeneratedBy[].Container: OPTIONAL
-        GeneratedBy[].Container.Type: RECOMMENDED
-        GeneratedBy[].Container.Tag: RECOMMENDED
-        GeneratedBy[].Container.URI: RECOMMENDED
-        SourceDatasets: RECOMMENDED
+  selectors:
+  - path == "/dataset_description.json"
+  fields:
+    Name: REQUIRED
+    BIDSVersion: REQUIRED
+    DatasetType: RECOMMENDED
+    License: RECOMMENDED
+    Authors: RECOMMENDED
+    Acknowledgements: OPTIONAL
+    HowToAcknowledge: OPTIONAL
+    Funding: OPTIONAL
+    EthicsApprovals: OPTIONAL
+    ReferencesAndLinks: OPTIONAL
+    DatasetDOI: OPTIONAL
+    GeneratedBy: RECOMMENDED
+    GeneratedBy[].Name: REQUIRED
+    GeneratedBy[].Version: RECOMMENDED
+    GeneratedBy[].Description: OPTIONAL
+    GeneratedBy[].CodeURL: OPTIONAL
+    GeneratedBy[].Container: OPTIONAL
+    GeneratedBy[].Container.Type: RECOMMENDED
+    GeneratedBy[].Container.Tag: RECOMMENDED
+    GeneratedBy[].Container.URI: RECOMMENDED
+    SourceDatasets: RECOMMENDED
 
 derivative_description:
-    selectors:
-    - path == "/dataset_description.json"
-    - json.DatasetType == "derivative"
-    fields:
-        GeneratedBy: REQUIRED
+  selectors:
+  - path == "/dataset_description.json"
+  - json.DatasetType == "derivative"
+  fields:
+    GeneratedBy: REQUIRED
 
 dataset_description_with_genetics:
-    selectors:
-    - path == "/dataset_description.json"
-    - dataset.files contains "/genetic_info.json"
-    fields:
-        Genetics: REQUIRED
-        Genetics.Dataset: REQUIRED
-        Genetics.Database: OPTIONAL
-        Genetics.Descriptors: OPTIONAL
+  selectors:
+  - path == "/dataset_description.json"
+  - dataset.files contains "/genetic_info.json"
+  fields:
+    Genetics: REQUIRED
+    Genetics.Dataset: REQUIRED
+    Genetics.Database: OPTIONAL
+    Genetics.Descriptors: OPTIONAL
 
 genetic_info:
-    selectors:
-    - path == "/genetic_info.json"
-    fields:
-        GeneticLevel: REQUIRED
-        SampleOrigin: REQUIRED
-        AnalyticalApproach: OPTIONAL
-        TissueOrigin: OPTIONAL
-        BrainLocation: OPTIONAL
-        CellType: OPTIONAL
+  selectors:
+  - path == "/genetic_info.json"
+  fields:
+    GeneticLevel: REQUIRED
+    SampleOrigin: REQUIRED
+    AnalyticalApproach: OPTIONAL
+    TissueOrigin: OPTIONAL
+    BrainLocation: OPTIONAL
+    CellType: OPTIONAL

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 dataset_description:
     selectors:
-    - path == /dataset_description.json
+    - path == "/dataset_description.json"
     fields:
         Name: REQUIRED
         BIDSVersion: REQUIRED
@@ -26,14 +26,14 @@ dataset_description:
 
 derivative_description:
     selectors:
-    - path == /dataset_description.json
-    - dataset.dataset_description.DatasetType == "derivative"
+    - path == "/dataset_description.json"
+    - json.DatasetType == "derivative"
     fields:
         GeneratedBy: REQUIRED
 
 dataset_description_with_genetics:
     selectors:
-    - path == /dataset_description.json
+    - path == "/dataset_description.json"
     - dataset.files contains "/genetic_info.json"
     fields:
         Genetics: REQUIRED
@@ -43,7 +43,7 @@ dataset_description_with_genetics:
 
 genetic_info:
     selectors:
-    - path == /genetic_info.json
+    - path == "/genetic_info.json"
     fields:
         GeneticLevel: REQUIRED
         SampleOrigin: REQUIRED

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -1,6 +1,6 @@
 dataset_description:
     selectors:
-    - path: /dataset_description.json
+    - path == /dataset_description.json
     fields:
         Name: REQUIRED
         BIDSVersion: REQUIRED
@@ -25,16 +25,16 @@ dataset_description:
         SourceDatasets: RECOMMENDED
 
 derivative_description:
-    path: /dataset_description.json
     selectors:
-        dataset.DatasetType == "derivative"
+    - path == /dataset_description.json
+    - dataset.dataset_description.DatasetType == "derivative"
     fields:
         GeneratedBy: REQUIRED
 
 dataset_description_with_genetics:
-    path: /dataset_description.json
     selectors:
-        dataset.genetic_info
+    - path == /dataset_description.json
+    - dataset.files contains "/genetic_info.json"
     fields:
         Genetics: REQUIRED
         Genetics.Dataset: REQUIRED
@@ -42,7 +42,8 @@ dataset_description_with_genetics:
         Genetics.Descriptors: OPTIONAL
 
 genetic_info:
-    path: /genetic_info.json
+    selectors:
+    - path == /genetic_info.json
     fields:
         GeneticLevel: REQUIRED
         SampleOrigin: REQUIRED

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -1,0 +1,40 @@
+dataset_description:
+    path: /dataset_description.json
+    fields:
+        Name: REQUIRED
+        BIDSVersion: REQUIRED
+        DatasetType: RECOMMENDED
+        License: RECOMMENDED
+        Authors: OPTIONAL
+        Acknowledgements: OPTIONAL
+        HowToAcknowledge: OPTIONAL
+        Funding: OPTIONAL
+        EthicsApprovals: OPTIONAL
+        ReferencesAndLinks: OPTIONAL
+        DatasetDOI: OPTIONAL
+        GeneratedBy: RECOMMENDED
+        SourceDatasets: RECOMMENDED
+
+derivative_description:
+    path: /dataset_description.json
+    selectors:
+        dataset.DatasetType == "derivative"
+    fields:
+        GeneratedBy: REQUIRED
+
+dataset_description_with_genetics:
+    path: /dataset_description.json
+    selectors:
+        dataset.genetic_info
+    fields:
+        Genetics: REQUIRED
+
+genetic_info:
+    path: /genetic_info.json
+    fields:
+        GeneticLevel: REQUIRED
+        SampleOrigin: REQUIRED
+        AnalyticalApproach: OPTIONAL
+        TissueOrigin: OPTIONAL
+        BrainLocation: OPTIONAL
+        CellType: OPTIONAL

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -10,7 +10,7 @@ dataset_description:
     Authors:
       level: RECOMMENDED
       issue:
-        name: NO_AUTHORS
+        code: NO_AUTHORS
         message: |
           The Authors field of dataset_description.json should contain an array of fields -
           with one author per field. This was triggered because there are no authors, which
@@ -48,7 +48,7 @@ dataset_description_with_genetics:
     Genetics{}.Dataset:
       level: REQUIRED
       issue:
-        name: NO_GENETIC_DATABASE
+        code: NO_GENETIC_DATABASE
         message: |
           A genetic_info.json file is present but no Database field present in Genetics
           object in dataset_description.json.

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -45,7 +45,7 @@ dataset_description_with_genetics:
   - dataset.files contains "/genetic_info.json"
   fields:
     Genetics: REQUIRED
-    Genetics{}.Dataset: REQUIRED
+    Genetics{}.Dataset:
       level: REQUIRED
       issue:
         name: NO_GENETIC_DATABASE

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -1,3 +1,4 @@
+---
 dataset_description:
   selectors:
   - path == "/dataset_description.json"

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -6,7 +6,14 @@ dataset_description:
     BIDSVersion: REQUIRED
     DatasetType: RECOMMENDED
     License: RECOMMENDED
-    Authors: RECOMMENDED
+    Authors:
+      level: RECOMMENDED
+      issue:
+        name: NO_AUTHORS
+        message: |
+          The Authors field of dataset_description.json should contain an array of fields -
+          with one author per field. This was triggered because there are no authors, which
+          will make DOI registration from dataset metadata impossible.
     Acknowledgements: OPTIONAL
     HowToAcknowledge: OPTIONAL
     Funding: OPTIONAL
@@ -38,6 +45,12 @@ dataset_description_with_genetics:
   fields:
     Genetics: REQUIRED
     Genetics.Dataset: REQUIRED
+      level: REQUIRED
+      issue:
+        name: NO_GENETIC_DATABASE
+        message: |
+          A genetic_info.json file is present but no Database field present in Genetics
+          object in dataset_description.json.
     Genetics.Database: OPTIONAL
     Genetics.Descriptors: OPTIONAL
 

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -13,6 +13,14 @@ dataset_description:
         ReferencesAndLinks: OPTIONAL
         DatasetDOI: OPTIONAL
         GeneratedBy: RECOMMENDED
+        GeneratedBy[].Name: REQUIRED
+        GeneratedBy[].Version: RECOMMENDED
+        GeneratedBy[].Description: OPTIONAL
+        GeneratedBy[].CodeURL: OPTIONAL
+        GeneratedBy[].Container: OPTIONAL
+        GeneratedBy[].Container.Type: RECOMMENDED
+        GeneratedBy[].Container.Tag: RECOMMENDED
+        GeneratedBy[].Container.URI: RECOMMENDED
         SourceDatasets: RECOMMENDED
 
 derivative_description:
@@ -28,6 +36,9 @@ dataset_description_with_genetics:
         dataset.genetic_info
     fields:
         Genetics: REQUIRED
+        Genetics.Dataset: REQUIRED
+        Genetics.Database: OPTIONAL
+        Genetics.Descriptors: OPTIONAL
 
 genetic_info:
     path: /genetic_info.json

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -1,5 +1,6 @@
 dataset_description:
-    path: /dataset_description.json
+    selectors:
+    - path: /dataset_description.json
     fields:
         Name: REQUIRED
         BIDSVersion: REQUIRED


### PR DESCRIPTION
Two open questions I see:

1) How do we want to encode, e.g. NO_AUTHORS, where we effectively promote dataset_description.Authors from OPTIONAL to REQUIRED?
2) Do we want to specify nested fields, such as `Genetics.Database` directly? Or have some way of specifying a nested structure as its own object?