### PR TITLE
[FIX] Clarify MEG empty-room recommendations

### DIFF
--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -610,7 +610,7 @@ It should be possible to query empty-room recordings just like usual subject
 recordings, hence all metadata sidecar files (such as the `channels.tsv`) file
 SHOULD be present as well.
 
-Example:
+Example 1:
 
 <!-- This block generates a file tree.
 A guide for using macros can be found at
@@ -627,6 +627,31 @@ A guide for using macros can be found at
             "sub-emptyroom_ses-20170801_task-noise_meg.ds": "",
             "sub-emptyroom_ses-20170801_task-noise_meg.json": "",
             "sub-emptyroom_ses-20170801_task-noise_channels.tsv": "",
+            }
+         }
+      },
+   }
+) }}
+
+
+Example 2:
+
+<!-- This block generates a file tree.
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_filetree_example(
+   {
+   "sub-control01": {
+      "ses-01": {
+         "sub-01_ses-01_scans.tsv": "",
+         "meg": {
+            "sub-control01_ses-01_task-rest_meg.ds": "",
+            "sub-control01_ses-01_task-rest_meg.json": "",
+            "sub-control01_ses-01_task-rest_channels.tsv": "",
+            "sub-control01_ses-01_task-noise_meg.ds": "",
+            "sub-control01_ses-01_task-noise_meg.json": "",
+            "sub-control01_ses-01_task-noise_channels.tsv": "",
             }
          }
       },

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -589,7 +589,7 @@ has to be updated, then for MEG it could be considered to be a new session.
 ## Empty-room MEG recordings
 
 Empty-room MEG recordings capture the environmental and recording system's noise.
-In the context of BIDS it is RECOMMENDED to associate an empty-room recording to each experimental session.
+In the context of BIDS it is RECOMMENDED to associate an empty-room recording to each experimental session (see `AssociatedEmptyRoom` field in the `*_meg.json` sidecar file).
 
 Empty-room recordings may be collected once per day, where a single empty-room recording may be shared between multiple subjects and/or sessions (see example 1).
 Empty-room recordings can also be collected for each individual experimental session (see example 2).

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -592,7 +592,7 @@ Empty-room MEG recordings capture the environmental and recording system's noise
 In the context of BIDS it is RECOMMENDED to perform an empty-room recording for each experimental session.
 
 If empty-room recordings are not collected for each individual experimental session, one empty-room recording may be used with multiple subjects and/or sessions.
-For example, they may be collected once a day. 
+For example, they may be collected once a day.
 In that case it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`.
 The label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be set to `noise`.
 If a [`session-<label>`](../99-appendices/09-entities.md#ses) entity is present, its label SHOULD be the date of the empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`.
@@ -622,7 +622,6 @@ A guide for using macros can be found at
       },
    }
 ) }}
-
 
 Example 2:
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -592,15 +592,15 @@ Empty-room MEG recordings capture the environmental and recording system's noise
 In the context of BIDS it is RECOMMENDED to associate an empty-room recording to each experimental session.
 
 Empty-room recordings may be collected once per day, where one empty-room recording may be used with multiple subjects and/or sessions (see example 1).
-Empty-room recordings can also be collected for each individual experimental session (see example 2). 
+Empty-room recordings can also be collected for each individual experimental session (see example 2).
 
-In the case of empty-room recordings being associated with multiple subjects and/or sessions, it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`. 
-If a [`session-<label>`](../99-appendices/09-entities.md#ses) entity is present, its label SHOULD be the date of the empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`. 
+In the case of empty-room recordings being associated with multiple subjects and/or sessions, it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`.
+If a [`session-<label>`](../99-appendices/09-entities.md#ses) entity is present, its label SHOULD be the date of the empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`.
 The `scans.tsv` file containing the date and time of the acquisition SHOULD also be included.
 The rationale is that this naming scheme will allow users to easily retrieve the empty-room recording that best matches a particular experimental session, based on date and time of the recording.
 It should be possible to query empty-room recordings just like usual subject recordings, hence all metadata sidecar files (such as the `channels.tsv`) file SHOULD be present as well.
 
