### PR TITLE
[SCHEMA] Mark CHANGES as optional

### DIFF
--- a/src/schema/rules/top_level_files.yaml
+++ b/src/schema/rules/top_level_files.yaml
@@ -7,7 +7,7 @@ README:
   - .rst
   - .txt
 CHANGES:
-  required: true
+  required: false
   extensions:
   - None
 LICENSE:


### PR DESCRIPTION
Current wording at
https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html#changes

	### `CHANGES`

	Version history of the dataset (describing changes, updates and corrections) MAY
	be provided in the form of a `CHANGES` text file. This file MUST follow the
	[CPAN Changelog convention](https://metacpan.org/pod/release/HAARG/CPAN-Changes-0.400002/lib/CPAN/Changes/Spec.pod).
	The `CHANGES` file MUST be either in ASCII or UTF-8 encoding.

so it MAY be provided, not MUST.  Alerted to by @satra in
https://github.com/dandi/dandi-cli/issues/1055#issuecomment-1189007674

Closes #1127.