### PR TITLE
[SCHEMA] Add "common.yaml" standard error schema rules

### DIFF
--- a/src/schema/rules/common.yaml
+++ b/src/schema/rules/common.yaml
@@ -1,0 +1,222 @@
+---
+# This file describes rules for broad "standard" errors in the specification.
+NiftiHeaderUnreadable:
+    code: NIFTI_HEADER_UNREADABLE
+    description: |
+        We were unable to parse header data from this NIfTI file.
+        Please ensure it is not corrupted or mislabeled.
+    level: error
+    validation: shallow
+    selectors:
+    - extension in [".nii", ".nii.gz"]
+JsonInvalid:
+    code: JSON_INVALID
+    description: |
+        Not a valid JSON file.
+    level: error
+    validation: shallow
+    selectors:
+    - extension == ".json"
+GzNotGzipped:
+    code: GZ_NOT_GZIPPED
+    description: |
+        This file ends in the .gz extension but is not actually gzipped.
+    level: error
+    validation: shallow
+    selectors:
+    - extension contains ".gz"
+BvalMultipleRows:
+    code: BVAL_MULTIPLE_ROWS
+    description: |
+        .bval files should contain exactly one row of volumes.
+    level: error
+    validation: deep
+    selectors:
+    - extension == ".bval"
+BvecNumberRows:
+    code: BVEC_NUMBER_ROWS
+    description: |
+        .bvec files should contain exactly three rows of volumes.
+    level: error
+    validation: deep
+    selectors:
+    - extension == ".bvec"
+NiftiTooSmall:
+    code: NIFTI_TOO_SMALL
+    description: |
+        This file is too small to contain the minimal NIfTI header.
+    level: error
+    validation: shallow
+    selectors:
+    - extension in [".nii", ".nii.gz"]
+OrphanedSymlink:
+    code: ORPHANED_SYMLINK
+    description: |
+        This file appears to be an orphaned symlink.
+        Make sure it correctly points to its referent.
+    level: error
+    validation: shallow
+FileRead:
+    code: FILE_READ
+    description: |
+        We were unable to read this file.
+        Make sure it contains data (file size > 0 kB) and is not corrupted,
+        incorrectly named, or incorrectly symlinked.
+    level: error
+BvecRowLength:
+    code: BVEC_ROW_LENGTH
+    description: |
+        Each row in a .bvec file should contain the same number of values.
+    level: error
+    validation: deep
+    selectors:
+    - extension == ".bvec"
+BFile:
+    code: B_FILE
+    description: |
+        .bval and .bvec files must be single space delimited
+        and contain only numerical values.
+    level: error
+    validation: deep
+    selectors:
+    - extension in [".bval", ".bvec"]
+JsonSchemaValidationError:
+    code: JSON_SCHEMA_VALIDATION_ERROR
+    description: |
+        Invalid JSON file. The file is not formatted according the schema.
+    level: error
+    validation: shallow
+    selectors:
+    - extension == ".json"
+NoValidDataFoundForSubject:
+    code: NO_VALID_DATA_FOUND_FOR_SUBJECT
+    description: |
+        No BIDS compatible data found for at least one subject.
+    level: error
+    validation: filename
+WrongNewLine:
+    code: WRONG_NEW_LINE
+    description: |
+        All TSV files must use Line Feed '\n' characters to denote new lines.
+        This files uses Carriage Return '\r'.
+    level: error
+    validation: shallow
+    selectors:
+    - extension == ".tsv"
+MalformedBvec:
+    code: MALFORMED_BVEC
+    description: |
+        The contents of this .bvec file are undefined or severely malformed.
+    level: error
+    validation: deep
+    selectors:
+    - extension == ".bvec"
+MalformedBval:
+    code: MALFORMED_BVAL
+    description: |
+        The contents of this .bval file are undefined or severely malformed.
+    level: error
+    validation: deep
+    selectors:
+    - extension == ".bval"
+SidecarWithoutDatafile:
+    code: SIDECAR_WITHOUT_DATAFILE
+    description: |
+        A json sidecar file was found without a corresponding data file.
+    level: error
+    validation: filename
+    selectors:
+    - extension == ".json"
+MissingSession:
+    code: MISSING_SESSION
+    description: |
+        Not all subjects contain the same sessions.
+    level: warning
+    validation: filename
+InaccessibleRemoteFile:
+    code: INACCESSIBLE_REMOTE_FILE
+    description: |
+        This file appears to be a symlink to a remote annexed file,
+        but could not be accessed from any of the configured remotes.
+    level: error
+    validation: shallow
+EmptyFile:
+    code: EMPTY_FILE
+    description: |
+        Empty files not allowed.
+    level: error
+    validation: shallow
+BrainvisionLinksBroken:
+    code: BRAINVISION_LINKS_BROKEN
+    description: |
+        Internal file pointers in BrainVision file triplet (*.eeg, *.vhdr,
+        and *.vmrk) are broken or some files do not exist.
+    level: error
+    validation: shallow
+    selectors:
+    - extension in [ ".eeg", ".vhdr", ".vmrk"]
+HedError:
+    code: HED_ERROR
+    description: |
+        The validation on this HED string returned an error.
+    level: error
+    validation: deep
+    selectors:
+    - suffix == "events"
+    - extension == ".tsv"
+HedWarning:
+    code: HED_WARNING
+    description: |
+        The validation on this HED string returned a warning.
+    level: warning
+    validation: deep
+    selectors:
+    - suffix == "events"
+    - extension == ".tsv"
+HedInternalError:
+    code: HED_INTERNAL_ERROR
+    description: |
+        An internal error occurred during HED validation.
+    level: error
+    validation: deep
+    selectors:
+    - suffix == "events"
+    - extension == ".tsv"
+HedInternalWarning:
+    code: HED_INTERNAL_WARNING
+    description: |
+        An internal warning occurred during HED validation.
+    level: warning
+    validation: deep
+    selectors:
+    - suffix == "events"
+    - extension == ".tsv"
+HedMissingValueInSidecar:
+    code: HED_MISSING_VALUE_IN_SIDECAR
+    description: |
+        The json sidecar does not contain this column value as
+        a possible key to a HED string.
+    level: warning
+    validation: deep
+    selectors:
+    - suffix == "events"
+    - extension == ".tsv"
+HedVersionNotDefined:
+    code: HED_VERSION_NOT_DEFINED
+    description: |
+        You should define 'HEDVersion' for this file.
+        If you don't provide this information, the HED validation will use
+        the latest version available.
+    level: warning
+    validation: deep
+    selectors:
+    - suffix == "events"
+    - extension == ".tsv"
+InvalidJsonEncoding:
+    code: INVALID_JSON_ENCODING
+    description: |
+        JSON files must be valid utf-8.
+    level: error
+    validation: shallow
+    selectors:
+    - extension == ".json"

