### PR TITLE
SCHEMA: Convert datatype lists to objects

### DIFF
--- a/src/schema/rules/datatypes/anat.yaml
+++ b/src/schema/rules/datatypes/anat.yaml
@@ -1,6 +1,6 @@
 ---
-# Nonparametric
-- suffixes:
+nonparametric:
+  suffixes:
   - T1w
   - T2w
   - PDw
@@ -28,8 +28,8 @@
     reconstruction: optional
     part: optional
 
-# Parametric
-- suffixes:
+parametric:
+  suffixes:
   - T1map
   - T2map
   - T2starmap
@@ -61,8 +61,8 @@
     ceagent: optional
     reconstruction: optional
 
-# Defacemask
-- suffixes:
+defacemask:
+  suffixes:
   - defacemask
   extensions:
   - .nii.gz
@@ -79,8 +79,8 @@
     reconstruction: optional
     modality: optional
 
-# Multi-echo
-- suffixes:
+multiecho:
+  suffixes:
   - MESE
   - MEGRE
   extensions:
@@ -99,8 +99,8 @@
     echo: required
     part: optional
 
-# Multi-flip
-- suffixes:
+multiflip:
+  suffixes:
   - VFA
   extensions:
   - .nii.gz
@@ -119,8 +119,8 @@
     flip: required
     part: optional
 
-# Multi-inv
-- suffixes:
+multiinversion:
+  suffixes:
   - IRT1
   extensions:
   - .nii.gz
@@ -138,8 +138,8 @@
     inversion: required
     part: optional
 
-# MP2RAGE
-- suffixes:
+mp2rage:
+  suffixes:
   - MP2RAGE
   extensions:
   - .nii.gz
@@ -159,8 +159,8 @@
     inversion: required
     part: optional
 
-# VFA+MT
-- suffixes:
+vfamt:
+  suffixes:
   - MPM
   - MTS
   extensions:
@@ -181,8 +181,8 @@
     mtransfer: required
     part: optional
 
-# MTR
-- suffixes:
+mtr:
+  suffixes:
   - MTR
   extensions:
   - .nii.gz

--- a/src/schema/rules/datatypes/beh.yaml
+++ b/src/schema/rules/datatypes/beh.yaml
@@ -1,6 +1,6 @@
 ---
-# Continuous data
-- suffixes:
+timeseries:
+  suffixes:
   - stim
   - physio
   extensions:
@@ -17,7 +17,8 @@
     recording: optional
 
 # Non-continuous data
-- suffixes:
+noncontinuous:
+  suffixes:
   - events
   - beh
   extensions:

--- a/src/schema/rules/datatypes/dwi.yaml
+++ b/src/schema/rules/datatypes/dwi.yaml
@@ -1,6 +1,6 @@
 ---
-# DWI
-- suffixes:
+dwi:
+  suffixes:
   - dwi
   extensions:
   - .nii.gz
@@ -18,8 +18,8 @@
     run: optional
     part: optional
 
-# Single-band reference images
-- suffixes:
+sbref:
+  suffixes:
   - sbref
   extensions:
   - .nii.gz
@@ -35,8 +35,8 @@
     run: optional
     part: optional
 
-# Timeseries
-- suffixes:
+timeseries:
+  suffixes:
   - physio
   - stim
   extensions:

--- a/src/schema/rules/datatypes/eeg.yaml
+++ b/src/schema/rules/datatypes/eeg.yaml
@@ -1,5 +1,6 @@
 ---
-- suffixes:
+eeg:
+  suffixes:
   - eeg
   extensions:
   - .json
@@ -19,7 +20,8 @@
     acquisition: optional
     run: optional
 
-- suffixes:
+channels:
+  suffixes:
   - channels
   extensions:
   - .json
@@ -33,7 +35,8 @@
     acquisition: optional
     run: optional
 
-- suffixes:
+coordsystem:
+  suffixes:
   - coordsystem
   extensions:
   - .json
@@ -45,7 +48,8 @@
     acquisition: optional
     space: optional
 
-- suffixes:
+electrodes:
+  suffixes:
   - electrodes
   extensions:
   - .json
@@ -58,7 +62,8 @@
     acquisition: optional
     space: optional
 
-- suffixes:
+events:
+  suffixes:
   - events
   extensions:
   - .json
@@ -72,7 +77,8 @@
     acquisition: optional
     run: optional
 
-- suffixes:
+photo:
+  suffixes:
   - photo
   extensions:
   - .jpg
@@ -83,8 +89,8 @@
     session: optional
     acquisition: optional
 
-# Timeseries
-- suffixes:
+timeseries:
+  suffixes:
   - physio
   - stim
   extensions:

