### PR TITLE
SCHEMA: Load global schema namespace to permit cross-file references

### DIFF
--- a/tools/schemacode/schemacode/schema.py
+++ b/tools/schemacode/schemacode/schema.py
@@ -3,6 +3,7 @@ import logging
 import os
 from copy import deepcopy
 from pathlib import Path
+from collections.abc import Mapping
 
 import yaml
 
@@ -19,6 +20,97 @@ def _get_entry_name(path):
         return path.name[:-5]  # no .yaml
     else:
         return path.name
+
+
+def _expand_dots(entry):
+    # Helper function for expand
+    key, val = entry
+    if "." in key:
+        init, post = key.split(".", 1)
+        return init, dict([_expand_dots((post, val))])
+    return key, expand(val)
+
+
+def expand(element):
+    """ Expand a dict, recursively, to replace dots in keys with recursive dictionaries
+
+    Examples
+    --------
+    >>> expand({"a": 1, "b.c": 2, "d": [{"e": 3, "f.g": 4}]})
+    {'a': 1, 'b': {'c': 2}, 'd': [{'e': 3, 'f': {'g': 4}}]}
+    """
+    if isinstance(element, dict):
+        return {key: val for key, val in map(_expand_dots, element.items())}
+    elif isinstance(element, list):
+        return [expand(el) for el in element]
+    return element
+
+
+class Namespace(Mapping):
+    """ Provides recursive attribute style access to a dict-like structure
+
+    Examples
+    --------
+    >>> ns = Namespace.build({"a": 1, "b.c": "val"})
+    >>> ns.a
+    1
+    >>> ns["a"]
+    1
+    >>> ns.b
+    <Namespace {'c': 'val'}>
+    >>> ns["b"]
+    <Namespace {'c': 'val'}>
+    >>> ns.b.c
+    'val'
+    >>> ns["b.c"]
+    'val'
+    >>> ns["b"]["c"]
+    'val'
+    >>> ns.b["c"]
+    'val'
+    >>> ns["b"].c
+    'val'
+    """
+    def __init__(self, *args, **kwargs):
+        self._properties = dict(*args, **kwargs)
+
+    @classmethod
+    def build(cls, mapping):
+        """ Expand mapping recursively and return as namespace """
+        return cls(expand(mapping))
+
+    def __getattribute__(self, key):
+        # Return actual properties first
+        err = None
+        try:
+            return super().__getattribute__(key)
+        except AttributeError as e:
+            err = e
+
+        # Utilize __getitem__ but keep original error on failure
+        try:
+            return self[key]
+        except KeyError:
+            raise err
+
+    def __getitem__(self, key):
+        key, dot, subkey = key.partition(".")
+        val = self._properties[key]
+        if isinstance(val, dict):
+            val = self.__class__(val)
+        if dot:
+            # Recursive step
+            val = val[subkey]
+        return val
+
+    def __repr__(self):
+        return f"<Namespace {self._properties}>"
+
+    def __len__(self):
+        return len(self._properties)
+
+    def __iter__(self):
+        return iter(self._properties)
 
 
 def dereference_yaml(schema, struct):

--- a/tools/schemacode/schemacode/tests/test_schema.py
+++ b/tools/schemacode/schemacode/tests/test_schema.py
@@ -1,5 +1,6 @@
 """Tests for the schemacode package."""
 import pytest
+import yaml
 
 from schemacode import schema
 
@@ -143,3 +144,133 @@ def test_formats(schema_obj):
             assert not bool(
                 search.fullmatch(test_string)
             ), f"'{test_string}' should not be a valid match for the pattern '{search.pattern}'"
+
+
+def test_dereferencing():
+    orig = {
+        "ReferencedObject": {
+            "Property1": "value1",
+            "Property2": "value2",
+        },
+        "ReferencingObject": {
+            "$ref": "ReferencedObject",
+            "Property2": "value4",
+        },
+    }
+    dereffed = schema.dereference_yaml(orig, orig.copy())
+    assert dereffed == {
+        "ReferencedObject": {
+            "Property1": "value1",
+            "Property2": "value2",
+        },
+        "ReferencingObject": {
+            "Property1": "value1",
+            "Property2": "value4",
+        },
+    }
+
+    orig = {
+        "raw.func": {
+            "suffix": ["bold", "cbv"],
+            "extensions": [".nii", ".nii.gz"],
+            "datatype": ["func"],
+            "entities": {
+                "subject": "required",
+                "session": "optional",
+                "task": "required",
+                "dir": "optional",
+            },
+        },
+        "derived.func": {
+            "$ref": "raw.func",
+            "entities": {
+                "$ref": "raw.func.entities",
+                "space": "optional",
+                "desc": "optional",
+            },
+        },
+    }
+
+    sch = schema.Namespace.build(orig)
+    expanded = schema.expand(orig)
+    dereffed = schema.dereference_yaml(sch, expanded)
+    assert dereffed == {
+        "raw": {"func": {
+            "suffix": ["bold", "cbv"],
+            "extensions": [".nii", ".nii.gz"],
+            "datatype": ["func"],
+            "entities": {
+                "subject": "required",
+                "session": "optional",
+                "task": "required",
+                "dir": "optional",
+            },
+        }},
+        "derived": {"func": {
+            "suffix": ["bold", "cbv"],
+            "extensions": [".nii", ".nii.gz"],
+            "datatype": ["func"],
+            "entities": {
+                "subject": "required",
+                "session": "optional",
+                "task": "required",
+                "dir": "optional",
+                "space": "optional",
+                "desc": "optional",
+            },
+        }},
+    }
+
+    orig = {
+        "_DERIV_ENTS": {
+            "space": "optional",
+            "desc": "optional",
+        },
+        "raw.func": {
+            "suffix": ["bold", "cbv"],
+            "extensions": [".nii", ".nii.gz"],
+            "datatype": ["func"],
+            "entities": {
+                "subject": "required",
+                "session": "optional",
+                "task": "required",
+                "dir": "optional",
+            },
+        },
+        "derived.func": {
+            "$ref": "raw.func",
+            "entities": {
+                "$ref": "_DERIV_ENTS",
+            },
+        },
+    }
+
+    sch = schema.Namespace.build(orig)
+    expanded = schema.expand(orig)
+    dereffed = schema.dereference_yaml(sch, expanded)
+    assert dereffed == {
+        "_DERIV_ENTS": {
+            "space": "optional",
+            "desc": "optional",
+        },
+        "raw": {"func": {
+            "suffix": ["bold", "cbv"],
+            "extensions": [".nii", ".nii.gz"],
+            "datatype": ["func"],
+            "entities": {
+                "subject": "required",
+                "session": "optional",
+                "task": "required",
+                "dir": "optional",
+            },
+        }},
+        "derived": {"func": {
+            "suffix": ["bold", "cbv"],
+            "extensions": [".nii", ".nii.gz"],
+            "datatype": ["func"],
+            "entities": {
+                "space": "optional",
+                "desc": "optional",
+            },
+        }},
+    }


### PR DESCRIPTION
Started by trying out an example inspired by #1072. Needed to create a `Namespace` object. Need to start loading multiple files and testing out fully qualified references.