### PR TITLE
ENH: use __file__ instead of getcwd to determine HERE, provide informative message on # of files

### DIFF
--- a/tools/no-bad-latin.py
+++ b/tools/no-bad-latin.py
@@ -11,14 +11,17 @@ import re
 import argparse
 from pull_files import filter_files
 
-HERE = os.getcwd()
-ABSOLUTE_HERE = os.path.dirname(HERE)
+ABSOLUTE_HERE = os.path.dirname(os.path.dirname(__file__))
 IGNORE_LIST = ["CHANGES.md", "01-contributors.md", "pregh-changes.md"]
 
 
 def parse_args():
     """Construct command line interface for parsing Pull Request number"""
-    DESCRIPTION = "Script to check for latin phrases in Markdown files"
+    DESCRIPTION = """Script to check for latin phrases in Markdown files.
+
+If no pull request number is provided, all relevant text files in the
+bids-specification are checked."""
+
     parser = argparse.ArgumentParser(description=DESCRIPTION)
 
     parser.add_argument(
@@ -121,6 +124,7 @@ def read_and_check_files(files):
             except FileNotFoundError:
                 pass
 
+    print(f"Checked {len(files)} files. {len(failing_files)} with problems.")
     return failing_files
 
 


### PR DESCRIPTION
I had to spend some time to figure out why running that script did nothing for me
but failed in CI for the PR.  Apparently it was because I had to run it while
in tools/ directory.  IMHO it is suboptimal.

With a short message on how many files were analyzed user at least could
get a hint in case if no files were read at all