### PR TITLE
SCHEMA: Update references to use _ref instead of $ref

### DIFF
--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -316,14 +316,14 @@ ExampleField:
 ```
 
 Furthermore, if the data type description of a field is reused across fields,
-then it may be defined in a separate field and referenced in each target field with the `$ref` keyword.
-Here is an example of a field definition using `$ref`:
+then it may be defined in a separate field and referenced in each target field with the `_ref` keyword.
+Here is an example of a field definition using `_ref`:
 ```yaml
 ExampleField:
     name: ExampleField
     description: |
         The description of "ExampleField".
-    $ref: _ReferenceField
+    _ref: _ReferenceField
 ```
 The target field (`_ReferenceField` in this case) MUST be located in
 the metadata YAML file, and MUST contain all information
@@ -341,7 +341,7 @@ _ReferenceField:
         - PossibleValue2
 ```
 
-The result of including `$ref` makes the `ExampleField` above equivalent to the following format:
+The result of including `_ref` makes the `ExampleField` above equivalent to the following format:
 ```yaml
 ExampleField:
     name: ExampleField

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -66,10 +66,10 @@ AnatomicalLandmarkCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"AnatomicalLandmarkCoordinateSystemDescription"`.
   anyOf:
-  - $ref: _MEGCoordSys
-  - $ref: _EEGCoordSys
-  - $ref: _StandardTemplateCoordSys
-  - $ref: _StandardTemplateDeprecatedCoordSys
+  - _ref: _MEGCoordSys
+  - _ref: _EEGCoordSys
+  - _ref: _StandardTemplateCoordSys
+  - _ref: _StandardTemplateDeprecatedCoordSys
 AnatomicalLandmarkCoordinateSystemDescription:
   name: AnatomicalLandmarkCoordinateSystemDescription
   description: |
@@ -552,10 +552,10 @@ DigitizedHeadPointsCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"DigitizedHeadPointsCoordinateSystemDescription"`.
   anyOf:
-  - $ref: _MEGCoordSys
-  - $ref: _EEGCoordSys
-  - $ref: _StandardTemplateCoordSys
-  - $ref: _StandardTemplateDeprecatedCoordSys
+  - _ref: _MEGCoordSys
+  - _ref: _EEGCoordSys
+  - _ref: _StandardTemplateCoordSys
+  - _ref: _StandardTemplateDeprecatedCoordSys
 DigitizedHeadPointsCoordinateSystemDescription:
   name: DigitizedHeadPointsCoordinateSystemDescription
   description: |
@@ -642,10 +642,10 @@ EEGCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `EEGCoordinateSystemDescription`.
   anyOf:
-  - $ref: _MEGCoordSys
-  - $ref: _EEGCoordSys
-  - $ref: _StandardTemplateCoordSys
-  - $ref: _StandardTemplateDeprecatedCoordSys
+  - _ref: _MEGCoordSys
+  - _ref: _EEGCoordSys
+  - _ref: _StandardTemplateCoordSys
+  - _ref: _StandardTemplateDeprecatedCoordSys
 EEGCoordinateSystemDescription:
   name: EEGCoordinateSystemDescription
   description: |
@@ -828,10 +828,10 @@ FiducialsCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"FiducialsCoordinateSystemDescription"`.
   anyOf:
-  - $ref: _MEGCoordSys
-  - $ref: _EEGCoordSys
-  - $ref: _StandardTemplateCoordSys
-  - $ref: _StandardTemplateDeprecatedCoordSys
+  - _ref: _MEGCoordSys
+  - _ref: _EEGCoordSys
+  - _ref: _StandardTemplateCoordSys
+  - _ref: _StandardTemplateDeprecatedCoordSys
 FiducialsCoordinateSystemDescription:
   name: FiducialsCoordinateSystemDescription
   description: |
@@ -961,10 +961,10 @@ GeneticLevel:
     Values MUST be one of `"Genetic"`, `"Genomic"`, `"Epigenomic"`,
     `"Transcriptomic"`, `"Metabolomic"`, or `"Proteomic"`.
   anyOf:
-  - $ref: _GeneticLevelEnum
+  - _ref: _GeneticLevelEnum
   - type: array
     items:
-      $ref: _GeneticLevelEnum
+      _ref: _GeneticLevelEnum
 Genetics.Database:
   name: Genetics.Database
   description: |