--- a/src/schema/rules/common.yaml
+++ b/src/schema/rules/common.yaml
@@ -1,5 +1,7 @@
 ---
 # This file describes rules for broad "standard" errors in the specification.
+
+# BIDS Validator Original Issue Code #26
 NiftiHeaderUnreadable:
     code: NIFTI_HEADER_UNREADABLE
     description: |
@@ -9,6 +11,8 @@ NiftiHeaderUnreadable:
     validation: shallow
     selectors:
     - extension in [".nii", ".nii.gz"]
+
+# BIDS Validator Original Issue Code #27
 JsonInvalid:
     code: JSON_INVALID
     description: |
@@ -17,6 +21,8 @@ JsonInvalid:
     validation: shallow
     selectors:
     - extension == ".json"
+
+# BIDS Validator Original Issue Code #28
 GzNotGzipped:
     code: GZ_NOT_GZIPPED
     description: |
@@ -25,6 +31,8 @@ GzNotGzipped:
     validation: shallow
     selectors:
     - extension contains ".gz"
+
+# BIDS Validator Original Issue Code #30
 BvalMultipleRows:
     code: BVAL_MULTIPLE_ROWS
     description: |
@@ -33,6 +41,8 @@ BvalMultipleRows:
     validation: deep
     selectors:
     - extension == ".bval"
