### PR TITLE
[INFRA] Curate changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
   # Automatically generate a changelog since migration from Google Docs to GitHub
   github_changelog_generator:
     docker:
-      - image: ferrarimarco/github_changelog_generator:1.14.3
+      - image: ferrarimarco/github-changelog-generator:1.14.3
     steps:
       - setup_remote_docker:
           version: 18.06.0-ce

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,14 @@ jobs:
                 --output ~/changelog_build/CHANGES.md \
                 --base ~/project/src/pregh-changes.md \
                 --header-label "# Changelog" \
+                --release-branch master \
                 --no-issues \
-                --no-issues-wo-labels \
                 --no-filter-by-milestone \
                 --no-compare-link \
                 --pr-label "" \
-                --release-branch master
+                --enhancement-label "" \
+                --bugs-label "" \
+                --exclude-labels "exclude-from-changelog"
               cat ~/changelog_build/CHANGES.md
             else
               echo "Commit or Release, do nothing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           path: ~/project/site/
           destination: dev_docs
 
-  linkchecker:
+  check_links:
     docker:
       - image: cimg/python:3.8
     steps:
@@ -89,10 +89,10 @@ jobs:
       - store_artifacts:
           path: bids-spec.pdf
 
-  # Auto changelog collector
-  github-changelog-generator:
+  # Automatically generate a changelog since migration from Google Docs to GitHub
+  github_changelog_generator:
     docker:
-      - image: ferrarimarco/github-changelog-generator:1.14.3
+      - image: ferrarimarco/github_changelog_generator:1.14.3
     steps:
       - setup_remote_docker:
           version: 18.06.0-ce
@@ -127,8 +127,8 @@ jobs:
           root: ~/.
           paths: changelog_build
 
-  # Run remark on the auto generated changes.md file
-  remark:
+  # Lint and fix the auto generated changes.md file
+  lint_generated_changelog:
     docker:
       - image: cimg/node:lts
     steps:
@@ -156,12 +156,12 @@ jobs:
               echo "Commit or Release, do nothing"
             fi
       - persist_to_workspace:
-          # fixed+linted changelog in ~/changelog_build/CHANGES.md
+          # linted and fixed changelog in ~/changelog_build/CHANGES.md
           root: ~/.
           paths: changelog_build
 
   # Push built changelog to repo
-  Changelog-bot:
+  commit_generated_changelog:
     docker:
       - image: cimg/base:stable
     steps:
@@ -195,22 +195,22 @@ workflows:
   search_build:
     jobs:
       - build_docs
-      - linkchecker:
+      - check_links:
           requires:
             - build_docs
-      - github-changelog-generator:
+      - github_changelog_generator:
           filters:
             branches:
               only: master
-      - remark:
+      - lint_generated_changelog:
           requires:
-            - github-changelog-generator
+            - github_changelog_generator
           filters:
             branches:
               only: master
-      - Changelog-bot:
+      - commit_generated_changelog:
           requires:
-            - remark
+            - lint_generated_changelog
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build_docs:
     docker:


### PR DESCRIPTION
closes #1147 



~~Probably need to use: `[no-]pr-wo-labels`, see: https://github.com/github-changelog-generator/github-changelog-generator/wiki/Advanced-change-log-generation-examples~~

EDIT: I tried around a bit to make PRs appear in the changelog via "opt in", but it turned out to be difficult / impossible. **However**, having an "opt out" is very easy via:

1. `--exclude-labels`
1. and the new label [exclude-from-changelog](https://github.com/bids-standard/bids-specification/labels/exclude-from-changelog) that I just generated: [![exclude-from-changelog](https://img.shields.io/badge/-exclude%20from%20changelog-000000.svg)](https://github.com/bids-standard/bids-specification/labels/exclude-from-changelog)

I think this is a solution that we can work with. We merely need to go through the list of PRs we'd like to exclude from the automatically generated changelog and give them that label.

Even better: If we disagree later, all we need to do is remove the label and upon the next "merge commit", when the changelog-generator is run again, the item will be back (except for in the stable, released versions, where the changelog is fixed).

---

On a separate note, I'd like to upgrade to more recent versions of the changelog software, but we are still blocked by:

- https://github.com/github-changelog-generator/github-changelog-generator/issues/901

... so that will have to wait.