### PR TITLE
[SCHEMA] Generate schema context object TypeScript definitions

### DIFF
--- a/.github/workflows/typescript_build.yml
+++ b/.github/workflows/typescript_build.yml
@@ -1,0 +1,59 @@
+name: "typescript_build"
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "tools/typescript/**"
+      - "src/schema/**"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "tools/typescript/**"
+      - "src/schema/**"
+
+jobs:
+  check_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.result_step.outputs.ci-skip }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: result_step
+        uses: mstachniuk/ci-skip@master
+        with:
+          commit-filter: "[skip ci];[ci skip];[skip github]"
+          commit-filter-separator: ";"
+
+  build_module:
+    needs: check_skip
+    if: ${{ needs.check_skip.outputs.skip == 'false' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest"]
+            deno-version: [1.21.3]
+    name: ${{ matrix.os }} with Deno ${{ matrix.deno-version }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Deno Version ${{ matrix.deno-version }}
+        uses: denolib/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno-version }}
+      - name: Run tests
+        run: deno test --no-check
+      - name: Build module
+        run: deno run --allow-write --allow-read --no-check tools/typescript/build-schema-types.ts
+      - name: Save module
+        uses: actions/upload-artifact@v3
+        with:
+          name: typescript-module
+          path: tools/typescript/output

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -232,24 +232,26 @@ context:
                 xyzt_units:
                     name: "XYZT Units"
                     description: "Units of pixdim[1..4]"
-                    xyz:
-                        name: "XYZ Units"
-                        description: "String representing the unit of voxel spacing."
-                        type: string
-                        enum:
-                        - "unknown"
-                        - "meter"
-                        - "mm"
-                        - "um"
-                    t:
-                        name: "Time Unit"
-                        description: "String representing the unit of inter-volume intervals."
-                        type: string
-                        enum:
-                        - "unknown"
-                        - "sec"
-                        - "msec"
-                        - "usec"
+                    type: object
+                    properties:
+                        xyz:
+                            name: "XYZ Units"
+                            description: "String representing the unit of voxel spacing."
+                            type: string
+                            enum:
+                            - "unknown"
+                            - "meter"
+                            - "mm"
+                            - "um"
+                        t:
+                            name: "Time Unit"
+                            description: "String representing the unit of inter-volume intervals."
+                            type: string
+                            enum:
+                            - "unknown"
+                            - "sec"
+                            - "msec"
+                            - "usec"
                 qform_code:
                     name: "qform code"
                     description: "Use of the quaternion fields."

--- a/tools/typescript/.gitignore
+++ b/tools/typescript/.gitignore
@@ -1,0 +1,2 @@
+output/src/*.ts
+output/dist

--- a/tools/typescript/README.md
+++ b/tools/typescript/README.md
@@ -1,0 +1,9 @@
+These tools generate and publish TypeScript definitions for use in JavaScript environments.
+
+
+```shell
+# Run tests
+deno test --allow-read --no-check .
+# Build types
+deno run --allow-read --no-check build-schema-types.ts
+```

--- a/tools/typescript/build-schema-types.ts
+++ b/tools/typescript/build-schema-types.ts
@@ -1,0 +1,27 @@
+import { parse } from 'https://deno.land/std@0.138.0/encoding/yaml.ts'
+import { join } from 'https://deno.land/std@0.138.0/path/mod.ts'
+import { createSourceFile, generateTypes, print } from './generate.ts'
+
+const contextPath = join('..', '..', 'src', 'schema', 'meta', 'context.yaml')
+
+async function buildContextTypes() {
+  const contextSchema = parse(await Deno.readTextFile(contextPath)) as Record<
+    string,
+    any
+  >
+  // Compiler configuration
+  const output = createSourceFile('context.ts')
+
+  // Test if the file has a sane root level object definition
+  if (
+    contextSchema.hasOwnProperty('context') &&
+    contextSchema.context.type === 'object'
+  ) {
+    output.statements = generateTypes(contextSchema)
+    console.log(print(output))
+  } else {
+    throw new Error('Could not find definition for Context type')
+  }
+}
+
+buildContextTypes()

--- a/tools/typescript/build-schema-types.ts
+++ b/tools/typescript/build-schema-types.ts
@@ -1,24 +1,58 @@
+import {
+  ts,
+  createProject,
+} from 'https://deno.land/x/ts_morph@14.0.0/bootstrap/mod.ts'
 import { parse } from 'https://deno.land/std@0.138.0/encoding/yaml.ts'
 import { join } from 'https://deno.land/std@0.138.0/path/mod.ts'
 import { createSourceFile, generateTypes, print } from './generate.ts'
 
 const contextPath = join('..', '..', 'src', 'schema', 'meta', 'context.yaml')
+const libraryPath = join('output')
 
 async function buildContextTypes() {
   const contextSchema = parse(await Deno.readTextFile(contextPath)) as Record<
     string,
     any
   >
-  // Compiler configuration
-  const output = createSourceFile('context.ts')
+
+  const project = await createProject({
+    compilerOptions: {
+      outDir: join(libraryPath, 'dist'),
+      target: ts.ScriptTarget.ESNext,
+      declaration: true,
+    },
+  })
 
   // Test if the file has a sane root level object definition
   if (
     contextSchema.hasOwnProperty('context') &&
     contextSchema.context.type === 'object'
   ) {
-    output.statements = generateTypes(contextSchema)
-    console.log(print(output))
+    // Setup output directory
+    await Deno.mkdir(join(libraryPath, 'src'), { recursive: true })
+    const contextFilePath = join(libraryPath, 'src', 'context.ts')
+    // Get a ts.SourceFile from the compiler initially (to add AST to it)
+    const contextFile = createSourceFile(contextFilePath)
+    // Generate types and add to the source file object
+    contextFile.statements = generateTypes(contextSchema)
+    // Use the TypeScript printer to format file as string
+    const source = print(contextFile)
+    // Write string out to the src tree
+    await Deno.writeTextFile(contextFilePath, source)
+    // Add source file to our project for type checking
+    await project.addSourceFilesByPaths(join(libraryPath, 'src', '**', '*.ts'))
+    // Output `dist` dir
+    const program = project.createProgram([contextFilePath])
+    // Display any compiler diagnostics in case the output is incorrect
+    const diagnostics = ts.getPreEmitDiagnostics(program)
+    const formattedDiagnostic =
+      project.formatDiagnosticsWithColorAndContext(diagnostics)
+    if (formattedDiagnostic) {
+      console.log(source)
+      console.log(formattedDiagnostic)
+    }
+    await program.emit()
+    console.log(`TypeScript package generated at path '${libraryPath}'`)
   } else {
     throw new Error('Could not find definition for Context type')
   }

--- a/tools/typescript/build-schema-types.ts
+++ b/tools/typescript/build-schema-types.ts
@@ -6,8 +6,8 @@ import { parse } from 'https://deno.land/std@0.138.0/encoding/yaml.ts'
 import { join } from 'https://deno.land/std@0.138.0/path/mod.ts'
 import { createSourceFile, generateTypes, print } from './generate.ts'
 
-const contextPath = join('..', '..', 'src', 'schema', 'meta', 'context.yaml')
-const libraryPath = join('output')
+const contextPath = join('src', 'schema', 'meta', 'context.yaml')
+const libraryPath = join('tools', 'typescript', 'output')
 
 async function buildContextTypes() {
   const contextSchema = parse(await Deno.readTextFile(contextPath)) as Record<

--- a/tools/typescript/generate.test.ts
+++ b/tools/typescript/generate.test.ts
@@ -1,5 +1,11 @@
 import { assertEquals } from 'https://deno.land/std@0.138.0/testing/asserts.ts'
-import { generateTypes, print, createSourceFile } from './generate.ts'
+import { toCamel, generateTypes, print, createSourceFile } from './generate.ts'
+
+Deno.test('toCamel() supports expected specification names', () => {
+  assertEquals(toCamel('dim_info'), 'DimInfo')
+  assertEquals(toCamel('dataset'), 'Dataset')
+  assertEquals(toCamel('Dataset_nifti_PixDim'), 'DatasetNiftiPixDim')
+})
 
 Deno.test('generateTypes() supports primitive string', () => {
   const file = createSourceFile('test.ts')
@@ -102,7 +108,7 @@ Deno.test('generateTypes() supports typed object type', () => {
 
   assertEquals(
     print(file),
-    `export interface dim_info {
+    `export interface DimInfo {
     freq: number;
     phase: number;
     slice: number;
@@ -144,7 +150,7 @@ Deno.test('generateTypes() supports object trees', () => {
     `export interface DatasetSubjects {
     sub_dirs: string[];
 }
-export interface dataset {
+export interface Dataset {
     dataset_description: object;
     subjects: DatasetSubjects;
 }

--- a/tools/typescript/generate.test.ts
+++ b/tools/typescript/generate.test.ts
@@ -1,0 +1,153 @@
+import { assertEquals } from 'https://deno.land/std@0.138.0/testing/asserts.ts'
+import { generateTypes, print, createSourceFile } from './generate.ts'
+
+Deno.test('generateTypes() supports primitive string', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    suffix: { description: 'Suffix of current file', type: 'string' },
+  })
+
+  assertEquals(print(file), 'suffix: string;\n')
+})
+
+Deno.test('generateTypes() supports enumerated string', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    t: {
+      name: 'Time Unit',
+      description: 'String representing the unit of inter-volume intervals.',
+      type: 'string',
+      enum: ['unknown', 'sec', 'msec', 'usec'],
+    },
+  })
+
+  assertEquals(print(file), 't: "unknown" | "sec" | "msec" | "usec";\n')
+})
+
+Deno.test('generateTypes() supports primitive integer', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    n_cols: { description: 'Number of columns in bvec file', type: 'integer' },
+  })
+
+  assertEquals(print(file), 'n_cols: number;\n')
+})
+
+// This is an array with no schema defined type
+Deno.test('generateTypes() supports generic array type', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    ignored: { description: 'Set of ignored files', type: 'array' },
+  })
+
+  assertEquals(print(file), 'ignored: any[];\n')
+})
+
+// This is an array with a schema defined type
+Deno.test('generateTypes() supports typed array type', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    sub_dirs: {
+      description: 'Subjects as determined by sub-*/ directories',
+      type: 'array',
+      items: { type: 'string' },
+    },
+  })
+
+  assertEquals(print(file), 'sub_dirs: string[];\n')
+})
+
+// Object without defined properties
+Deno.test('generateTypes() supports generic object type', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    dataset_description: {
+      description: 'Contents of /dataset_description.json',
+      type: 'object',
+    },
+  })
+
+  assertEquals(print(file), 'dataset_description: object;\n')
+})
+
+// Object with defined properties
+Deno.test('generateTypes() supports typed object type', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    dim_info: {
+      name: 'Dimension Information',
+      description: 'Metadata about dimensions data.',
+      type: 'object',
+      properties: {
+        freq: {
+          name: 'Frequency',
+          description:
+            'These fields encode which spatial dimension (1, 2, or 3).',
+          type: 'integer',
+        },
+        phase: {
+          name: 'Phase',
+          description:
+            'Corresponds to which acquisition dimension for MRI data.',
+          type: 'integer',
+        },
+        slice: {
+          name: 'Slice',
+          description: 'Slice dimensions.',
+          type: 'integer',
+        },
+      },
+    },
+  })
+
+  assertEquals(
+    print(file),
+    `interface dim_info {
+    freq: number;
+    phase: number;
+    slice: number;
+}
+`
+  )
+})
+
+// Works with complex object trees
+// Object with defined properties
+Deno.test('generateTypes() supports object trees', () => {
+  const file = createSourceFile('test.ts')
+  file.statements = generateTypes({
+    dataset: {
+      description: 'Test dataset fragment',
+      type: 'object',
+      properties: {
+        dataset_description: {
+          description: 'Contents of /dataset_description.json',
+          type: 'object',
+        },
+        subjects: {
+          description: 'Collections of subjects in dataset',
+          type: 'object',
+          properties: {
+            sub_dirs: {
+              description: 'Subjects as determined by sub-*/ directories',
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  assertEquals(
+    print(file),
+    `interface DatasetSubjects {
+    sub_dirs: string[];
+}
+interface dataset {
+    dataset_description: object;
+    subjects: DatasetSubjects;
+}
+`
+  )
+})

--- a/tools/typescript/generate.test.ts
+++ b/tools/typescript/generate.test.ts
@@ -102,7 +102,7 @@ Deno.test('generateTypes() supports typed object type', () => {
 
   assertEquals(
     print(file),
-    `interface dim_info {
+    `export interface dim_info {
     freq: number;
     phase: number;
     slice: number;
@@ -141,10 +141,10 @@ Deno.test('generateTypes() supports object trees', () => {
 
   assertEquals(
     print(file),
-    `interface DatasetSubjects {
+    `export interface DatasetSubjects {
     sub_dirs: string[];
 }
-interface dataset {
+export interface dataset {
     dataset_description: object;
     subjects: DatasetSubjects;
 }

--- a/tools/typescript/generate.ts
+++ b/tools/typescript/generate.ts
@@ -13,7 +13,7 @@ function capitalize(str) {
  * Convert schema primitives to nearest JS equivalent
  */
 function mapSchemaType(typename) {
-  if ('integer') return 'number'
+  if (typename === 'integer') return 'number'
   return typename
 }
 

--- a/tools/typescript/generate.ts
+++ b/tools/typescript/generate.ts
@@ -1,0 +1,172 @@
+/**
+ * Use the TypeScript compiler to
+ */
+import { ts } from 'https://deno.land/x/ts_morph@14.0.0/bootstrap/mod.ts'
+
+function capitalize(str) {
+  return `${str.charAt(0).toUpperCase()}${str.slice(1)}`
+}
+
+export function generateObjectDefinition(name, definition): Array<ts.Node> {
+  const customTypeInterfaces = []
+  // Construct all properties of the interface
+  const interfaceProps = Object.entries(definition.properties).map(
+    ([key, value]) => {
+      // Test for an nested interface we can define
+      if (value.type === 'object' && value.hasOwnProperty('properties')) {
+        const customInterface = generateObjectDefinition(
+          `${capitalize(name)}${capitalize(key)}`,
+          value
+        )
+        if (Array.isArray(customInterface)) {
+          customTypeInterfaces.push(...customInterface)
+          return ts.factory.createPropertySignature(
+            undefined,
+            key,
+            undefined,
+            ts.factory.createTypeReferenceNode(customInterface.at(-1).name)
+          )
+        } else {
+          // Save it for the node list at this level
+          customTypeInterfaces.push(customInterface)
+          // Insert a reference to the type in the AST for the root interface
+          return ts.factory.createPropertySignature(
+            undefined,
+            key,
+            undefined,
+            ts.factory.createTypeReferenceNode(customInterface.name)
+          )
+        }
+      } else {
+        return generatePrimitiveDefinition(key, value)
+      }
+    }
+  )
+  // Add the root level interface last
+  customTypeInterfaces.push(
+    ts.factory.createInterfaceDeclaration(
+      undefined,
+      undefined,
+      name,
+      undefined,
+      undefined,
+      interfaceProps
+    )
+  )
+  return ts.factory.createNodeArray(customTypeInterfaces)
+}
+
+/**
+ * Recursively generate a TypeScript definition for a BIDS schema object
+ */
+export function generatePrimitiveDefinition(
+  name: string,
+  definition: Record<string, any>
+): Node {
+  if (definition.type === 'string') {
+    if (definition.hasOwnProperty('enum')) {
+      return ts.factory.createPropertySignature(
+        undefined,
+        name,
+        undefined,
+        ts.factory.createUnionTypeNode(
+          definition.enum.map((enumValue) =>
+            ts.factory.createLiteralTypeNode(
+              ts.factory.createStringLiteral(enumValue)
+            )
+          )
+        )
+      )
+    } else {
+      return ts.factory.createPropertySignature(
+        undefined,
+        name,
+        undefined,
+        ts.factory.createTypeReferenceNode('string')
+      )
+    }
+  } else if (definition.type === 'integer' || definition.type === 'number') {
+    return ts.factory.createPropertySignature(
+      undefined,
+      name,
+      undefined,
+      ts.factory.createTypeReferenceNode('number')
+    )
+  } else if (definition.type === 'array') {
+    let arrayDefinition = ts.factory.createArrayTypeNode(
+      ts.factory.createTypeReferenceNode('any')
+    )
+    // Typed array case
+    if (
+      definition.hasOwnProperty('items') &&
+      definition.items.hasOwnProperty('type')
+    ) {
+      arrayDefinition = ts.factory.createArrayTypeNode(
+        ts.factory.createTypeReferenceNode(definition.items.type)
+      )
+    }
+    return ts.factory.createPropertySignature(
+      undefined,
+      name,
+      undefined,
+      arrayDefinition
+    )
+  } else if (definition.type === 'object') {
+    return ts.factory.createPropertySignature(
+      undefined,
+      name,
+      undefined,
+      ts.factory.createTypeReferenceNode('object')
+    )
+  }
+}
+
+/**
+ * Given an object like `{ suffix: { type: 'string' } }` return a TypeScript interface
+ */
+export function generateTypes(schemaObj: Record<string, any>): Array<ts.Node> {
+  const tsNodes = []
+  for (const prop in schemaObj) {
+    if (
+      schemaObj[prop].type === 'object' &&
+      schemaObj[prop].hasOwnProperty('properties')
+    ) {
+      tsNodes.push(...generateObjectDefinition(prop, schemaObj[prop]))
+    } else {
+      tsNodes.push(generatePrimitiveDefinition(prop, schemaObj[prop]))
+    }
+  }
+  for (const node of tsNodes) {
+    const resultFile = ts.createSourceFile(
+      'someFileName.ts',
+      '',
+      ts.ScriptTarget.Latest,
+      /*setParentNodes*/ false,
+      ts.ScriptKind.TS
+    )
+    const printer = ts.createPrinter({
+      newLine: ts.NewLineKind.LineFeed,
+      omitTrailingSemicolon: true,
+    })
+  }
+  return tsNodes
+}
+
+export function print(file) {
+  // Output formatting
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+    omitTrailingSemicolon: true,
+  })
+  return printer.printFile(file)
+}
+
+export function createSourceFile(filename: string) {
+  return ts.createSourceFile(
+    filename,
+    '',
+    ts.ScriptTarget.ESNext,
+    false,
+    ts.ScriptKind.TS
+  )
+}

--- a/tools/typescript/generate.ts
+++ b/tools/typescript/generate.ts
@@ -5,8 +5,12 @@
  */
 import { ts } from 'https://deno.land/x/ts_morph@14.0.0/bootstrap/mod.ts'
 
-function capitalize(str) {
-  return `${str.charAt(0).toUpperCase()}${str.slice(1)}`
+export function toCamel(str) {
+  return str
+    .split('_')
+    .filter((x) => x.length > 0)
+    .map((x) => x.charAt(0).toUpperCase() + x.slice(1))
+    .join('')
 }
 
 /**
@@ -23,14 +27,17 @@ const interfaceExport = ts.factory.createModifiersFromModifierFlags(
 )
 
 export function generateObjectDefinition(name, definition): Array<ts.Node> {
+  const interfaceName = toCamel(name)
   const customTypeInterfaces = []
   // Construct all properties of the interface
   const interfaceProps = Object.entries(definition.properties).map(
     ([key, value]) => {
       // Test for an nested interface we can define
       if (value.type === 'object' && value.hasOwnProperty('properties')) {
+        // Create a name for this nested interface using snake case terms and convert to title case
+        const customInterfaceName = toCamel(`${name}_${key}`)
         const customInterface = generateObjectDefinition(
-          `${capitalize(name)}${capitalize(key)}`,
+          customInterfaceName,
           value
         )
         if (Array.isArray(customInterface)) {
@@ -62,7 +69,7 @@ export function generateObjectDefinition(name, definition): Array<ts.Node> {
     ts.factory.createInterfaceDeclaration(
       undefined,
       interfaceExport,
-      name,
+      interfaceName,
       undefined,
       undefined,
       interfaceProps

--- a/tools/typescript/generate.ts
+++ b/tools/typescript/generate.ts
@@ -87,7 +87,7 @@ export function generatePrimitiveDefinition(
         ts.factory.createUnionTypeNode(
           definition.enum.map((enumValue) =>
             ts.factory.createLiteralTypeNode(
-              ts.factory.createStringLiteral(mapSchemaType(enumValue))
+              ts.factory.createStringLiteral(enumValue)
             )
           )
         )
@@ -117,7 +117,7 @@ export function generatePrimitiveDefinition(
       definition.items.hasOwnProperty('type')
     ) {
       arrayDefinition = ts.factory.createArrayTypeNode(
-        ts.factory.createTypeReferenceNode(definition.items.type)
+        ts.factory.createTypeReferenceNode(mapSchemaType(definition.items.type))
       )
     }
     return ts.factory.createPropertySignature(


### PR DESCRIPTION
This adds a TypeScript build script for the schema context type and some scaffolding to generate types for the rest of the schema to be used by the JavaScript validator. The plan is to automate this and publish the output as an ECMAScript module but for now this just adds the script for manual testing with the validator.

One minor change to the context schema was needed to make this work, typing xyzt_units as a custom object definition.