### PR TITLE
Default logpaths

### DIFF
--- a/tools/schemacode/bidsschematools/tests/test_validator.py
+++ b/tools/schemacode/bidsschematools/tests/test_validator.py
@@ -377,7 +377,6 @@ def test_bids_datasets(bids_examples, tmp_path, dataset):
     result = validate_bids(
         target,
         schema_version=schema_path,
-        report_path=True,
     )
     # Have all files been validated?
     assert len(result["path_tracking"]) == 0

--- a/tools/schemacode/bidsschematools/validator.py
+++ b/tools/schemacode/bidsschematools/validator.py
@@ -462,7 +462,7 @@ def validate_all(
 
 def write_report(
     validation_result,
-    report_path="/var/tmp/bids-validator/report_{datetime}-{pid}.log",
+    report_path="~/.cache/bidsschematools/validator-report_{datetime}-{pid}.log",
     datetime_format="%Y%m%d%H%M%SZ",
 ):
     """Write a human-readable report based on the validation result.
@@ -492,8 +492,9 @@ def write_report(
         pid=os.getpid(),
     )
     report_path = os.path.abspath(os.path.expanduser(report_path))
+    report_dir = os.path.dirname(report_path)
     try:
-        os.makedirs(os.path.dirname(report_path))
+        os.makedirs(report_dir)
     except OSError:
         pass
 


### PR DESCRIPTION
Initially I though it would be a good idea to use system-wide log and temporary data directories, but it causes all sorts of sandboxing issues, and now that I think of it might leak patient data...