### PR TITLE
[FIX] Standardized tabular_metadata.yaml syntax to conform to: f04b47ff

### DIFF
--- a/src/schema/rules/tabular_metadata.yaml
+++ b/src/schema/rules/tabular_metadata.yaml
@@ -1,17 +1,15 @@
 ---
-# scans.tsv
-- suffixes:
+scans:
+  suffixes:
   - scans
   extensions:
   - .tsv
   - .json
   entities:
     subject: required
-    # session is required if session is present in the dataset.
-    session: optional
-# sessions.tsv
-# This file may only exist if session is present in the dataset.
-- suffixes:
+    session: optional # session is required if session is present in the dataset.
+sessions: # This file may only exist if session is present in the dataset.
+  suffixes:
   - sessions
   extensions:
   - .tsv


### PR DESCRIPTION
https://github.com/bids-standard/bids-specification/commit/f04b47ff makes a number of things much more interesting, but if we're doing this, probably best done everywhere.

@effigies
