### PR TITLE
[FIX] clarify alphanumeric

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2986,7 +2986,7 @@ TaskName:
     Name of the task.
     No two tasks should have the same name.
     The task label included in the file name is derived from this `"TaskName"` field
-    by removing all non-alphanumeric (`[a-zA-Z0-9]`) characters.
+    by removing all non-alphanumeric (`[^0-9a-zA-Z]`) characters.
     For example `"TaskName"` `"faces n-back"` will correspond to task label
     `facesnback`.
   type: string

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2986,7 +2986,7 @@ TaskName:
     Name of the task.
     No two tasks should have the same name.
     The task label included in the file name is derived from this `"TaskName"` field
-    by removing all non-alphanumeric (`[^0-9a-zA-Z]`) characters.
+    by removing all non-alphanumeric characters (that is, all except those matching `[0-9a-zA-Z]`).
     For example `"TaskName"` `"faces n-back"` will correspond to task label
     `facesnback`.
   type: string


### PR DESCRIPTION
since `non-`, regex should have `^`

and place 0-9 first for consistency (complimentary to #1162 by @TheChymera )