### PR TITLE
[ENH] Update src/schema's README.md to correspond

### DIFF
--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -422,15 +422,17 @@ The `datatypes` dictionary contains a list of datatypes that fall under that mod
 The files in this directory are currently the least standardized of any part of the schema.
 
 Each file corresponds to a single `datatype`.
-Within the file is a list of dictionaries.
-Each dictionary corresponds to a group of suffixes that have the same rules regarding filenames.
-
-The dictionaries have three keys: `suffixes`, `extensions`, and `entities`.
+Within the file is a dictionary.
+Each dictionary entry corresponds to a group of suffixes that have the same rules regarding filenames.
+Key of the entry corresponds to ???.
+Value of the entry is a dictionary with four keys: `suffixes`, `extensions`, `datatypes`, and `entities`.
 
 The `suffixes` entry is a list of file suffixes for which all of the extensions in the `extensions` entry
 and all of the entity rules in the `entities` entry apply.
 
 The `extensions` entry is a list of valid file extensions.
+
+The `datatypes` entry is a list of the datatypes (ATM has a single entry and 1-to-1 correspondence to the filename).
 
 The `entities` entry is a dictionary in which the keys are entity names and the values are whether the entity is
 required or optional for that suffix.
@@ -446,10 +448,18 @@ That information is present in `rules/entities.yaml`.
 As an example, let us look at part of `meg.yaml`:
 
 ```yaml
-- suffixes:
+---
+meg:
+  suffixes:
   - meg
   extensions:
+  - /  # corresponds to BTi/4D data
+  - .ds/
+  - .json
   - .fif
+  #  ... more extensions
+  datatypes:
+  - meg
   entities:
     subject: required
     session: optional
@@ -459,10 +469,13 @@ As an example, let us look at part of `meg.yaml`:
     processing: optional
     split: optional
 
-- suffixes:
+crosstalk:
+  suffixes:
   - meg
   extensions:
   - .fif
+  datatypes:
+  - meg
   entities:
     subject: required
     session: optional
@@ -473,8 +486,8 @@ As an example, let us look at part of `meg.yaml`:
       - crosstalk
 ```
 
-In this case, the first group has one suffix: `meg`.
-The second group has the same suffix (`meg`), but describes different rules for files with that suffix.
+In this case, both groups have the same single suffix: `meg`.
+The second group describes different rules for files with that suffix.
 While the valid extension is the same for both groups (`.fif`), the entities are not.
 
 Specifically, files in the first group may have `task`, `run`, `processing`, and `split` entities,


### PR DESCRIPTION
v1.7.0-87-gf04b47ff (f04b47ff5e90373dd6574f4dff27c84dda0941f4)
introduced refactoring making it from simpler list into a
dict for datatypes.  I was trying to orient myself and found that
README.md was not updated for that new schema of the schema.

Still needs clarification on what those keys are

@bids-standard/schema-users  please help to finalize this PR