### PR TITLE
[ENH] Ensure consistent indentation for comments in yaml files, address yamllint warning

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -6,3 +6,5 @@ rules:
   indentation:
     # See https://github.com/yaml/pyyaml/issues/545 for why
     indent-sequences: false
+  comments:
+    level: error

--- a/src/schema/rules/checks/func.yaml
+++ b/src/schema/rules/checks/func.yaml
@@ -1,3 +1,5 @@
+# Rules for functional data that are not defined in tables.
+---
 PhaseSuffixDeprecated:
   issue:
     code: PHASE_SUFFIX_DEPRECATED

--- a/src/schema/rules/tabular_metadata.yaml
+++ b/src/schema/rules/tabular_metadata.yaml
@@ -7,8 +7,8 @@ scans:
   - .json
   entities:
     subject: required
-    session: optional # session is required if session is present in the dataset.
-sessions: # This file may only exist if session is present in the dataset.
+    session: optional  # session is required if session is present in the dataset.
+sessions:  # This file may only exist if session is present in the dataset.
   suffixes:
   - sessions
   extensions:


### PR DESCRIPTION
Was

```
$> yamllint -c .yamllint.yml src/schema/                                                   
src/schema/rules/tabular_metadata.yaml
  10:23     error    too few spaces before comment  (comments)
  11:11     error    too few spaces before comment  (comments)

src/schema/rules/checks/func.yaml
  1:1       warning  missing document start "---"  (document-start)
```

inspired by https://github.com/bids-standard/bids-specification/pull/1106/files#r883077519