-In the case of empty-room recordings being collected for the individual experimental session, it is recommended to store the empty-room recording along with that subject and session. 
+In the case of empty-room recordings being collected for the individual experimental session, it is recommended to store the empty-room recording along with that subject and session.
 
 In either case, the label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be set to `noise`.
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -606,7 +606,7 @@ In either case, the label for the [`task-<label>`](../99-appendices/09-entities.
 
 Example 1:
 
-One noise recording per day, applying to all subjects for that day.
+One empty-room recording per day, applying to all subjects for that day.
 
 <!-- This block generates a file tree.
 A guide for using macros can be found at

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -588,26 +588,17 @@ has to be updated, then for MEG it could be considered to be a new session.
 
 ## Empty-room MEG recordings
 
-Empty-room MEG recordings capture the environmental and recording system's
-noise.
-In the context of BIDS it is RECOMMENDED to perform an empty-room recording for
-each experimental session.
+Empty-room MEG recordings capture the environmental and recording system's noise.
+In the context of BIDS it is RECOMMENDED to perform an empty-room recording for each experimental session.
 
-If empty-room recordings are not collected for each individual experimental session, one empty-room recording may be used with multiple subjects and/or sessions. For example, they may be collected once a day. 
-In that case it is RECOMMENDED to store the empty-room recording inside a subject directory
-named `sub-emptyroom`.
-The label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be
-set to `noise`.
-If a [`session-<label>`](../99-appendices/09-entities.md#ses) entity is present, its label SHOULD be the date of the
-empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`.
-The `scans.tsv` file containing the date and time of the acquisition SHOULD
-also be included.
-The rationale is that this naming scheme will allow users to easily retrieve the
-empty-room recording that best matches a particular experimental session, based
-on date and time of the recording.
-It should be possible to query empty-room recordings just like usual subject
-recordings, hence all metadata sidecar files (such as the `channels.tsv`) file
-SHOULD be present as well.
+If empty-room recordings are not collected for each individual experimental session, one empty-room recording may be used with multiple subjects and/or sessions.
+For example, they may be collected once a day. 
+In that case it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`.
+The label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be set to `noise`.
+If a [`session-<label>`](../99-appendices/09-entities.md#ses) entity is present, its label SHOULD be the date of the empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`.
+The `scans.tsv` file containing the date and time of the acquisition SHOULD also be included.
+The rationale is that this naming scheme will allow users to easily retrieve the empty-room recording that best matches a particular experimental session, based on date and time of the recording.
+It should be possible to query empty-room recordings just like usual subject recordings, hence all metadata sidecar files (such as the `channels.tsv`) file SHOULD be present as well.
 
 Example 1:
 

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -589,7 +589,8 @@ has to be updated, then for MEG it could be considered to be a new session.
 ## Empty-room MEG recordings
 
 Empty-room MEG recordings capture the environmental and recording system's noise.
-In the context of BIDS it is RECOMMENDED to associate an empty-room recording to each experimental session (see `AssociatedEmptyRoom` field in the `*_meg.json` sidecar file).
+
+It is RECOMMENDED to explicitly specify which empty-room recording should be used with which experimental run(s) or session(s). This can be done via the [`AssociatedEmptyRoom`](SPEC_ROOT/99-appendices/14-glossary.md#associatedemptyroom-metadata) field in the `*_meg.json` sidecar files.
 
 Empty-room recordings may be collected once per day, where a single empty-room recording may be shared between multiple subjects and/or sessions (see example 1).
 Empty-room recordings can also be collected for each individual experimental session (see example 2).

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -590,7 +590,7 @@ has to be updated, then for MEG it could be considered to be a new session.
 
 Empty-room MEG recordings capture the environmental and recording system's noise.
 
-It is RECOMMENDED to explicitly specify which empty-room recording should be used with which experimental run(s) or session(s). This can be done via the [`AssociatedEmptyRoom`](SPEC_ROOT/99-appendices/14-glossary.md#associatedemptyroom-metadata) field in the `*_meg.json` sidecar files.
+It is RECOMMENDED to explicitly specify which empty-room recording should be used with which experimental run(s) or session(s). This can be done via the [`AssociatedEmptyRoom`](../99-appendices/14-glossary.md#associatedemptyroom-metadata) field in the `*_meg.json` sidecar files.
 
 Empty-room recordings may be collected once per day, where a single empty-room recording may be shared between multiple subjects and/or sessions (see example 1).
 Empty-room recordings can also be collected for each individual experimental session (see example 2).

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -592,7 +592,10 @@ Empty-room MEG recordings capture the environmental and recording system's
 noise.
 In the context of BIDS it is RECOMMENDED to perform an empty-room recording for
 each experimental session.
-It is RECOMMENDED to store the empty-room recording inside a subject directory
+
+If empty-room recordings are not done prior to each individual experimental session, but
+on a daily schedule, one empty-room recording may have to be used with multiple subjects and/or sessions. In that case
+it is RECOMMENDED to store the empty-room recording inside a subject directory
 named `sub-emptyroom`.
 The label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be
 set to `noise`.

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -591,7 +591,7 @@ has to be updated, then for MEG it could be considered to be a new session.
 Empty-room MEG recordings capture the environmental and recording system's noise.
 In the context of BIDS it is RECOMMENDED to associate an empty-room recording to each experimental session.
 
-Empty-room recordings may be collected once per day, where one empty-room recording may be used with multiple subjects and/or sessions (see example 1).
+Empty-room recordings may be collected once per day, where a single empty-room recording may be shared between multiple subjects and/or sessions (see example 1).
 Empty-room recordings can also be collected for each individual experimental session (see example 2).
 
 In the case of empty-room recordings being associated with multiple subjects and/or sessions, it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`.

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -593,9 +593,8 @@ noise.
 In the context of BIDS it is RECOMMENDED to perform an empty-room recording for
 each experimental session.
 
-If empty-room recordings are not done prior to each individual experimental session, but
-on a daily schedule, one empty-room recording may have to be used with multiple subjects and/or sessions. In that case
-it is RECOMMENDED to store the empty-room recording inside a subject directory
+If empty-room recordings are not collected for each individual experimental session, one empty-room recording may be used with multiple subjects and/or sessions. For example, they may be collected once a day. 
+In that case it is RECOMMENDED to store the empty-room recording inside a subject directory
 named `sub-emptyroom`.
 The label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be
 set to `noise`.

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -589,7 +589,7 @@ has to be updated, then for MEG it could be considered to be a new session.
 ## Empty-room MEG recordings
 
 Empty-room MEG recordings capture the environmental and recording system's noise.
-In the context of BIDS it is RECOMMENDED to perform an empty-room recording for each experimental session.
+In the context of BIDS it is RECOMMENDED to associate an empty-room recording to each experimental session.
 
 If empty-room recordings are not collected for each individual experimental session, one empty-room recording may be used with multiple subjects and/or sessions.
 For example, they may be collected once a day.

--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -591,16 +591,22 @@ has to be updated, then for MEG it could be considered to be a new session.
 Empty-room MEG recordings capture the environmental and recording system's noise.
 In the context of BIDS it is RECOMMENDED to associate an empty-room recording to each experimental session.
 
-If empty-room recordings are not collected for each individual experimental session, one empty-room recording may be used with multiple subjects and/or sessions.
-For example, they may be collected once a day.
-In that case it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`.
-The label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be set to `noise`.
-If a [`session-<label>`](../99-appendices/09-entities.md#ses) entity is present, its label SHOULD be the date of the empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`.
+Empty-room recordings may be collected once per day, where one empty-room recording may be used with multiple subjects and/or sessions (see example 1).
+Empty-room recordings can also be collected for each individual experimental session (see example 2). 
+
+In the case of empty-room recordings being associated with multiple subjects and/or sessions, it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`. 
+If a [`session-<label>`](../99-appendices/09-entities.md#ses) entity is present, its label SHOULD be the date of the empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`. 
 The `scans.tsv` file containing the date and time of the acquisition SHOULD also be included.
 The rationale is that this naming scheme will allow users to easily retrieve the empty-room recording that best matches a particular experimental session, based on date and time of the recording.
 It should be possible to query empty-room recordings just like usual subject recordings, hence all metadata sidecar files (such as the `channels.tsv`) file SHOULD be present as well.
 
+In the case of empty-room recordings being collected for the individual experimental session, it is recommended to store the empty-room recording along with that subject and session. 
+
+In either case, the label for the [`task-<label>`](../99-appendices/09-entities.md#task) entity in the empty-room recording SHOULD be set to `noise`.
+
 Example 1:
+
+One noise recording per day, applying to all subjects for that day.
 
 <!-- This block generates a file tree.
 A guide for using macros can be found at
@@ -624,6 +630,8 @@ A guide for using macros can be found at
 ) }}
 
 Example 2:
+
+One recording per session, stored within the session folder.
 
 <!-- This block generates a file tree.
 A guide for using macros can be found at


### PR DESCRIPTION
@mcvinding noted to me that the recommendation for empty-room MEG recordings was confusing, as it confounds two practices. 

Some labs record an empty-room recording every morning to be shared, that is then to be used for all subjects/sessions recorded during that day.

Other labs record an empty-room recording prior to each experimental session, those are not shared.

The text specified that it is "RECOMMENDED to perform an empty-room recording for each experimental session" (i.e., non -shared) and subsequently it explained how to organize the daily shared empty-room recordings in a `sub-emptyroom/ses-YYYYMMDD` structure.

The updated text splits the two and does not prescribe the recommended `ses-YYYYMMDD` practice for empty-room recordings done prior to each experimental session, as those are more logically shared with the actual subject and session.
