### PR TITLE
[FIX] fix typo in PR title which got into src/CHANGES.md

### DIFF
--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -10,7 +10,7 @@
 -   \[ENH] Catch and report invalid JSON in dataset_description [#1122](https://github.com/bids-standard/bids-specification/pull/1122) ([TheChymera](https://github.com/TheChymera))
 -   \[ENH] Ensure consistent indentation for comments in yaml files, address yamllint warning [#1117](https://github.com/bids-standard/bids-specification/pull/1117) ([yarikoptic](https://github.com/yarikoptic))
 -   \[FIX] clarify no blank and duplicated headers in TSV [#1116](https://github.com/bids-standard/bids-specification/pull/1116) ([sappelhoff](https://github.com/sappelhoff))
--   \[INFRA] Skipping tests which requre network access via env variable [#1109](https://github.com/bids-standard/bids-specification/pull/1109) ([TheChymera](https://github.com/TheChymera))
+-   \[INFRA] Skipping tests which require network access via env variable [#1109](https://github.com/bids-standard/bids-specification/pull/1109) ([TheChymera](https://github.com/TheChymera))
 -   \[SCHEMA] Unify metadata [#1107](https://github.com/bids-standard/bids-specification/pull/1107) ([effigies](https://github.com/effigies))
 -   \[ENH] NGFF format support [#1104](https://github.com/bids-standard/bids-specification/pull/1104) ([TheChymera](https://github.com/TheChymera))
 -   \[ENH] Add Microscopy-BIDS citation [#1102](https://github.com/bids-standard/bids-specification/pull/1102) ([mariehbourget](https://github.com/mariehbourget))


### PR DESCRIPTION
That leads to failing CI as in
https://github.com/bids-standard/bids-specification/pull/1120/files#file-src-changes-md-L13

Ideally we should add spell checking for PR title, but those would keep changing,
would need separate workflow and react to changes to titles and then have no way
to easily say "ignore". May be src/CHANGES.md should be excluded... separate issue would
that be