+
+# BIDS Validator Original Issue Code #31
 BvecNumberRows:
     code: BVEC_NUMBER_ROWS
     description: |
@@ -41,6 +51,8 @@ BvecNumberRows:
     validation: deep
     selectors:
     - extension == ".bvec"
+
+# BIDS Validator Original Issue Code #36
 NiftiTooSmall:
     code: NIFTI_TOO_SMALL
     description: |
@@ -49,6 +61,8 @@ NiftiTooSmall:
     validation: shallow
     selectors:
     - extension in [".nii", ".nii.gz"]
+
+# BIDS Validator Original Issue Code #43
 OrphanedSymlink:
     code: ORPHANED_SYMLINK
     description: |
@@ -56,6 +70,8 @@ OrphanedSymlink:
         Make sure it correctly points to its referent.
     level: error
     validation: shallow
+
+# BIDS Validator Original Issue Code #44
 FileRead:
     code: FILE_READ
     description: |
@@ -63,6 +79,8 @@ FileRead:
         Make sure it contains data (file size > 0 kB) and is not corrupted,
         incorrectly named, or incorrectly symlinked.
     level: error
+
+# BIDS Validator Original Issue Code #46
 BvecRowLength:
     code: BVEC_ROW_LENGTH
     description: |
@@ -71,6 +89,8 @@ BvecRowLength:
     validation: deep
     selectors:
     - extension == ".bvec"
+
+# BIDS Validator Original Issue Code #47
 BFile:
     code: B_FILE
     description: |
@@ -80,6 +100,8 @@ BFile:
     validation: deep
     selectors:
     - extension in [".bval", ".bvec"]
+
+# BIDS Validator Original Issue Code #55
 JsonSchemaValidationError:
     code: JSON_SCHEMA_VALIDATION_ERROR
     description: |
@@ -88,12 +110,16 @@ JsonSchemaValidationError:
     validation: shallow
     selectors:
     - extension == ".json"
+
+# BIDS Validator Original Issue Code #67
 NoValidDataFoundForSubject:
     code: NO_VALID_DATA_FOUND_FOR_SUBJECT
     description: |
         No BIDS compatible data found for at least one subject.
     level: error
     validation: filename
+
+# BIDS Validator Original Issue Code #70
 WrongNewLine:
     code: WRONG_NEW_LINE
     description: |
@@ -103,6 +129,8 @@ WrongNewLine:
     validation: shallow
     selectors:
     - extension == ".tsv"
+
+# BIDS Validator Original Issue Code #74
 MalformedBvec:
     code: MALFORMED_BVEC
     description: |
@@ -111,6 +139,8 @@ MalformedBvec:
     validation: deep
     selectors:
     - extension == ".bvec"
+
+# BIDS Validator Original Issue Code #88
 MalformedBval:
     code: MALFORMED_BVAL
     description: |
@@ -119,6 +149,8 @@ MalformedBval:
     validation: deep
     selectors:
     - extension == ".bval"
+
+# BIDS Validator Original Issue Code #89
 SidecarWithoutDatafile:
     code: SIDECAR_WITHOUT_DATAFILE
     description: |
@@ -127,12 +159,16 @@ SidecarWithoutDatafile:
     validation: filename
     selectors:
     - extension == ".json"
+
+# BIDS Validator Original Issue Code #90
 MissingSession:
     code: MISSING_SESSION
     description: |
         Not all subjects contain the same sessions.
     level: warning
     validation: filename
+
+# BIDS Validator Original Issue Code #98
 InaccessibleRemoteFile:
     code: INACCESSIBLE_REMOTE_FILE
     description: |
