### PR TITLE
[ENH] Extend microscopy spec to support NGFF

### DIFF
--- a/src/04-modality-specific-files/10-microscopy.md
+++ b/src/04-modality-specific-files/10-microscopy.md
@@ -54,12 +54,10 @@ Microscopy raw data MUST be stored in one of the following formats:
     (`.ome.tif` for standard TIFF files or `.ome.btf` for
     [BigTIFF](https://www.awaresystems.be/imaging/tiff/bigtiff.html) files)
 
-If different from PNG, TIFF or OME-TIFF, the original unprocessed data in the native format MAY be
-stored in the [`/sourcedata` directory](../02-common-principles.md#source-vs-raw-vs-derived-data).
+-   [NGFF/OME-ZARR](https://ngff.openmicroscopy.org/latest/) (`.ngff` - Note that these are directories.)
 
-Future versions may extend this list of supported file formats, for example with the
-Next-Generation File Formats currently developed by OME ([OME-NGFF](https://ngff.openmicroscopy.org/latest/))
-as a successor to OME-TIFF for better remote sharing of large datasets.
+If different from PNG, TIFF, OME-TIFF, or NGFF the original unprocessed data in the native format MAY be
+stored in the [`/sourcedata` directory](../02-common-principles.md#source-vs-raw-vs-derived-data).
 
 ### Modality suffixes
 Microscopy data currently support the following imaging modalities:


### PR DESCRIPTION
As we (in the dandiarchive) are beginning to distribute substantial amount (320TB and growing) microscopy data, some of which are in NGFF format (https://dandiarchive.org/dandiset/000108), we believe it may be time to extend the spec to support NGFF (https://www.nature.com/articles/s41592-021-01326-w, https://ngff.openmicroscopy.org/latest/). 

NGFF is a zarr based format, and hence it is a directory rather than file, and it is a cloud native format to support really large datasets, which a lot of microscopy data will be for the human brain. This format thus allows direct access to the data as a data stream, without downloading all of it. More generally these datasets are unlikely to be ever moved out of the cloud at that scale, and thus this format, which includes multi-scale representation, allows any downstream user to visualize or compute on different scales of data. 

cc/ @bids-standard/bep031 