### PR TITLE
[DO NOT MERGE] CI: Install wheel, rely on pyproject.toml for build-time dependencies

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -57,8 +57,8 @@ jobs:
       - name: "Install the schemacode package"
         shell: bash {0}
         run: |
-          python -m pip install --progress-bar off --upgrade pip setuptools wheel
-          python -m pip install -e ./tools/schemacode[tests]
+          python -m pip install --progress-bar off --upgrade pip
+          python -m pip install ./tools/schemacode[tests]
 
       - name: "Run tests"
         shell: bash {0}


### PR DESCRIPTION
This should break things. Checking so that we can verify #1208 fixes them.