@@ -140,12 +176,16 @@ InaccessibleRemoteFile:
         but could not be accessed from any of the configured remotes.
     level: error
     validation: shallow
+
+# BIDS Validator Original Issue Code #99
 EmptyFile:
     code: EMPTY_FILE
     description: |
         Empty files not allowed.
     level: error
     validation: shallow
+
+# BIDS Validator Original Issue Code #100
 BrainvisionLinksBroken:
     code: BRAINVISION_LINKS_BROKEN
     description: |
@@ -155,6 +195,8 @@ BrainvisionLinksBroken:
     validation: shallow
     selectors:
     - extension in [ ".eeg", ".vhdr", ".vmrk"]
+
+# BIDS Validator Original Issue Code #104
 HedError:
     code: HED_ERROR
     description: |
@@ -164,6 +206,8 @@ HedError:
     selectors:
     - suffix == "events"
     - extension == ".tsv"
+
+# BIDS Validator Original Issue Code #105
 HedWarning:
     code: HED_WARNING
     description: |
@@ -173,6 +217,8 @@ HedWarning:
     selectors:
     - suffix == "events"
     - extension == ".tsv"
+
+# BIDS Validator Original Issue Code #106
 HedInternalError:
     code: HED_INTERNAL_ERROR
     description: |
@@ -182,6 +228,8 @@ HedInternalError:
     selectors:
     - suffix == "events"
     - extension == ".tsv"
+
+# BIDS Validator Original Issue Code #107
 HedInternalWarning:
     code: HED_INTERNAL_WARNING
     description: |
@@ -191,6 +239,8 @@ HedInternalWarning:
     selectors:
     - suffix == "events"
     - extension == ".tsv"
+
+# BIDS Validator Original Issue Code #108
 HedMissingValueInSidecar:
     code: HED_MISSING_VALUE_IN_SIDECAR
     description: |
@@ -201,6 +251,8 @@ HedMissingValueInSidecar:
     selectors:
     - suffix == "events"
     - extension == ".tsv"
+
+# BIDS Validator Original Issue Code #109
 HedVersionNotDefined:
     code: HED_VERSION_NOT_DEFINED
     description: |
@@ -212,6 +264,8 @@ HedVersionNotDefined:
     selectors:
     - suffix == "events"
     - extension == ".tsv"
+
+# BIDS Validator Original Issue Code #123
 InvalidJsonEncoding:
     code: INVALID_JSON_ENCODING
     description: |


### PR DESCRIPTION
1. Couldn't think of a better filename.
2. These are from the sprint day 3.
3. These are based on the "standard error messages" task.

Based around the following current BIDS Validator Issue Codes:

- 26: NIFTI_HEADER_UNREADABLE
- 27: JSON_INVALID
- 28: GZ_NOT_GZIPPED
- 30: BVAL_MULTIPLE_ROWS
- 31: BVEC_NUMBER_ROWS
- 36: NIFTI_TOO_SMALL
- 43: ORPHANED_SYMLINK
- 44: FILE_READ
- 46: BVEC_ROW_LENGTH
- 47: B_FILE
- 55: JSON_SCHEMA_VALIDATION_ERROR
- 67: NO_VALID_DATA_FOUND_FOR_SUBJECT
- 70: WRONG_NEW_LINE
- 74: DUPLICATE_NIFTI_FILES
- 88: MALFORMED_BVEC
- 89: MALFORMED_BVAL
- 90: SIDECAR_WITHOUT_DATAFILE
- 97: MISSING_SESSION
- 98: INACCESSIBLE_REMOTE_FILE
- 99: EMPTY_FILE
- 100: BRAINVISION_LINKS_BROKEN
- 104: HED_ERROR
- 105: HED_WARNING
- 106: HED_INTERNAL_ERROR
- 107: HED_INTERNAL_WARNING
- 108: HED_MISSING_VALUE_IN_SIDECAR
- 109: HED_VERSION_NOT_DEFINED
- 114: INCOMPLETE_DATASET
- 123: INVALID JSON ENCODING
