### PR TITLE
[FIX] cover bidsschematools not old name schemacode

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: "Run tests"
         shell: bash {0}
         run: |
-          python -m pytest --pyargs bidsschematools --cov=schemacode
+          python -m pytest --pyargs bidsschematools --cov=bidsschematools
 
       - name: "Upload coverage to CodeCov"
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
renaming happened in f84cd8514 but coverage submission was not adjusted.
That is what resulted (I guess) in no coverage being submitted as in
https://github.com/bids-standard/bids-specification/pull/1120

    ==> GitHub Actions detected.
        Env vars used:
          -> GITHUB_ACTIONS:    true
          -> GITHUB_HEAD_REF:   validator_inheritance
          -> GITHUB_REF:        refs/pull/1120/merge
          -> GITHUB_REPOSITORY: bids-standard/bids-specification
          -> GITHUB_RUN_ID:     2680833203
          -> GITHUB_SHA:        b39dbd75f515e1f2f114437f423cdcaef915c535
          -> GITHUB_WORKFLOW:   schemacode_ci
    project root: .
    Yaml not found, that's ok! Learn more athttp://docs.codecov.io/docs/codecov-yaml
    ==> Running gcov in . (disable via -X gcov)
    ==> Python coveragepy exists disable via -X coveragepy
    -> Running coverage xml
    No data to report.
    ==> Searching for coverage reports in:
    + .
    --> No coverage report found.
        Please visit http://docs.codecov.io/docs/supported-languages

