### PR TITLE
SCHEMA convert selectors and checks to javascript

### DIFF
--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -20,10 +20,10 @@ ASLLabelingDurationNiftiLength:
     level: error
   selectors:
   - suffix == "asl"
-  - sidecar contains "LabelingDuration"
-  - type(sidecar.LabelingDuration) == "array"
+  - 'sidecar'.includes('"LabelingDuration")'
+  - sidecar.LabelingDuration.constructor.isArray(sidecar.LabelingDuration)
   checks:
-  - nifti_header.dim[4] == len(sidecar.LabelingDuration)
+  - nifti_header.dim[4] == sidecar.LabelingDuration.length
 
 # 165
 ASLContextConsistent:
@@ -35,7 +35,7 @@ ASLContextConsistent:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
+  - 'associations'.includes('"aslcontext")'
   checks:
   - nifti_header.dim[4] == associations.aslcontext.n_rows
 
@@ -55,10 +55,10 @@ ASLFlipAngleNiftiLength:
     level: error
   selectors:
   - suffix == "asl"
-  - sidecar contains "FlipAngle"
-  - type(sidecar.FlipAngle) == "array"
+  - 'sidecar'.includes('"FlipAngle")'
+  - sidecar.FlipAngle.constructor.isArray(sidecar.FlipAngle)
   checks:
-  - nifti_header.dim[4] == len(sidecar.FlipAngle)
+  - nifti_header.dim[4] == sidecar.FlipAngle.length
 
 # 172
 ASLFlipAngleASLContextLength:
@@ -76,11 +76,11 @@ ASLFlipAngleASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - sidecar contains "FlipAngle"
-  - type(sidecar.FlipAngle) == "array"
+  - 'associations'.includes('"aslcontext")'
+  - 'sidecar'.includes('"FlipAngle")'
+  - sidecar.FlipAngle.constructor.isArray(sidecar.FlipAngle)
   checks:
-  - aslcontext.n_rows == sidecar.FlipAngle.size
+  - aslcontext.n_rows == sidecar.FlipAngle.length
 
 # 173
 ASLPostLabelingDelayNiftiLength:
@@ -101,10 +101,10 @@ ASLPostLabelingDelayNiftiLength:
     level: error
   selectors:
   - suffix == "asl"
-  - sidecar contains "PostLabelingDelay"
-  - type(sidecar.PostLabelingDelay) == "array"
+  - 'associations'.includes('"aslcontext")'
+  - sidecar.PostLabelingDelay.constructor.isArray(sidecar.PostLabelingDelay)
   checks:
-  - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.size
+  - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.length
 
 # 174
 ASLPostLabelingDelayASLContextLength:
@@ -125,11 +125,10 @@ ASLPostLabelingDelayASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - sidecar contains "PostLabelingDelay"
-  - type(sidecar.PostLabelingDelay) == "array"
+  - 'associations'.includes('"aslcontext")'
+  - sidecar.PostLabelingDelay.constructor.isArray(sidecar.PostLabelingDelay)
   checks:
-  - aslcontext.n_rows == sidecar.PostLabelingDelay.size
+  - aslcontext.n_rows == sidecar.PostLabelingDelay.length
 
 # 175
 ASLLabelingDurationASLContextLength:
@@ -151,11 +150,11 @@ ASLLabelingDurationASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - sidecar contains "LabelingDuration"
-  - type(sidecar.LabelingDuration) == "array"
+  - 'associations'.includes('"aslcontext")'
+  - 'sidecar'.includes('"LabelingDuration")'
+  - sidecar.LabelingDuration.cobstructor.isArray(sidecar.LabelingDuration)
   checks:
-  - aslcontext.n_rows == sidecar.LabelingDuration.size
+  - aslcontext.n_rows == sidecar.LabelingDuration.length
 
 # 177
 ASLRepetitionTimePreparationASLContextLength:
@@ -172,11 +171,11 @@ ASLRepetitionTimePreparationASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - sidecar contains "RepetitionTimePreparation"
-  - type(sidecar.RepetitionTimePreparation) == "array"
+  - 'associations'.includes('"aslcontext")'
+  - 'sidecar'.includes('"RepetitionTimePreparation")'
+  - sidecar.RepetitionTimePreparation.constructor.isArray(sidecar.RepetitionTimePreparation)
   checks:
-  - aslcontext.n_rows == sidecar.RepetitionTimePreparation.size
+  - aslcontext.n_rows == sidecar.RepetitionTimePreparation.length
 
 # 180
 ASLBackgroundSuppressionNumberPulses:
@@ -190,11 +189,11 @@ ASLBackgroundSuppressionNumberPulses:
     level: warning
   selectors:
   - suffix == "asl"
-  - sidecar contains "BackgroundSuppressionNumberPulses"
-  - sidecar contains "BackgroundSuppressionPulseTime"
-  - type(sidecar.BackgroundSuppressionPulseTime) == "array"
+  - 'sidecar'.includes('"BackgroundSuppressionNumberPulses")'
+  - 'sidecar'.includes('"BackgroundSuppressionPulseTime")'
+  - sidecar.BackgroundSuppressionPulseTime.constructor.isArray(sidecar.BackgroundSuppressionPulseTime)
   checks:
-  - sidecar.BackgroundSuppressionPulseTime.size == sidecar.BackgroundSuppressionNumberPulses
+  - sidecar.BackgroundSuppressionPulseTime.length == sidecar.BackgroundSuppressionNumberPulses
 
 # 181
 ASLTotalAcquiredVolumesASLContextLength:
@@ -208,8 +207,8 @@ ASLTotalAcquiredVolumesASLContextLength:
     level: warning
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - sidecar contains "TotalAcquiredVolumes"
+  - 'associations'.includes('"aslcontext")'
+  - 'sidecar'.includes('"TotalAcquiredVolumes")'
   checks:
   - aslcontext.n_rows == sidecar.TotalAcquiredVolumes
 
@@ -224,11 +223,11 @@ ASLEchoTimeASLContextLength:
     level: warning
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - sidecar contains "EchoTime"
-  - type(sidecar.EchoTime) == "array"
+  - 'associations'.includes('"aslcontext")'
+  - 'sidecar'.includes('"EchoTime")'
+  - sidecar.EchoTime.constructor.isArray(sidecar.EchoTime)
   checks:
-  - aslcontext.n_rows == sidecar.EchoTime.size
+  - aslcontext.n_rows == sidecar.EchoTime.length
 
 # 198
 ASLM0TypeAbsentScan:
@@ -241,9 +240,9 @@ ASLM0TypeAbsentScan:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - associations contains "m0scan"
-  - sidecar contains "M0Type"
+  - 'associations'.includes('"aslcontext")'
+  - 'associations'.includes('"m0scan")'
+  - 'sidecar'.includes('"M0Type")'
   checks:
   - sidecar.M0Type != "absent"
 
@@ -257,9 +256,9 @@ ASLM0TypeAbsentASLContext:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - aslcontext.volume_type contains "m0scan"
-  - sidecar contains "M0Type"
+  - 'associations'.includes('"aslcontext")'
+  - 'aslcontext.volume_type'.includes('"m0scan")'
+  - 'sidecar'.includes('"M0Type")'
   checks:
   - sidecar.M0Type != "absent"
 
@@ -273,8 +272,8 @@ ASLM0TypeIncorrect:
     level: error
   selectors:
   - suffix == "asl"
-  - associations contains "aslcontext"
-  - sidecar contains "M0Type"
+  - 'associations'.includes('"aslcontext")'
+  - 'sidecar'.includes('"M0Type")'
   - sidecar.M0Type == "separate"
   checks:
-  - associations contains "m0scan"
+  - 'associations'.includes('"m0scan")'

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -20,7 +20,7 @@ ASLLabelingDurationNiftiLength:
     level: error
   selectors:
   - suffix == "asl"
-  - 'sidecar'.includes('"LabelingDuration")'
+  - '"LabelingDuration" in sidecar'
   - sidecar.LabelingDuration.constructor.isArray(sidecar.LabelingDuration)
   checks:
   - nifti_header.dim[4] == sidecar.LabelingDuration.length
@@ -35,7 +35,7 @@ ASLContextConsistent:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
+  - '"aslcontext" in associations'
   checks:
   - nifti_header.dim[4] == associations.aslcontext.n_rows
 
@@ -55,7 +55,7 @@ ASLFlipAngleNiftiLength:
     level: error
   selectors:
   - suffix == "asl"
-  - 'sidecar'.includes('"FlipAngle")'
+  - '"FlipAngle" in sidecar'
   - sidecar.FlipAngle.constructor.isArray(sidecar.FlipAngle)
   checks:
   - nifti_header.dim[4] == sidecar.FlipAngle.length
@@ -76,8 +76,8 @@ ASLFlipAngleASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'sidecar'.includes('"FlipAngle")'
+  - '"aslcontext" in associations'
+  - '"FlipAngle" in sidecar'
   - sidecar.FlipAngle.constructor.isArray(sidecar.FlipAngle)
   checks:
   - aslcontext.n_rows == sidecar.FlipAngle.length
@@ -101,7 +101,7 @@ ASLPostLabelingDelayNiftiLength:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
+  - '"aslcontext" in associations'
   - sidecar.PostLabelingDelay.constructor.isArray(sidecar.PostLabelingDelay)
   checks:
   - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.length
@@ -125,7 +125,7 @@ ASLPostLabelingDelayASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
+  - '"aslcontext" in associations'
   - sidecar.PostLabelingDelay.constructor.isArray(sidecar.PostLabelingDelay)
   checks:
   - aslcontext.n_rows == sidecar.PostLabelingDelay.length
@@ -150,8 +150,8 @@ ASLLabelingDurationASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'sidecar'.includes('"LabelingDuration")'
+  - '"aslcontext" in associations'
+  - '"LabelingDuration" in sidecar'
   - sidecar.LabelingDuration.cobstructor.isArray(sidecar.LabelingDuration)
   checks:
   - aslcontext.n_rows == sidecar.LabelingDuration.length
@@ -171,8 +171,8 @@ ASLRepetitionTimePreparationASLContextLength:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'sidecar'.includes('"RepetitionTimePreparation")'
+  - '"aslcontext" in associations'
+  - '"RepetitionTimePreparation" in sidecar'
   - sidecar.RepetitionTimePreparation.constructor.isArray(sidecar.RepetitionTimePreparation)
   checks:
   - aslcontext.n_rows == sidecar.RepetitionTimePreparation.length
@@ -189,8 +189,8 @@ ASLBackgroundSuppressionNumberPulses:
     level: warning
   selectors:
   - suffix == "asl"
-  - 'sidecar'.includes('"BackgroundSuppressionNumberPulses")'
-  - 'sidecar'.includes('"BackgroundSuppressionPulseTime")'
+  - '"BackgroundSuppressionNumberPulses" in sidecar'
+  - '"BackgroundSuppressionPulseTime" in sidecar'
   - sidecar.BackgroundSuppressionPulseTime.constructor.isArray(sidecar.BackgroundSuppressionPulseTime)
   checks:
   - sidecar.BackgroundSuppressionPulseTime.length == sidecar.BackgroundSuppressionNumberPulses
@@ -207,8 +207,8 @@ ASLTotalAcquiredVolumesASLContextLength:
     level: warning
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'sidecar'.includes('"TotalAcquiredVolumes")'
+  - '"aslcontext" in associations'
+  - '"TotalAcquiredVolumes" in sidecar'
   checks:
   - aslcontext.n_rows == sidecar.TotalAcquiredVolumes
 
@@ -223,8 +223,8 @@ ASLEchoTimeASLContextLength:
     level: warning
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'sidecar'.includes('"EchoTime")'
+  - '"aslcontext" in associations'
+  - '"EchoTime" in sidecar'
   - sidecar.EchoTime.constructor.isArray(sidecar.EchoTime)
   checks:
   - aslcontext.n_rows == sidecar.EchoTime.length
@@ -240,9 +240,9 @@ ASLM0TypeAbsentScan:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'associations'.includes('"m0scan")'
-  - 'sidecar'.includes('"M0Type")'
+  - '"aslcontext" in associations'
+  - '"m0scan" in associations'
+  - '"M0Type" in sidecar'
   checks:
   - sidecar.M0Type != "absent"
 
@@ -256,9 +256,9 @@ ASLM0TypeAbsentASLContext:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'aslcontext.volume_type'.includes('"m0scan")'
-  - 'sidecar'.includes('"M0Type")'
+  - '"aslcontext" in associations'
+  - aslcontext.volume_type.includes('"m0scan")
+  - '"M0Type" in sidecar'
   checks:
   - sidecar.M0Type != "absent"
 
@@ -272,8 +272,8 @@ ASLM0TypeIncorrect:
     level: error
   selectors:
   - suffix == "asl"
-  - 'associations'.includes('"aslcontext")'
-  - 'sidecar'.includes('"M0Type")'
+  - '"aslcontext" in associations'
+  - '"M0Type" in sidecar'
   - sidecar.M0Type == "separate"
   checks:
-  - 'associations'.includes('"m0scan")'
+  - '"m0scan" in associations'

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -21,7 +21,7 @@ ASLLabelingDurationNiftiLength:
   selectors:
   - suffix == "asl"
   - '"LabelingDuration" in sidecar'
-  - sidecar.LabelingDuration.constructor.isArray(sidecar.LabelingDuration)
+  - type(sidecar.LabelingDuration) == 'array'
   checks:
   - nifti_header.dim[4] == sidecar.LabelingDuration.length
 
@@ -56,7 +56,7 @@ ASLFlipAngleNiftiLength:
   selectors:
   - suffix == "asl"
   - '"FlipAngle" in sidecar'
-  - sidecar.FlipAngle.constructor.isArray(sidecar.FlipAngle)
+  - type(sidecar.FlipAngle) == 'array'
   checks:
   - nifti_header.dim[4] == sidecar.FlipAngle.length
 
@@ -78,7 +78,7 @@ ASLFlipAngleASLContextLength:
   - suffix == "asl"
   - '"aslcontext" in associations'
   - '"FlipAngle" in sidecar'
-  - sidecar.FlipAngle.constructor.isArray(sidecar.FlipAngle)
+  - type(sidecar.FlipAngle) == 'array'
   checks:
   - aslcontext.n_rows == sidecar.FlipAngle.length
 
@@ -102,7 +102,7 @@ ASLPostLabelingDelayNiftiLength:
   selectors:
   - suffix == "asl"
   - '"aslcontext" in associations'
-  - sidecar.PostLabelingDelay.constructor.isArray(sidecar.PostLabelingDelay)
+  - type(sidecar.PostLabelingDelay) == 'array'
   checks:
   - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.length
 
@@ -126,7 +126,7 @@ ASLPostLabelingDelayASLContextLength:
   selectors:
   - suffix == "asl"
   - '"aslcontext" in associations'
-  - sidecar.PostLabelingDelay.constructor.isArray(sidecar.PostLabelingDelay)
+  - type(sidecar.PostLabelingDelay) == 'array'
   checks:
   - aslcontext.n_rows == sidecar.PostLabelingDelay.length
 
@@ -152,7 +152,7 @@ ASLLabelingDurationASLContextLength:
   - suffix == "asl"
   - '"aslcontext" in associations'
   - '"LabelingDuration" in sidecar'
-  - sidecar.LabelingDuration.cobstructor.isArray(sidecar.LabelingDuration)
+  - type(sidecar.LabelingDuration) == 'array'
   checks:
   - aslcontext.n_rows == sidecar.LabelingDuration.length
 
@@ -173,7 +173,7 @@ ASLRepetitionTimePreparationASLContextLength:
   - suffix == "asl"
   - '"aslcontext" in associations'
   - '"RepetitionTimePreparation" in sidecar'
-  - sidecar.RepetitionTimePreparation.constructor.isArray(sidecar.RepetitionTimePreparation)
+  - type(sidecar.RepetitionTimePreparation) == 'array'
   checks:
   - aslcontext.n_rows == sidecar.RepetitionTimePreparation.length
 
@@ -191,7 +191,7 @@ ASLBackgroundSuppressionNumberPulses:
   - suffix == "asl"
   - '"BackgroundSuppressionNumberPulses" in sidecar'
   - '"BackgroundSuppressionPulseTime" in sidecar'
-  - sidecar.BackgroundSuppressionPulseTime.constructor.isArray(sidecar.BackgroundSuppressionPulseTime)
+  - type(sidecar.BackgroundSuppressionPulseTime) == 'array'
   checks:
   - sidecar.BackgroundSuppressionPulseTime.length == sidecar.BackgroundSuppressionNumberPulses
 
@@ -225,7 +225,7 @@ ASLEchoTimeASLContextLength:
   - suffix == "asl"
   - '"aslcontext" in associations'
   - '"EchoTime" in sidecar'
-  - sidecar.EchoTime.constructor.isArray(sidecar.EchoTime)
+  - type(sidecar.EchoTime) == 'array'
   checks:
   - aslcontext.n_rows == sidecar.EchoTime.length
 

--- a/src/schema/rules/checks/dwi.yaml
+++ b/src/schema/rules/checks/dwi.yaml
@@ -10,8 +10,8 @@ DWIVolumeCount:
   level: error
   selectors:
   - suffix == "dwi"
-  - 'associations' .includes('"bval")'
-  - 'associations' .includes('"bvec")'
+  - '"bval" in associations'
+  - '"bvec" in associations'
   checks:
   - associations.bval.n_cols == nifti_header.dim[4]
   - associations.bvec.n_cols == nifti_header.dim[4]
@@ -47,7 +47,7 @@ DWIMissingBvec:
   selectors:
   - suffix == "dwi"
   checks:
-  - 'associations'.includes('"bvec")'
+  - '"bvec" in associations'
 
 # 33
 DWIMissingBval:
@@ -58,4 +58,4 @@ DWIMissingBval:
   selectors:
   - suffix == "dwi"
   checks:
-  - 'associations'.includes('"bval")'
+  - '"bval" in associations'

--- a/src/schema/rules/checks/dwi.yaml
+++ b/src/schema/rules/checks/dwi.yaml
@@ -10,8 +10,8 @@ DWIVolumeCount:
   level: error
   selectors:
   - suffix == "dwi"
-  - associations contains "bval"
-  - associations contains "bvec"
+  - 'associations' .includes('"bval")'
+  - 'associations' .includes('"bvec")'
   checks:
   - associations.bval.n_cols == nifti_header.dim[4]
   - associations.bvec.n_cols == nifti_header.dim[4]
@@ -47,7 +47,7 @@ DWIMissingBvec:
   selectors:
   - suffix == "dwi"
   checks:
-  - associations contains "bvec"
+  - 'associations'.includes('"bvec")'
 
 # 33
 DWIMissingBval:
@@ -58,4 +58,4 @@ DWIMissingBval:
   selectors:
   - suffix == "dwi"
   checks:
-  - associations contains "bval"
+  - 'associations'.includes('"bval")'

--- a/src/schema/rules/checks/events.yaml
+++ b/src/schema/rules/checks/events.yaml
@@ -10,8 +10,8 @@ EventsMissing:
       If this is a resting state scan you can ignore this warning or rename the task to include the word "rest".
     level: warning  # could be an error with the proper selectors, I think
   selectors:
-  - entities contains "task"
+  - 'entities'.includes('"task)'
   - entities.task != "rest"
-  - entities.task not(contains "rest")  # Alternative for including the word "rest"
+  - 'entities.task) # Alternative for including the word "rest".includes(!("rest")'
   checks:
-  - associations contains "events"
+  - 'associations'.includes('"events")'

--- a/src/schema/rules/checks/events.yaml
+++ b/src/schema/rules/checks/events.yaml
@@ -10,8 +10,7 @@ EventsMissing:
       If this is a resting state scan you can ignore this warning or rename the task to include the word "rest".
     level: warning  # could be an error with the proper selectors, I think
   selectors:
-  - 'entities'.includes('"task)'
-  - entities.task != "rest"
-  - 'entities.task) # Alternative for including the word "rest".includes(!("rest")'
+  - '"task" in entities'
+  - '!(entities.task.includes("rest"))'
   checks:
-  - 'associations'.includes('"events")'
+  - '"events" in associations'

--- a/src/schema/rules/checks/fmap.yaml
+++ b/src/schema/rules/checks/fmap.yaml
@@ -11,7 +11,7 @@ FmapFieldmapWithoutMagnitude:
   selectors:
   - suffix == "fieldmap"
   checks:
-  - associations contains "magnitude"
+  - 'associations'.includes('"magnitude")'
 
 # 92
 FmapPhasediffWithoutMagnitude:
@@ -23,4 +23,4 @@ FmapPhasediffWithoutMagnitude:
   selectors:
   - suffix == "phasediff"
   checks:
-  - associations contains "magnitude1"
+  - 'associations'.includes('"magnitude1")'

--- a/src/schema/rules/checks/fmap.yaml
+++ b/src/schema/rules/checks/fmap.yaml
@@ -11,7 +11,7 @@ FmapFieldmapWithoutMagnitude:
   selectors:
   - suffix == "fieldmap"
   checks:
-  - 'associations'.includes('"magnitude")'
+  - '"magnitude" in associations'
 
 # 92
 FmapPhasediffWithoutMagnitude:
@@ -23,4 +23,4 @@ FmapPhasediffWithoutMagnitude:
   selectors:
   - suffix == "phasediff"
   checks:
-  - 'associations'.includes('"magnitude1")'
+  - '"magnitude1" in associations'

--- a/src/schema/rules/checks/func.yaml
+++ b/src/schema/rules/checks/func.yaml
@@ -1,0 +1,14 @@
+PhaseSuffixDeprecated:
+  issue:
+    code: PHASE_SUFFIX_DEPRECATED
+    message: |
+      DEPRECATED. Phase information associated with magnitude information stored in BOLD contrast.
+      This suffix should be replaced by the part-phase in conjunction with the bold suffix.
+      For backwards compatibility, _phase is considered equivalent to _part-phase_bold.
+      When the _phase suffix is not used, each file shares the same name with the exception of the
+      part-<mag|phase> or part-<real|imag> key/value.
+    level: warning
+  selectors:
+  - datatype == "func"
+  checks:
+  - '!(suffix == "phase")'

--- a/src/schema/rules/common_derivatives_validation.yaml
+++ b/src/schema/rules/common_derivatives_validation.yaml
@@ -2,17 +2,17 @@
 ResInSidecar:
     selectors:
     - dataset.dataset_description.DatasetType == "derivative"
-    - modality in ["mri", "pet"]
-    - extension in ["nii", " nii.gz"]
-    - type(sidecar.Resolution) == "object"
+    - '["mri", "pet"].includes(modality)'
+    - '["nii", " nii.gz"].includes(extension)'
+    - typeof(sidecar.Resolution) == "object"
     checks:
-    - sidecar.Resolution contains entities.resolution
+    - entities.resolution in sidecar.Resolution
 
 DenInSidecar:
     selectors:
     - dataset.dataset_description.DatasetType == "derivative"
-    - modality in ["mri", "pet"]
-    - extension in [".nii", ".nii.gz"]
-    - type(sidecar.Density) == "object"
+    - '["mri", "pet"].includes(modality)'
+    - '[".nii", ".nii.gz"].includes(extension)'
+    - typeof(sidecar.Density) == "object"
     checks:
-    - sidecar.Density contains entities.density
+    - entities.density in sidecar.Density

--- a/src/schema/rules/common_derivatives_validation.yaml
+++ b/src/schema/rules/common_derivatives_validation.yaml
@@ -4,7 +4,7 @@ ResInSidecar:
     - dataset.dataset_description.DatasetType == "derivative"
     - '["mri", "pet"].includes(modality)'
     - '["nii", " nii.gz"].includes(extension)'
-    - typeof(sidecar.Resolution) == "object"
+    - type(sidecar.Resolution) == "object"
     checks:
     - entities.resolution in sidecar.Resolution
 
@@ -13,6 +13,6 @@ DenInSidecar:
     - dataset.dataset_description.DatasetType == "derivative"
     - '["mri", "pet"].includes(modality)'
     - '[".nii", ".nii.gz"].includes(extension)'
-    - typeof(sidecar.Density) == "object"
+    - type(sidecar.Density) == "object"
     checks:
     - entities.density in sidecar.Density

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -42,7 +42,7 @@ derivative_description:
 dataset_description_with_genetics:
   selectors:
   - path == "/dataset_description.json"
-  - 'dataset.files'.includes('"/genetic_info.json")'
+  - 'dataset.files.includes("/genetic_info.json")'
   fields:
     Genetics: REQUIRED
     Genetics{}.Dataset:

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -42,7 +42,7 @@ derivative_description:
 dataset_description_with_genetics:
   selectors:
   - path == "/dataset_description.json"
-  - dataset.files contains "/genetic_info.json"
+  - 'dataset.files'.includes('"/genetic_info.json")'
   fields:
     Genetics: REQUIRED
     Genetics{}.Dataset:

--- a/src/schema/rules/sidecars/anat.yaml
+++ b/src/schema/rules/sidecars/anat.yaml
@@ -16,3 +16,19 @@ MRIAnatomyCommonMetadataFields:
         ContrastBolusIngredient: OPTIONAL
         RepetitionTimeExcitation: OPTIONAL
         RepetitionTimePreparation: OPTIONAL
+
+PhaseEntityUnits:
+    selectors:
+    - modality == "MRI"
+    - datatype == "anat"
+    - entities.part == "phase"
+    fields:
+        Unit: REQUIRED
+
+PhaseSuffixUnits:
+    selectors:
+    - modality == "MRI"
+    - datatype == "anat"
+    - suffix == "phase"
+    fields:
+        Unit: REQUIRED

--- a/src/schema/rules/sidecars/asl.yaml
+++ b/src/schema/rules/sidecars/asl.yaml
@@ -29,7 +29,7 @@ MRIASLTextOnlySliceTiming:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - 'sidecar'.includes('"MRAcquisitionType")'
+    - '"MRAcquisitionType" in sidecar'
     - sidecar.MRAcquisitionType == "2D"
     fields:
         SliceTiming:
@@ -131,7 +131,7 @@ MRIASLCommonMetadataFieldsBackgroundSuppression:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - '"BackgroundSuppression" in sidecar'.
+    - '"BackgroundSuppression" in sidecar'
     - sidecar.BackgroundSuppression == true
     fields:
         BackgroundSuppressionNumberPulses: recommended
@@ -152,7 +152,7 @@ MRIASLPCASLSpecific:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - "ArterialSpinLabelingType" in sidecar'
+    - '"ArterialSpinLabelingType" in sidecar'
     - '["CASL", "PCASL"].includes(sidecar.ArterialSpinLabelingType)'
     fields:
         LabelingDuration: required

--- a/src/schema/rules/sidecars/asl.yaml
+++ b/src/schema/rules/sidecars/asl.yaml
@@ -29,7 +29,7 @@ MRIASLTextOnlySliceTiming:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "MRAcquisitionType"
+    - 'sidecar'.includes('"MRAcquisitionType")'
     - sidecar.MRAcquisitionType == "2D"
     fields:
         SliceTiming:
@@ -56,7 +56,7 @@ MRIASLTextOnlyFlipAngle:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "LookLocker"
+    - '"LookLocker in sidecar'
     - sidecar.LookLocker == true
     fields:
         FlipAngle:
@@ -113,7 +113,7 @@ MRIASLCommonMetadataFieldsM0Type:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "M0Type"
+    - '"M0Type" in sidecar'
     - sidecar.M0Type == "Estimate"
     fields:
         M0Estimate:
@@ -131,7 +131,7 @@ MRIASLCommonMetadataFieldsBackgroundSuppression:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "BackgroundSuppression"
+    - '"BackgroundSuppression" in sidecar'.
     - sidecar.BackgroundSuppression == true
     fields:
         BackgroundSuppressionNumberPulses: recommended
@@ -142,7 +142,7 @@ MRIASLCommonMetadataFieldsVascularCrushing:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "VascularCrushing"
+    - '"VascularCrushing" in sidecar'
     - sidecar.VascularCrushing == true
     fields:
         VascularCrushingVENC: recommended
@@ -152,8 +152,8 @@ MRIASLPCASLSpecific:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "ArterialSpinLabelingType"
-    - sidecar.ArterialSpinLabelingType in ["CASL", "PCASL"]
+    - "ArterialSpinLabelingType" in sidecar'
+    - '["CASL", "PCASL"].includes(sidecar.ArterialSpinLabelingType)'
     fields:
         LabelingDuration: required
         LabelingPulseAverageGradient: recommended
@@ -168,7 +168,7 @@ MRIASLPCASLSpecific2:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "ArterialSpinLabelingType"
+    - '"ArterialSpinLabelingType" in sidecar'
     - sidecar.ArterialSpinLabelingType == "PCASL"
     fields:
         PCASLType: recommended
@@ -178,7 +178,7 @@ MRIASLCASLSpecific:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "ArterialSpinLabelingType"
+    - '"ArterialSpinLabelingType" in sidecar'
     - sidecar.ArterialSpinLabelingType == "CASL"
     fields:
         CASLType: recommended
@@ -188,7 +188,7 @@ MRIASLPASLSpecific:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "ArterialSpinLabelingType"
+    - '"ArterialSpinLabelingType" in sidecar'
     - sidecar.ArterialSpinLabelingType == "PASL"
     fields:
         BolusCutOffFlag: required
@@ -206,9 +206,9 @@ MRIASLPASLSpecificBolusCutOffFlag:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    - sidecar contains "ArterialSpinLabelingType"
+    - '"ArterialSpinLabelingType" in sidecar'
     - sidecar.ArterialSpinLabelingType == "PASL"
-    - sidecar contains "BolusCutOffFlag"
+    - '"BolusCutOffFlag" in sidecar'
     - sidecar.BolusCutOffFlag == true
     fields:
         BolusCutOffDelayTime:
@@ -254,7 +254,7 @@ MRIASLM0ScanTextOnlyFlipAngle:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "m0scan"
-    - sidecar contains "LookLocker"
+    - '"LookLocker" in sidecar'
     - sidecar.LookLocker == true
     fields:
         FlipAngle:

--- a/src/schema/rules/sidecars/beh.yaml
+++ b/src/schema/rules/sidecars/beh.yaml
@@ -9,7 +9,7 @@
 # Metadata for either beh or events files
 BEHTabularData:
     selectors:
-    - suffix in ["beh", "events"]
+    - '["beh", "events"].includes(suffix)'
     fields:
         TaskName: recommended
         Instructions: recommended

--- a/src/schema/rules/sidecars/continuous.yaml
+++ b/src/schema/rules/sidecars/continuous.yaml
@@ -9,7 +9,7 @@
 # Metadata for either physio or stim files
 Continuous:
     selectors:
-    - suffix in ["physio", "stim"]
+    - '["physio", "stim"].includes(suffix)'
     fields:
         SamplingFrequency: required
         StartTime: required

--- a/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
@@ -10,21 +10,21 @@ CommonDerivativeFields:
 SpatialReferenceEntity:
   selectors:
   - dataset.DatasetType == "derivative"
-  - entities contains "space"
+  - '"space" in entities'
   fields:
     SpatialReference: RECOMMENDED
 
 SpatialReferenceNonStandard:
   selectors:
   - dataset.DatasetType == "derivative"
-  - not(entities.space in schema.objects.metadata._StandardTemplateCoordSys)
+  - 'schema.objects.metadata._StandardTemplateCoordSys).includes(not(entities.space)'
   fields:
     SpatialReference: REQUIRED
 
 SpatialReferenceNoEntity:
   selectors:
   - dataset.DatasetType == "derivative"
-  - not(entities contains "space")
+  - '!("space" in entities)'
   fields:
     SpatialReference: REQUIRED
 
@@ -45,14 +45,14 @@ MaskDerivativesAtlas:
   selectors:
   - dataset.DatasetType == "derivative"
   - suffix == "mask"
-  - entities contains "label"
+  - '"label" in entities'
   fields:
     atlas: RECOMMENDED
 
 SegmentationCommon:
   selectors:
   - dataset.DatasetType == "derivative"
-  - suffix in ["dseg", "probseg"]
+  - '["dseg", "probseg"].includes(suffix)'
   fields:
     Type: RECOMMENDED
     Atlas: OPTIONAL
@@ -63,23 +63,23 @@ SegmentationCommon:
 ImageDerivatives:
   selectors:
   - dataset.DatasetType == "derivative"
-  - modality in ["mri", "pet"]
-  - extension in [".nii", ".nii.gz"]
+  - '["mri", "pet"].includes(modality)'
+  - '[".nii", ".nii.gz"].includes(extension)'
   fields:
     SkullStripped: REQUIRED
 
 ImageDerivativeResEntity:
   selectors:
   - dataset.DatasetType == "derivative"
-  - modality in ["mri", "pet"]
-  - entities contains "res"
+  - '["mri", "pet"].includes(modality)'
+  - '"res" in entities'
   fields:
     Resolution: REQUIRED
 
 ImageDerivativeDenEntity:
   selectors:
   - dataset.DatasetType == "derivative"
-  - modality in ["mri", "pet"]
-  - entities contains "den"
+  - '["mri", "pet"].includes(modality)'
+  - '"den" in entities'
   fields:
     Density: REQUIRED

--- a/src/schema/rules/sidecars/eeg.yaml
+++ b/src/schema/rules/sidecars/eeg.yaml
@@ -110,7 +110,7 @@ EEGCoordsystemOther:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
-    - sidecar contains "EEGCoordinateSystem"
+    - '"EEGCoordinateSystem" in sidecar'
     - sidecar.EEGCoordinateSystem == "Other"
     fields:
         EEGCoordinateSystemDescription: required
@@ -160,7 +160,7 @@ EEGCoordsystemAnatomicalLandmarkCoordinateSystemDescription:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
-    - sidecar contains "AnatomicalLandmarkCoordinateSystem"
+    - '"AnatomicalLandmarkCoordinateSystem" in sidecar'
     - sidecar.AnatomicalLandmarkCoordinateSystem == "Other"
     fields:
         AnatomicalLandmarkCoordinateSystemDescription: required

--- a/src/schema/rules/sidecars/entities.yaml
+++ b/src/schema/rules/sidecars/entities.yaml
@@ -11,25 +11,25 @@
 
 EntitiesTaskMetadata:
     selectors:
-    - entities contains "task"
+    - '"task" in entities'
     fields:
         TaskName: recommended
 
 EntitiesCeMetadata:
     selectors:
-    - entities contains "ce"
+    - '"ce" in entities'
     fields:
         ContrastBolusIngredient: optional
 
 EntitiesTrcMetadata:
     selectors:
-    - entities contains "trc"
+    - '"trc" in entities'
     fields:
         TracerName: required
 
 EntitiesStainMetadata:
     selectors:
-    - entities contains "stain"
+    - '"stain" in entities'
     fields:
         SampleStaining: recommended
         SamplePrimaryAntibodies: recommended
@@ -37,25 +37,25 @@ EntitiesStainMetadata:
 
 EntitiesEchoMetadata:
     selectors:
-    - entities contains "echo"
+    - '"echo" in entities'
     fields:
         EchoTime: required
 
 EntitiesFlipMetadata:
     selectors:
-    - entities contains "flip"
+    - '"flip" in entities'
     fields:
         FlipAngle: required
 
 EntitiesInvMetadata:
     selectors:
-    - entities contains "inv"
+    - '"inv" in entities'
     fields:
         InversionTime: required
 
 EntitiesMTMetadata:
     selectors:
-    - entities contains "mt"
+    - '"mt" in entities'
     fields:
         MTState: required
 
@@ -66,16 +66,16 @@ EntitiesPartMetadata:
         Units:
             level: required
             rules:
-            - value in ["rad", "arbitrary"]
+            - '["rad", "arbitrary"].includes(value)'
 
 EntitiesResMetadata:
     selectors:
-    - entities contains "res"
+    - '"res" in entities'
     fields:
         Resolution: required
 
 EntitiesDenMetadata:
     selectors:
-    - entities contains "den"
+    - '"den" in entities'
     fields:
         Density: required

--- a/src/schema/rules/sidecars/fmap.yaml
+++ b/src/schema/rules/sidecars/fmap.yaml
@@ -59,7 +59,7 @@ MRIFieldmapTwoPhase:
     selectors:
     - modality == "MRI"
     - datatype == "fmap"
-    - suffix in ["phase1", "phase2", "magnitude1", "magnitude2"]
+    - '["phase1", "phase2", "magnitude1", "magnitude2"].includes(suffix)'
     fields:
         EchoTime__fmap: required
 
@@ -68,7 +68,7 @@ MRIFieldmapDirectFieldMapping:
     selectors:
     - modality == "MRI"
     - datatype == "fmap"
-    - suffix in ["phase", "fieldmap"]
+    - '["phase", "fieldmap"].includes(suffix)'
     fields:
         Units:
             level: required

--- a/src/schema/rules/sidecars/func.yaml
+++ b/src/schema/rules/sidecars/func.yaml
@@ -49,7 +49,7 @@ MRIFuncTimingParametersMutualExclusion1:
     selectors:
     - modality == "mri"
     - datatype == "func"
-    - sidecar contains "RepetitionTime"
+    - '"RepetitionTime" in sidecar'
     fields:
         AcquisitionDuration: prohibited
         VolumeTiming: prohibited
@@ -58,8 +58,8 @@ MRIFuncTimingParametersMutualExclusion2:
     selectors:
     - modality == "mri"
     - datatype == "func"
-    - sidecar contains "SliceTiming"
-    - sidecar contains "VolumeTiming"
+    - '"SliceTiming" in sidecar'
+    - '"VolumeTiming" in sidecar'
     fields:
         RepetitionTime: prohibited
         DelayTime: prohibited
@@ -68,8 +68,8 @@ MRIFuncTimingParametersMutualExclusion3:
     selectors:
     - modality == "mri"
     - datatype == "func"
-    - sidecar contains "AcquisitionDuration"
-    - sidecar contains "VolumeTiming"
+    - '"AcquisitionDuration" in sidecar'
+    - '"VolumeTiming" in sidecar'
     fields:
         RepetitionTime: prohibited
         DelayTime: prohibited
@@ -78,8 +78,8 @@ MRIFuncTimingParametersMutualExclusion4:
     selectors:
     - modality == "mri"
     - datatype == "func"
-    - sidecar contains "RepetitionTime"
-    - sidecar contains "SliceTiming"
+    - '"RepetitionTime" in sidecar'
+    - '"SliceTiming" in sidecar'
     fields:
         AcquisitionDuration: prohibited
         VolumeTiming: prohibited
@@ -88,8 +88,8 @@ MRIFuncTimingParametersMutualExclusion5:
     selectors:
     - modality == "mri"
     - datatype == "func"
-    - sidecar contains "RepetitionTime"
-    - sidecar contains "DelayTime"
+    - '"RepetitionTime" in sidecar'
+    - '"DelayTime" in sidecar'
     fields:
         AcquisitionDuration: prohibited
         VolumeTiming: prohibited

--- a/src/schema/rules/sidecars/ieeg.yaml
+++ b/src/schema/rules/sidecars/ieeg.yaml
@@ -138,7 +138,7 @@ iEEGCoordsystemOther:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "coordsystem"
-    - sidecar contains "iEEGCoordinateSystem"
+    - '"iEEGCoordinateSystem" in sidecar'
     - sidecar.iEEGCoordinateSystem == "Other"
     fields:
         iEEGCoordinateSystemDescription: required

--- a/src/schema/rules/sidecars/meg.yaml
+++ b/src/schema/rules/sidecars/meg.yaml
@@ -106,7 +106,7 @@ MEGwithEEG:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "meg"
-    - dataset.modalities contains "EEG"
+    - 'dataset.modalities'.includes('"EEG")'
     fields:
         EEGPlacementScheme: optional
         CapManufacturer: optional
@@ -145,7 +145,7 @@ MEGCoordsystemWithEEGMEGCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - sidecar contains "MEGCoordinateSystem"
+    - 'sidecar'.includes('"MEGCoordinateSystem")'
     - sidecar.MEGCoordinateSystem == "Other"
     fields:
         MEGCoordinateSystemDescription: required
@@ -156,7 +156,7 @@ MEGCoordsystemWithEEGEEGCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - sidecar contains "EEGCoordinateSystem"
+    - 'sidecar'.includes('"EEGCoordinateSystem")'
     - sidecar.EEGCoordinateSystem == "Other"
     fields:
         EEGCoordinateSystemDescription: required
@@ -180,7 +180,7 @@ MEGCoordsystemHeadLocalizationCoilsHeadCoilCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - sidecar contains "HeadCoilCoordinateSystem"
+    - 'sidecar'.includes('"HeadCoilCoordinateSystem")'
     - sidecar.HeadCoilCoordinateSystem == "Other"
     fields:
         HeadCoilCoordinateSystemDescription: required
@@ -204,7 +204,7 @@ MEGCoordsystemDigitizedHeadPointsDigitizedHeadPointsCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - sidecar contains "DigitizedHeadPointsCoordinateSystem"
+    - 'sidecar'.includes('"DigitizedHeadPointsCoordinateSystem")'
     - sidecar.DigitizedHeadPointsCoordinateSystem == "Other"
     fields:
         DigitizedHeadPointsCoordinateSystemDescription: required
@@ -215,7 +215,7 @@ MEGCoordsystemAnatomicalMRI:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - dataset.modalities contains "anat"
+    - 'dataset.modalities'.includes('"anat")'
     fields:
         IntendedFor:
             level: optional
@@ -246,7 +246,7 @@ MEGCoordsystemAnatomicalLandmarksAnatomicalLandmarkCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - sidecar contains "AnatomicalLandmarkCoordinateSystem"
+    - 'sidecar'.includes('"AnatomicalLandmarkCoordinateSystem")'
     - sidecar.AnatomicalLandmarkCoordinateSystem == "Other"
     fields:
         AnatomicalLandmarkCoordinateSystemDescription: required

--- a/src/schema/rules/sidecars/meg.yaml
+++ b/src/schema/rules/sidecars/meg.yaml
@@ -106,7 +106,7 @@ MEGwithEEG:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "meg"
-    - 'dataset.modalities'.includes('"EEG")'
+    - dataset.modalities.includes('"EEG")
     fields:
         EEGPlacementScheme: optional
         CapManufacturer: optional
@@ -145,7 +145,7 @@ MEGCoordsystemWithEEGMEGCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - 'sidecar'.includes('"MEGCoordinateSystem")'
+    - '"MEGCoordinateSystem" in sidecar'
     - sidecar.MEGCoordinateSystem == "Other"
     fields:
         MEGCoordinateSystemDescription: required
@@ -156,7 +156,7 @@ MEGCoordsystemWithEEGEEGCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - 'sidecar'.includes('"EEGCoordinateSystem")'
+    - '"EEGCoordinateSystem" in sidecar'
     - sidecar.EEGCoordinateSystem == "Other"
     fields:
         EEGCoordinateSystemDescription: required
@@ -180,7 +180,7 @@ MEGCoordsystemHeadLocalizationCoilsHeadCoilCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - 'sidecar'.includes('"HeadCoilCoordinateSystem")'
+    - '"HeadCoilCoordinateSystem" in sidecar'
     - sidecar.HeadCoilCoordinateSystem == "Other"
     fields:
         HeadCoilCoordinateSystemDescription: required
@@ -204,7 +204,7 @@ MEGCoordsystemDigitizedHeadPointsDigitizedHeadPointsCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - 'sidecar'.includes('"DigitizedHeadPointsCoordinateSystem")'
+    - '"DigitizedHeadPointsCoordinateSystem" in sidecar'
     - sidecar.DigitizedHeadPointsCoordinateSystem == "Other"
     fields:
         DigitizedHeadPointsCoordinateSystemDescription: required
@@ -215,7 +215,7 @@ MEGCoordsystemAnatomicalMRI:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - 'dataset.modalities'.includes('"anat")'
+    - dataset.modalities.includes("anat")
     fields:
         IntendedFor:
             level: optional
@@ -246,7 +246,7 @@ MEGCoordsystemAnatomicalLandmarksAnatomicalLandmarkCoordinateSystem:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    - 'sidecar'.includes('"AnatomicalLandmarkCoordinateSystem")'
+    - '"AnatomicalLandmarkCoordinateSystem" in sidecar'
     - sidecar.AnatomicalLandmarkCoordinateSystem == "Other"
     fields:
         AnatomicalLandmarkCoordinateSystemDescription: required

--- a/src/schema/rules/sidecars/micr.yaml
+++ b/src/schema/rules/sidecars/micr.yaml
@@ -65,7 +65,7 @@ MicroscopyChunkTransformations:
     selectors:
     - modality == "micr"
     - datatype == "micr"
-    - entities contains "chunk"
+    - '"chunk" in entities'
     fields:
         ChunkTransformationMatrix: recommended
 
@@ -73,7 +73,7 @@ MicroscopyChunkTransformationsMatrixAxis:
     selectors:
     - modality == "micr"
     - datatype == "micr"
-    - entities contains "chunk"
-    - sidecar contains "ChunkTransformationMatrix"
+    - '"chunk" in entities'
+    - '"ChunkTransformationMatrix" in sidecar'
     fields:
         ChunkTransformationMatrixAxis: required

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -64,7 +64,7 @@ MRISequenceSpecifics:
 PETMRISequenceSpecifics:
     selectors:
     - modality == "mri"
-    - dataset.modalities contains "PET"
+    - dataset.modalities.includes("PET")
     fields:
         NonLinearGradientCorrection: required
 
@@ -77,7 +77,7 @@ ASLMRISequenceSpecifics:
 
 MTParameters:
     selectors:
-    - sidecar contains "MTState"
+    - '"MTState" in sidecar'
     - sidecar.MTState == "True"
     fields:
         MTOffsetFrequency: recommended
@@ -88,22 +88,22 @@ MTParameters:
 
 SpoilingType:
     selectors:
-    - sidecar contains "SpoilingState"
+    - '"SpoilingState" in sidecar'
     - sidecar.SpoilingState == True
     fields:
         SpoilingType: recommended
 
 SpoilingRF:
     selectors:
-    - sidecar contains "SpoilingType"
-    - sidecar.SpoilingType in ["RF", "COMBINED"]
+    - '"SpoilingType" in sidecar'
+    - '["RF", "COMBINED"].includes(sidecar.SpoilingType)'
     fields:
         SpoilingRFPhaseIncrement: recommended
 
 SpoilingGradient:
     selectors:
-    - sidecar contains "SpoilingType"
-    - sidecar.SpoilingType in ["GRADIENT", "COMBINED"]
+    - '"SpoilingType" in sidecar'
+    - '["GRADIENT", "COMBINED"].includes(sidecar.SpoilingType)'
     fields:
         SpoilingGradientMoment: recommended
         SpoilingGradientDuration: recommended
@@ -184,8 +184,8 @@ SliceTimingASL:
     selectors:
     - modality == "mri"
     - datatype == "perf"
-    - suffix in ["asl", "m0scan"]
-    - sidecar contains "MRAcquisitionType"
+    - '["asl", "m0scan"].includes(suffix)'
+    - '"MRAcquisitionType" in sidecar'
     - sidecar.MRAcquisitionType == "2D"
     fields:
         SliceTiming: required
@@ -194,7 +194,7 @@ SliceTimingASL:
 SliceTimingSparse:
     selectors:
     - modality == "mri"
-    - sidecar contains "DelayTime"
+    - '"DelayTime" in sidecar'
     fields:
         SliceTiming: required
 
@@ -224,7 +224,7 @@ MRIRFandContrast:
 MRIFlipAngleLookLocker:
     selectors:
     - modality == "mri"
-    - sidecar contains "LookLocker"
+    - '"LookLocker" in sidecar'
     - sidecar.LookLocker == True
     fields:
         FlipAngle: required

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -89,7 +89,7 @@ MTParameters:
 SpoilingType:
     selectors:
     - '"SpoilingState" in sidecar'
-    - sidecar.SpoilingState == True
+    - sidecar.SpoilingState == true
     fields:
         SpoilingType: recommended
 

--- a/src/schema/rules/tabular_data/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/tabular_data/derivatives/common_derivatives.yaml
@@ -2,7 +2,7 @@
 SegmentationLookup:
   selectors:
   - dataset.DatasetType == "derivative"
-  - suffix in ["dseg", "probseg"]
+  - '["dseg", "probseg"].includes(suffix)'
   columns:
     index: REQUIRED
     name: REQUIRED

--- a/src/schema/rules/tabular_data/pet.yaml
+++ b/src/schema/rules/tabular_data/pet.yaml
@@ -17,7 +17,7 @@ BloodPlasma:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
-    - sidecar contains "PlasmaAvail"
+    - '"PlasmaAvail" in sidecar'
     columns:
         plasma_radioactivity: required
 
@@ -26,7 +26,7 @@ BloodMetabolite:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
-    - sidecar contains "MetaboliteAvail"
+    - '"MetaboliteAvail" in sidecar'
     columns:
         metabolite_parent_fraction: required
         metabolite_polar_fraction: recommended
@@ -36,7 +36,7 @@ BloodMetaboliteCorrection:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
-    - sidecar contains "MetaboliteRecoveryCorrectionApplied"
+    - '"MetaboliteRecoveryCorrectionApplied" in sidecar'
     - sidecar.MetaboliteRecoveryCorrectionApplied == true
     columns:
         hplc_recovery_fractions: required
@@ -46,7 +46,7 @@ BloodWholeBlood:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
-    - sidecar contains "WholeBloodAvail"
+    - '"WholeBloodAvail" in sidecar'
     - sidecar.WholeBloodAvail == true
     columns:
         whole_blood_radioactivity: required

--- a/src/schema/rules/tabular_data/task.yaml
+++ b/src/schema/rules/tabular_data/task.yaml
@@ -1,7 +1,7 @@
 ---
 TaskEvents:
     selectors:
-    - entities contains "task"
+    - '"task" in entities'
     - suffix == "events"
     columns:
         onset: REQUIRED


### PR DESCRIPTION
As an intermediary expression language the validator will be attempting to interpret schema rules as javascript where applicable.

Originally the spec used the  `<object> contains "<key-string>"` pattern to avoid the double quotes around the string representing the key from appearing at the start of the line. To get around this issue in this PR the entire line is wrapped in single quotes.

~~Other wonky thing is testing if something is an Array. Current way of evaluating strings as JS may not give us access to the `Array`  class, so its methods are accessed through the `constructor` field of the thing to be tested.~~

Converted all calls of `isArray` and `typeof` to `type(...)` which we will implement as a function in JS space to return 'object', 'array' 'string' etc.