@@ -998,11 +998,11 @@ Genetics:
   type: object
   properties:
     Database:
-      $ref: Genetics.Database
+      _ref: Genetics.Database
     Dataset:
-      $ref: Genetics.Dataset
+      _ref: Genetics.Dataset
     Descriptors:
-      $ref: Genetics.Descriptors
+      _ref: Genetics.Descriptors
 GradientSetType:
   name: GradientSetType
   description: |
@@ -1072,10 +1072,10 @@ HeadCoilCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `HeadCoilCoordinateSystemDescription`.
   anyOf:
-  - $ref: _MEGCoordSys
-  - $ref: _EEGCoordSys
-  - $ref: _StandardTemplateCoordSys
-  - $ref: _StandardTemplateDeprecatedCoordSys
+  - _ref: _MEGCoordSys
+  - _ref: _EEGCoordSys
+  - _ref: _StandardTemplateCoordSys
+  - _ref: _StandardTemplateDeprecatedCoordSys
 HeadCoilCoordinateSystemDescription:
   name: HeadCoilCoordinateSystemDescription
   description: |
@@ -1492,10 +1492,10 @@ MEGCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"MEGCoordinateSystemDescription"`.
   anyOf:
-  - $ref: _MEGCoordSys
-  - $ref: _EEGCoordSys
-  - $ref: _StandardTemplateCoordSys
-  - $ref: _StandardTemplateDeprecatedCoordSys
+  - _ref: _MEGCoordSys
+  - _ref: _EEGCoordSys
+  - _ref: _StandardTemplateCoordSys
+  - _ref: _StandardTemplateDeprecatedCoordSys
 MEGCoordinateSystemDescription:
   name: MEGCoordinateSystemDescription
   description: |
@@ -2622,15 +2622,15 @@ StimulusPresentation:
   type: object
   properties:
     OperatingSystem:
-      $ref: OperatingSystem
+      _ref: OperatingSystem
     SoftwareName:
-      $ref: SoftwareName
+      _ref: SoftwareName
     SoftwareRRID:
-      $ref: SoftwareRRID
+      _ref: SoftwareRRID
     SoftwareVersion:
-      $ref: SoftwareVersion
+      _ref: SoftwareVersion
     Code:
-      $ref: Code
+      _ref: Code
 SubjectArtefactDescription:
   name: SubjectArtefactDescription
   description: |
@@ -2945,9 +2945,9 @@ iEEGCoordinateSystem:
     [2D coordinate systems](/04-modality-specific-files/04-intracranial\
     -electroencephalography.html#allowed-2d-coordinate-systems).
   anyOf:
-  - $ref: _iEEGCoordSys
-  - $ref: _StandardTemplateCoordSys
-  - $ref: _StandardTemplateDeprecatedCoordSys
+  - _ref: _iEEGCoordSys
+  - _ref: _StandardTemplateCoordSys
+  - _ref: _StandardTemplateDeprecatedCoordSys
 iEEGCoordinateSystemDescription:
   name: iEEGCoordinateSystemDescription
   description: |

--- a/tools/schemacode/schemacode/schema.py
+++ b/tools/schemacode/schemacode/schema.py
@@ -21,17 +21,17 @@ def _get_entry_name(path):
         return path.name
 
 
-def dereference_yaml(schema, struct):
-    """Recursively search a dictionary-like object for $ref keys.
+def dereference_yaml(schema, struct, ref_key="_ref"):
+    """Recursively search a dictionary-like object for _ref keys.
 
-    Each $ref key is replaced with the contents of the referenced field in the overall
+    Each _ref key is replaced with the contents of the referenced field in the overall
     dictionary-like object.
     """
     if isinstance(struct, dict):
-        if "$ref" in struct:
-            ref_field = struct["$ref"]
+        if ref_key in struct:
+            ref_field = struct[ref_key]
             template = schema[ref_field]
-            struct.pop("$ref")
+            struct.pop(ref_key)
             # Result is template object with local overrides
             struct = {**template, **struct}
 


### PR DESCRIPTION
It looks like using `$ref` will cause issues with the MATLAB YAML reader (or maybe just MATLAB). I think `_ref` is very unlikely to hit collisions while being friendly to various languages.