--- a/src/schema/rules/datatypes/fmap.yaml
+++ b/src/schema/rules/datatypes/fmap.yaml
@@ -1,6 +1,6 @@
 ---
-# Fieldmaps
-- suffixes:
+fieldmaps:
+  suffixes:
   - phasediff
   - phase1
   - phase2
@@ -20,8 +20,8 @@
     acquisition: optional
     run: optional
 
-# PEPolar
-- suffixes:
+pepolar:
+  suffixes:
   - epi
   - m0scan
   extensions:
@@ -38,8 +38,8 @@
     direction: required
     run: optional
 
-# TB1DAM
-- suffixes:
+TB1DAM:
+  suffixes:
   - TB1DAM
   extensions:
   - .nii.gz
@@ -58,8 +58,8 @@
     inversion: optional
     part: optional
 
-# TB1EPI
-- suffixes:
+TB1EPI:
+  suffixes:
   - TB1EPI
   extensions:
   - .nii.gz
@@ -79,8 +79,8 @@
     inversion: optional
     part: optional
 
-# RFFieldMaps
-- suffixes:
+RFFieldMaps:
+  suffixes:
   - TB1AFI
   - TB1TFL
   - TB1RFM
@@ -103,8 +103,8 @@
     inversion: optional
     part: optional
 
-# TB1SRGE
-- suffixes:
+TB1SRGE:
+  suffixes:
   - TB1SRGE
   extensions:
   - .nii.gz
@@ -124,8 +124,8 @@
     inversion: required
     part: optional
 
-# Parametric
-- suffixes:
+parametric:
+  suffixes:
   - TB1map
   - RB1map
   extensions:

--- a/src/schema/rules/datatypes/func.yaml
+++ b/src/schema/rules/datatypes/func.yaml
@@ -1,6 +1,6 @@
 ---
-# Func
-- suffixes:
+func:
+  suffixes:
   - bold
   - cbv
   - sbref
@@ -22,8 +22,8 @@
     echo: optional
     part: optional
 
-# Phase (deprecated)
-- suffixes:
+phase:
+  suffixes:
   - phase  # deprecated
   extensions:
   - .nii.gz
@@ -42,8 +42,8 @@
     run: optional
     echo: optional
 
-# Events
-- suffixes:
+events:
+  suffixes:
   - events
   extensions:
   - .tsv
@@ -60,8 +60,8 @@
     direction: optional
     run: optional
 
-# Timeseries
-- suffixes:
+timeseries:
+  suffixes:
   - physio
   - stim
   extensions:

--- a/src/schema/rules/datatypes/ieeg.yaml
+++ b/src/schema/rules/datatypes/ieeg.yaml
@@ -1,5 +1,6 @@
 ---
-- suffixes:
+ieeg:
+  suffixes:
   - ieeg
   extensions:
   - .mefd/
@@ -20,7 +21,8 @@
     acquisition: optional
     run: optional
 
-- suffixes:
+channels:
+  suffixes:
   - channels
   extensions:
   - .json
@@ -34,7 +36,8 @@
     acquisition: optional
     run: optional
 
-- suffixes:
+coordsystem:
+  suffixes:
   - coordsystem
   extensions:
   - .json
@@ -46,7 +49,8 @@
     acquisition: optional
     space: optional
 
-- suffixes:
+electrodes:
+  suffixes:
   - electrodes
   extensions:
   - .json
@@ -59,7 +63,8 @@
     acquisition: optional
     space: optional
 
-- suffixes:
+events:
+  suffixes:
   - events
   extensions:
   - .json
@@ -73,7 +78,8 @@
     acquisition: optional
     run: optional
 
-- suffixes:
+photo:
+  suffixes:
   - photo
   extensions:
   - .jpg
@@ -82,8 +88,8 @@
     session: optional
     acquisition: optional
 
-# Timeseries
-- suffixes:
+timeseries:
+  suffixes:
   - physio
   - stim
   extensions:

--- a/src/schema/rules/datatypes/meg.yaml
+++ b/src/schema/rules/datatypes/meg.yaml
@@ -1,7 +1,6 @@
 ---
-# MEG data files
-# First group
-- suffixes:
+meg:
+  suffixes:
   - meg
   extensions:
   - /  # corresponds to BTi/4D data
@@ -28,9 +27,8 @@
     processing: optional
     split: optional
 
-# Second group
-# Specifically, it's dat files with "acq-calibration"
-- suffixes:
+calibration:
+  suffixes:
   - meg
   extensions:
   - .dat
@@ -45,9 +43,8 @@
       enum:
       - calibration
 
-# Third group
-# fif files with "acq-crosstalk"
-- suffixes:
+crosstalk:
+  suffixes:
   - meg
   extensions:
   - .fif
@@ -62,8 +59,8 @@
       enum:
       - crosstalk
 
