### PR TITLE
[SCHEMA] add schema and spec version to object dumped by bidsschematools

### DIFF
--- a/tools/schemacode/bidsschematools/schema.py
+++ b/tools/schemacode/bidsschematools/schema.py
@@ -9,8 +9,7 @@ from pathlib import Path
 
 import yaml
 
-from . import utils
-from . import __version__, __bids_version__
+from . import __bids_version__, __version__, utils
 
 lgr = utils.get_logger()
 # Basic settings for output, for now just basic

--- a/tools/schemacode/bidsschematools/schema.py
+++ b/tools/schemacode/bidsschematools/schema.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import yaml
 
 from . import utils
+from . import __version__, __bids_version__
 
 lgr = utils.get_logger()
 # Basic settings for output, for now just basic
@@ -227,7 +228,10 @@ def load_schema(schema_path=None):
 
 
 def export_schema(schema):
-    return json.dumps(schema.to_dict())
+    schema_dict = schema.to_dict()
+    schema_dict['schema_version'] = __version__
+    schema_dict['bids_version'] = __bids_version__
+    return json.dumps(schema_dict)
 
 
 def filter_schema(schema, **kwargs):

--- a/tools/schemacode/bidsschematools/schema.py
+++ b/tools/schemacode/bidsschematools/schema.py
@@ -228,8 +228,8 @@ def load_schema(schema_path=None):
 
 def export_schema(schema):
     schema_dict = schema.to_dict()
-    schema_dict['schema_version'] = __version__
-    schema_dict['bids_version'] = __bids_version__
+    schema_dict["schema_version"] = __version__
+    schema_dict["bids_version"] = __bids_version__
     return json.dumps(schema_dict)
 
 


### PR DESCRIPTION
These files may be passed around and have lives outside of readthedocs url. Having basic provenance info may save someone a headache in the future.
