### PR TITLE
[FIX] Solves isort ImportError 

### DIFF
--- a/tools/schemacode/setup.cfg
+++ b/tools/schemacode/setup.cfg
@@ -37,10 +37,9 @@ doc =
 tests =
     codecov
     coverage<5.0
-    flake8>=3.7
+    flake8<5.0
     flake8-black
     flake8-isort
-    isort<5.0
     pytest
     pytest-cov
 all =

--- a/tools/schemacode/setup.cfg
+++ b/tools/schemacode/setup.cfg
@@ -40,6 +40,7 @@ tests =
     flake8>=3.7
     flake8-black
     flake8-isort
+    isort<5.0
     pytest
     pytest-cov
 all =


### PR DESCRIPTION
Test suite has started failing with:
```
/flake8_isort.py", line 3, in <module>
    from isort import SortImports
ImportError: cannot import name 'SortImports' from 'isort' (/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/isort/__init__.py)
```

Error seen in action here:
https://ppb.chymera.eu/62fd78.log