-# Headshape files
-- suffixes:
+headshape:
+  suffixes:
   - headshape
   extensions:
   - .*
@@ -75,8 +72,8 @@
     session: optional
     acquisition: optional
 
-# Marker files
-- suffixes:
+markers:
+  suffixes:
   - markers
   extensions:
   - .sqd
@@ -90,8 +87,8 @@
     acquisition: optional
     space: optional
 
-# Coordinate systems
-- suffixes:
+coordsystem:
+  suffixes:
   - coordsystem
   extensions:
   - .json
@@ -102,8 +99,8 @@
     session: optional
     acquisition: optional
 
-# Channel files
-- suffixes:
+channels:
+  suffixes:
   - channels
   extensions:
   - .json
@@ -118,8 +115,8 @@
     run: optional
     processing: optional
 
-# Events files
-- suffixes:
+events:
+  suffixes:
   - events
   extensions:
   - .json
@@ -133,8 +130,8 @@
     acquisition: optional
     run: optional
 
-# Head photos
-- suffixes:
+photo:
+  suffixes:
   - photo
   extensions:
   - .jpg
@@ -145,8 +142,8 @@
     session: optional
     acquisition: optional
 
-# Timeseries
-- suffixes:
+timeseries:
+  suffixes:
   - physio
   - stim
   extensions:

--- a/src/schema/rules/datatypes/micr.yaml
+++ b/src/schema/rules/datatypes/micr.yaml
@@ -1,6 +1,6 @@
 ---
-# Microscopy
-- suffixes:
+microscopy:
+  suffixes:
   - TEM
   - SEM
   - uCT
@@ -35,7 +35,8 @@
     run: optional
     chunk: optional
 
-- suffixes:
+photo:
+  suffixes:
   - photo
   extensions:
   - .jpg

--- a/src/schema/rules/datatypes/perf.yaml
+++ b/src/schema/rules/datatypes/perf.yaml
@@ -1,6 +1,6 @@
 ---
-# First group
-- suffixes:
+asl:
+  suffixes:
   - asl
   - m0scan
   extensions:
@@ -17,8 +17,8 @@
     direction: optional
     run: optional
 
-# Second group
-- suffixes:
+aslcontext:
+  suffixes:
   - aslcontext
   extensions:
   - .tsv
@@ -33,8 +33,8 @@
     direction: optional
     run: optional
 
-# Third group
-- suffixes:
+asllabeling:
+  suffixes:
   - asllabeling
   extensions:
   - .jpg
@@ -47,8 +47,8 @@
     reconstruction: optional
     run: optional
 
-# Timeseries
-- suffixes:
+timeseries:
+  suffixes:
   - physio
   - stim
   extensions:

--- a/src/schema/rules/datatypes/pet.yaml
+++ b/src/schema/rules/datatypes/pet.yaml
@@ -1,6 +1,6 @@
 ---
-# PET recordings
-- suffixes:
+pet:
+  suffixes:
   - pet
   extensions:
   - .nii.gz
@@ -16,8 +16,8 @@
     reconstruction: optional
     run: optional
 
-# Blood recordings
-- suffixes:
+blood:
+  suffixes:
   - blood
   extensions:
   - .tsv
@@ -33,8 +33,8 @@
     run: optional
     recording: required
 
-# Events
-- suffixes:
+events:
+  suffixes:
   - events
   extensions:
   - .tsv
@@ -49,8 +49,8 @@
     reconstruction: optional
     run: optional
 
-# Timeseries
-- suffixes:
+timeseries:
+  suffixes:
   - physio
   - stim
   extensions:

--- a/tools/schemacode/schemacode/render.py
+++ b/tools/schemacode/schemacode/render.py
@@ -188,7 +188,7 @@ def make_filename_template(schema, n_dupes_to_combine=6, **kwargs):
         paragraph += "\t\t{}/\n".format(datatype)
 
         # Unique filename patterns
-        for group in schema["rules"]["datatypes"][datatype]:
+        for group in schema["rules"]["datatypes"][datatype].values():
             string = "\t\t\t"
             for ent in entity_order:
                 if "enum" in schema["objects"]["entities"][ent].keys():
@@ -302,7 +302,7 @@ def make_entity_table(schema, tablefmt="github", **kwargs):
         duplicate_row_counter = 0
 
         # each dtype could have multiple specs
-        for i_dtype_spec, dtype_spec in enumerate(dtype_specs):
+        for dtype_spec in dtype_specs.values():
             suffixes = dtype_spec.get("suffixes")
 
             # Skip this part of the schema if no suffixes are found.


### PR DESCRIPTION
This allows us to have an unambiguous name for each rule, such as `schema.rules.datatypes.anat.nonparametric`.