### PR TITLE
[ENH] Filtering child datasets from parent validation

### DIFF
--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -10,7 +10,7 @@
 -   \[ENH] Catch and report invalid JSON in dataset_description [#1122](https://github.com/bids-standard/bids-specification/pull/1122) ([TheChymera](https://github.com/TheChymera))
 -   \[ENH] Ensure consistent indentation for comments in yaml files, address yamllint warning [#1117](https://github.com/bids-standard/bids-specification/pull/1117) ([yarikoptic](https://github.com/yarikoptic))
 -   \[FIX] clarify no blank and duplicated headers in TSV [#1116](https://github.com/bids-standard/bids-specification/pull/1116) ([sappelhoff](https://github.com/sappelhoff))
--   \[INFRA] Skipping tests which requre network access via env variable [#1109](https://github.com/bids-standard/bids-specification/pull/1109) ([TheChymera](https://github.com/TheChymera))
+-   \[INFRA] Skipping tests which require network access via env variable [#1109](https://github.com/bids-standard/bids-specification/pull/1109) ([TheChymera](https://github.com/TheChymera))
 -   \[SCHEMA] Unify metadata [#1107](https://github.com/bids-standard/bids-specification/pull/1107) ([effigies](https://github.com/effigies))
 -   \[ENH] NGFF format support [#1104](https://github.com/bids-standard/bids-specification/pull/1104) ([TheChymera](https://github.com/TheChymera))
 -   \[ENH] Add Microscopy-BIDS citation [#1102](https://github.com/bids-standard/bids-specification/pull/1102) ([mariehbourget](https://github.com/mariehbourget))

--- a/tools/schemacode/bidsschematools/tests/test_validator.py
+++ b/tools/schemacode/bidsschematools/tests/test_validator.py
@@ -315,6 +315,7 @@ def test_bids_datasets(bids_examples, tmp_path):
         "pet003",
         "qmri_tb1tfl",
         "qmri_vfa/derivatives/qMRLab",
+        "qmri_qsm",
     ]
     schema_path = "{module_path}/data/schema/"
 

--- a/tools/schemacode/bidsschematools/validator.py
+++ b/tools/schemacode/bidsschematools/validator.py
@@ -37,8 +37,6 @@ def _get_paths(
     * Figure out how to return paths from BIDS root.
     * Deduplicate paths (if input dirs are subsets of other input dirs), might best be done at the
         very end.
-    * Specifying file paths currently breaks because they are truncated based on the bids_paths
-        input.
     """
     exclude_subdirs = [
         rf"{os.sep}.dandi",
@@ -55,12 +53,19 @@ def _get_paths(
     ]
 
     path_list = []
+    bids_root_found = False
     for bids_path in bids_paths:
         bids_path = os.path.abspath(os.path.expanduser(bids_path))
         if os.path.isfile(bids_path):
             path_list.append(bids_path)
             continue
         for root, dirs, file_names in os.walk(bids_path, topdown=True):
+            if "dataset_description.json" in file_names:
+                if bids_root_found:
+                    dirs[:] = []
+                    file_names[:] = []
+                else:
+                    bids_root_found = True
             if any(root.endswith(i) for i in pseudofile_suffixes):
                 # Add the directory name to the validation paths list.
                 path_list.append(f"{root}/")


### PR DESCRIPTION
Formerly, the validator would index child datasets (i.e. derivatives) automatically when pointed at a parent dataset, and complain about having found more than one `README`, `dataset_description.json`, etc.  