### PR TITLE
[FIX] Discourage use of "sample" in events if sampling frequency is ambiguous, add guidelines for precision

### DIFF
--- a/src/04-modality-specific-files/05-task-events.md
+++ b/src/04-modality-specific-files/05-task-events.md
@@ -67,7 +67,7 @@ For example in an EEG experiment with devices operating at 1000 Hz sampling freq
 dataset curators SHOULD specify **at least** 3 figures after the decimal point.
 
 An arbitrary number of additional columns can be added. Those allow describing
-other properties of events that could be later referred in modelling and
+other properties of events that could be later referenced in modelling and
 hypothesis extensions of BIDS.
 Note that the `trial_type` and any additional columns in a TSV file
 SHOULD be documented in an accompanying JSON sidecar file.

--- a/src/04-modality-specific-files/05-task-events.md
+++ b/src/04-modality-specific-files/05-task-events.md
@@ -52,13 +52,19 @@ and a guide for using macros can be found at
    }
 ) }}
 
-<sup>5</sup> Note for MRI data:
+Note for MRI data:
 If any acquired scans have been discarded before forming the imaging data file,
 ensure that an `onset` of 0 corresponds to the time the first image was stored.
 For example in case there is an in scanner training phase that
 begins before the scanning sequence has started events from this sequence should
 have negative onset time counting down to the beginning of the acquisition of
 the first volume.
+
+Note regarding the precision of numeric metadata:
+It is RECOMMENDENDED that dataset curators specify numeric metadata like `onset` and
+`duration` with as much decimal precision as is reasonable in the context of the experiment.
+For example in an EEG experiment with devices operating at 1000 Hz sampling frequency,
+dataset curators SHOULD specify **at least** 3 figures after the decimal point.
 
 An arbitrary number of additional columns can be added. Those allow describing
 other properties of events that could be later referred in modelling and

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -347,6 +347,9 @@ sample:
   description: |
     Onset of the event according to the sampling scheme of the recorded modality
     (that is, referring to the raw data file that the `events.tsv` file accompanies).
+    When there are several sampling schemes present in the raw data file (as can be
+    the case for example for `.edf` files), this metadata field is ambiguous and
+    SHOULD NOT be used.
   type: integer
 sample_id:
   name: sample_id

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -348,7 +348,7 @@ sample:
     Onset of the event according to the sampling scheme of the recorded modality
     (that is, referring to the raw data file that the `events.tsv` file accompanies).
     When there are several sampling schemes present in the raw data file (as can be
-    the case for example for `.edf` files), this metadata field is ambiguous and
+    the case for example for `.edf` files), this column is ambiguous and
     SHOULD NOT be used.
   type: integer
 sample_id:


### PR DESCRIPTION
closes #1043 

Adds two minor tweaks to our documentation of `events.tsv`:

1. Don't Use `sample` when the sampling frequency in the raw data is ambiguous / mixed
2. Use a reasonable precision for numeric metadata (onset, duration, response_time, ...)