### PR TITLE
[ENH] Prettier; Updating yaml formatting to play nicely w/ yamllint, .editorconfig, and prettier. (Warning: compromises made)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.yaml]
+max_line_length = 120
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+quote_type = single

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# 2022-08-19 12:59:40 -0400 - markiewicz@stanford.edu - [git-blame-ignore-rev] prettified schema files.
+aaccb5ffc10e7f9460bbe9eb8c246872de167543

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-json
-    -   id: check-ast
-    -   id: check-added-large-files
-    -   id: check-case-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-ast
+      - id: check-added-large-files
+      - id: check-case-conflict

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,6 +5,8 @@ rules:
     max: 120
   indentation:
     # See https://github.com/yaml/pyyaml/issues/545 for why
-    indent-sequences: false
+    spaces: 2
+    indent-sequences: true
   comments:
     level: error
+    min-spaces-from-content: 1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+
+runprettier:
+	prettier --write "src/schema/**/*.yaml"
+	python3 -m yamllint -f standard src/schema/ -c .yamllint.yml
+
+SCHEMA_CHANGES := $(shell git diff --name-only | grep src/schema/*.yaml)
+
+commitschema:
+	@echo SCHEMA_CHANGES $(SCHEMA_CHANGES)
+	git add src/schema/*.yaml && \
+	git commit -m "[git-blame-ignore-rev] prettified schema files." && \
+	git log --grep "\[git-blame-ignore-rev\]" --pretty=format:"# %ai - %ae - %s%n%H" >> .git-blame-ignore-revs \
+	|| true
+
+formatschema: runprettier commitschema
+
+all:
+
+.PHONY: runprettier commitschema

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -18,245 +18,245 @@
 #
 ---
 context:
-    type: object
-    properties:
-        dataset:
-            description: "Properties and contents of the entire dataset"
-            type: object
-            properties:
-                dataset_description:
-                    description: "Contents of /dataset_description.json"
-                    type: object
-                files:
-                    description: "List of all files in dataset"
-                    type: array
-                tree:
-                    description: "Tree view of all files in dataset"
-                    type: object
-                ignored:
-                    description: "Set of ignored files"
-                    type: array
-                modalities:
-                    description: "Modalities present in the dataset"
-                    type: array
-                subjects:
-                    description: "Collections of subjects in dataset"
-                    type: object
-                    properties:
-                        sub_dirs:
-                            description: "Subjects as determined by sub-*/ directories"
-                            type: array
-                            items:
-                                type: string
-                        participant_id:
-                            description: "The participant_id column of participants.tsv"
-                            type: array
-                            items:
-                                type: string
-                        phenotype:
-                            description: "The union of participant_id columns in phenotype files"
-                            type: array
-                            items:
-                                type: string
-        subject:
-            description: "Properties and contents of the current subject"
-            type: object
-            properties:
-                sessions:
-                    description: "Collections of sessions in subject"
-                    type: object
-                    properties:
-                        ses_dirs:
-                            description: "Sessions as determined by ses-*/ directories"
-                            type: array
-                            items:
-                                type: string
-                        session_id:
-                            description: "The session_id column of sessions.tsv"
-                            type: array
-                            items:
-                                type: string
-                        phenotype:
-                            description: "The union of session_id columns in phenotype files"
-                            type: array
-                            items:
-                                type: string
+  type: object
+  properties:
+    dataset:
+      description: 'Properties and contents of the entire dataset'
+      type: object
+      properties:
+        dataset_description:
+          description: 'Contents of /dataset_description.json'
+          type: object
+        files:
+          description: 'List of all files in dataset'
+          type: array
+        tree:
+          description: 'Tree view of all files in dataset'
+          type: object
+        ignored:
+          description: 'Set of ignored files'
+          type: array
+        modalities:
+          description: 'Modalities present in the dataset'
+          type: array
+        subjects:
+          description: 'Collections of subjects in dataset'
+          type: object
+          properties:
+            sub_dirs:
+              description: 'Subjects as determined by sub-*/ directories'
+              type: array
+              items:
+                type: string
+            participant_id:
+              description: 'The participant_id column of participants.tsv'
+              type: array
+              items:
+                type: string
+            phenotype:
+              description: 'The union of participant_id columns in phenotype files'
+              type: array
+              items:
+                type: string
+    subject:
+      description: 'Properties and contents of the current subject'
+      type: object
+      properties:
+        sessions:
+          description: 'Collections of sessions in subject'
+          type: object
+          properties:
+            ses_dirs:
+              description: 'Sessions as determined by ses-*/ directories'
+              type: array
+              items:
+                type: string
+            session_id:
+              description: 'The session_id column of sessions.tsv'
+              type: array
+              items:
+                type: string
+            phenotype:
+              description: 'The union of session_id columns in phenotype files'
+              type: array
+              items:
+                type: string
 
-        # Properties of the current file
-        path:
-            description: "Path of the current file"
-            type: string
-        entities:
-            description: "Entities parsed from the current filename"
-            type: object
-        datatype:
-            description: "Datatype of current file, for examples, anat"
-            type: string
-        suffix:
-            description: "Suffix of current file"
-            type: string
-        extension:
-            description: "Extension of current file including initial dot"
-            type: string
-        modality:
-            description: "Modality of current file, for examples, MRI"
-            type: string
+    # Properties of the current file
+    path:
+      description: 'Path of the current file'
+      type: string
+    entities:
+      description: 'Entities parsed from the current filename'
+      type: object
+    datatype:
+      description: 'Datatype of current file, for examples, anat'
+      type: string
+    suffix:
+      description: 'Suffix of current file'
+      type: string
+    extension:
+      description: 'Extension of current file including initial dot'
+      type: string
+    modality:
+      description: 'Modality of current file, for examples, MRI'
+      type: string
 
-        sidecar:
-            description: "Sidecar metadata constructed via the inheritance principle"
-            type: object
-        associations:
-            # Note that this is not intended to be an exhaustive list of associated files
-            # or to expose every attribute of those files. It is specifically those files
-            # and attributes for which a rule needs to be applied from an originating file.
-            description: |
-                Associated files, indexed by suffix, selected according to the inheritance principle
-            type: object
-            properties:
-                events:
-                    description: "Events file"
-                    type: object
-                    properties:
-                        path:
-                            description: "Path to associated events file"
-                            type: string
-                        onset:
-                            description: "Contents of the onset column"
-                            type: array
-                            items:
-                                type: string
-                aslcontext:
-                    description: "ASL context file"
-                    type: object
-                    properties:
-                        path:
-                            description: "Path to associated aslcontext file"
-                            type: string
-                        n_rows:
-                            description: "Number of rows in aslcontext.tsv"
-                            type: integer
-                        volume_type:
-                            description: "Contents of the volume_type column"
-                            type: array
-                            items:
-                                type: string
-                m0scan:
-                    description: "M0 scan file"
-                    type: object
-                    properties:
-                        path:
-                            description: "Path to associated M0 scan file"
-                            type: string
-                magnitude:
-                    description: "Magnitude image file"
-                    type: object
-                    properties:
-                        path:
-                            description: "Path to associated magnitude file"
-                            type: string
-                magnitude1:
-                    description: "Magnitude1 image file"
-                    type: object
-                    properties:
-                        path:
-                            description: "Path to associated magnitude1 file"
-                            type: string
-                bval:
-                    description: "B value file"
-                    type: object
-                    properties:
-                        path:
-                            description: "Path to associated bval file"
-                            type: string
-                        n_cols:
-                            description: "Number of columns in bval file"
-                            type: integer
-                bvec:
-                    description: "B vector file"
-                    type: object
-                    properties:
-                        path:
-                            description: "Path to associated bvec file"
-                            type: string
-                        n_cols:
-                            description: "Number of columns in bvec file"
-                            type: integer
+    sidecar:
+      description: 'Sidecar metadata constructed via the inheritance principle'
+      type: object
+    associations:
+      # Note that this is not intended to be an exhaustive list of associated files
+      # or to expose every attribute of those files. It is specifically those files
+      # and attributes for which a rule needs to be applied from an originating file.
+      description: |
+        Associated files, indexed by suffix, selected according to the inheritance principle
+      type: object
+      properties:
+        events:
+          description: 'Events file'
+          type: object
+          properties:
+            path:
+              description: 'Path to associated events file'
+              type: string
+            onset:
+              description: 'Contents of the onset column'
+              type: array
+              items:
+                type: string
+        aslcontext:
+          description: 'ASL context file'
+          type: object
+          properties:
+            path:
+              description: 'Path to associated aslcontext file'
+              type: string
+            n_rows:
+              description: 'Number of rows in aslcontext.tsv'
+              type: integer
+            volume_type:
+              description: 'Contents of the volume_type column'
+              type: array
+              items:
+                type: string
+        m0scan:
+          description: 'M0 scan file'
+          type: object
+          properties:
+            path:
+              description: 'Path to associated M0 scan file'
+              type: string
+        magnitude:
+          description: 'Magnitude image file'
+          type: object
+          properties:
+            path:
+              description: 'Path to associated magnitude file'
+              type: string
+        magnitude1:
+          description: 'Magnitude1 image file'
+          type: object
+          properties:
+            path:
+              description: 'Path to associated magnitude1 file'
+              type: string
+        bval:
+          description: 'B value file'
+          type: object
+          properties:
+            path:
+              description: 'Path to associated bval file'
+              type: string
+            n_cols:
+              description: 'Number of columns in bval file'
+              type: integer
+        bvec:
+          description: 'B vector file'
+          type: object
+          properties:
+            path:
+              description: 'Path to associated bvec file'
+              type: string
+            n_cols:
+              description: 'Number of columns in bvec file'
+              type: integer
 
-        # The following properties are populated if the current file is of an appropriate type
-        columns:
-            description: "TSV columns, indexed by column header, values are arrays with column contents"
-            type: object
-            additionalProperties:
-                type: array
-        json:
-            description: "Contents of the current JSON file"
-            type: object
-        nifti_header:
-            name: "NIfTI Header"
-            description: "Parsed contents of NIfTI header referenced elsewhere in schema."
-            type: object
-            properties:
-                dim_info:
-                    name: "Dimension Information"
-                    description: "Metadata about dimensions data."
-                    type: object
-                    properties:
-                        freq:
-                            name: "Frequency"
-                            description: "These fields encode which spatial dimension (1, 2, or 3)."
-                            type: integer
-                        phase:
-                            name: "Phase"
-                            description: "Corresponds to which acquisition dimension for MRI data."
-                            type: integer
-                        slice:
-                            name: "Slice"
-                            description: "Slice dimensions."
-                            type: integer
-                dim:
-                    name: "Data Dimensions"
-                    description: "Data seq dimensions."
-                    type: array
-                    minItems: 8
-                    maxItems: 8
-                    items:
-                        type: integer
-                pixdim:
-                    name: "Pixel Dimension"
-                    description: "Grid spacings (unit per dimension)."
-                    type: array
-                    minItems: 8
-                    maxItems: 8
-                    items:
-                        type: number
-                xyzt_units:
-                    name: "XYZT Units"
-                    description: "Units of pixdim[1..4]"
-                    type: object
-                    properties:
-                        xyz:
-                            name: "XYZ Units"
-                            description: "String representing the unit of voxel spacing."
-                            type: string
-                            enum:
-                            - "unknown"
-                            - "meter"
-                            - "mm"
-                            - "um"
-                        t:
-                            name: "Time Unit"
-                            description: "String representing the unit of inter-volume intervals."
-                            type: string
-                            enum:
-                            - "unknown"
-                            - "sec"
-                            - "msec"
-                            - "usec"
-                qform_code:
-                    name: "qform code"
-                    description: "Use of the quaternion fields."
-                    type: integer
-                sform_code:
-                    name: "sform code"
-                    description: "Use of the affine fields."
-                    type: integer
+    # The following properties are populated if the current file is of an appropriate type
+    columns:
+      description: 'TSV columns, indexed by column header, values are arrays with column contents'
+      type: object
+      additionalProperties:
+        type: array
+    json:
+      description: 'Contents of the current JSON file'
+      type: object
+    nifti_header:
+      name: 'NIfTI Header'
+      description: 'Parsed contents of NIfTI header referenced elsewhere in schema.'
+      type: object
+      properties:
+        dim_info:
+          name: 'Dimension Information'
+          description: 'Metadata about dimensions data.'
+          type: object
+          properties:
+            freq:
+              name: 'Frequency'
+              description: 'These fields encode which spatial dimension (1, 2, or 3).'
+              type: integer
+            phase:
+              name: 'Phase'
+              description: 'Corresponds to which acquisition dimension for MRI data.'
+              type: integer
+            slice:
+              name: 'Slice'
+              description: 'Slice dimensions.'
+              type: integer
+        dim:
+          name: 'Data Dimensions'
+          description: 'Data seq dimensions.'
+          type: array
+          minItems: 8
+          maxItems: 8
+          items:
+            type: integer
+        pixdim:
+          name: 'Pixel Dimension'
+          description: 'Grid spacings (unit per dimension).'
+          type: array
+          minItems: 8
+          maxItems: 8
+          items:
+            type: number
+        xyzt_units:
+          name: 'XYZT Units'
+          description: 'Units of pixdim[1..4]'
+          type: object
+          properties:
+            xyz:
+              name: 'XYZ Units'
+              description: 'String representing the unit of voxel spacing.'
+              type: string
+              enum:
+                - 'unknown'
+                - 'meter'
+                - 'mm'
+                - 'um'
+            t:
+              name: 'Time Unit'
+              description: 'String representing the unit of inter-volume intervals.'
+              type: string
+              enum:
+                - 'unknown'
+                - 'sec'
+                - 'msec'
+                - 'usec'
+        qform_code:
+          name: 'qform code'
+          description: 'Use of the quaternion fields.'
+          type: integer
+        sform_code:
+          name: 'sform code'
+          description: 'Use of the affine fields.'
+          type: integer

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -82,12 +82,12 @@ duration:
     A "duration" value of zero implies that the delta function or event is so
     short as to be effectively modeled as an impulse.
   anyOf:
-  - type: number
-    unit: s
-    minimum: 0
-  - type: string
-    enum:
-    - n/a
+    - type: number
+      unit: s
+      minimum: 0
+    - type: string
+      enum:
+        - n/a
 filename:
   name: filename
   display_name: Filename
@@ -103,8 +103,8 @@ group__channel:
     This is relevant because one group has one cable-bundle and noise can be shared.
     This can be a name or number.
   anyOf:
-  - type: string
-  - type: number
+    - type: string
+    - type: number
 handedness:
   name: handedness
   display_name: Subject handedness
@@ -119,22 +119,22 @@ handedness:
     `Ambidextrous`.
   type: string
   enum:
-  - left
-  - l
-  - L
-  - LEFT
-  - Left
-  - right
-  - r
-  - R
-  - RIGHT
-  - Right
-  - ambidextrous
-  - a
-  - A
-  - AMBIDEXTROUS
-  - Ambidextrous
-  - n/a
+    - left
+    - l
+    - L
+    - LEFT
+    - Left
+    - right
+    - r
+    - R
+    - RIGHT
+    - Right
+    - ambidextrous
+    - a
+    - A
+    - AMBIDEXTROUS
+    - Ambidextrous
+    - n/a
 hemisphere:
   name: hemisphere
   display_name: Electrode hemisphere
@@ -142,8 +142,8 @@ hemisphere:
     The hemisphere in which the electrode is placed.
   type: string
   enum:
-  - L
-  - R
+    - L
+    - R
 high_cutoff:
   name: high_cutoff
   display_name: High cutoff
@@ -153,12 +153,12 @@ high_cutoff:
     Note that hardware anti-aliasing in A/D conversion of all MEG/EEG electronics
     applies a low-pass filter; specify its frequency here if applicable.
   anyOf:
-  - type: number
-    unit: Hz
-    minimum: 0
-  - type: string
-    enum:
-    - n/a
+    - type: number
+      unit: Hz
+      minimum: 0
+    - type: string
+      enum:
+        - n/a
 hplc_recovery_fractions:
   name: hplc_recovery_fractions
   display_name: HPLC recovery fractions
@@ -186,11 +186,11 @@ low_cutoff:
     Frequencies used for the high-pass filter applied to the channel in Hz.
     If no high-pass filter applied, use `n/a`.
   anyOf:
-  - type: number
-    unit: Hz
-  - type: string
-    enum:
-    - n/a
+    - type: number
+      unit: Hz
+    - type: string
+      enum:
+        - n/a
 manufacturer:
   name: manufacturer
   display_name: Manufacturer
@@ -254,11 +254,11 @@ notch:
     Frequencies used for the notch filter applied to the channel, in Hz.
     If no notch filter applied, use `n/a`.
   anyOf:
-  - type: number
-    unit: Hz
-  - type: string
-    enum:
-    - n/a
+    - type: number
+      unit: Hz
+    - type: string
+      enum:
+        - n/a
 onset:
   name: onset
   display_name: Event onset
@@ -318,10 +318,10 @@ reference__ieeg:
     Specification of the reference (for example, `mastoid`, `ElectrodeName01`, `intracranial`, `CAR`, `other`, `n/a`).
     If the channel is not an electrode channel (for example, a microphone channel) use `n/a`.
   anyOf:
-  - type: string
-  - type: string
-    enum:
-    - n/a
+    - type: string
+    - type: string
+      enum:
+        - n/a
 respiratory:
   name: respiratory
   display_name: Respiratory measurement
@@ -336,11 +336,11 @@ response_time:
     A negative response time can be used to represent preemptive responses and
     `n/a` denotes a missed response.
   anyOf:
-  - type: number
-    unit: s
-  - type: string
-    enum:
-    - n/a
+    - type: number
+      unit: s
+    - type: string
+      enum:
+        - n/a
 sample:
   name: sample
   display_name: Sample index
@@ -367,15 +367,15 @@ sample_type:
     [ENCODE Biosample Type](https://www.encodeproject.org/profiles/biosample_type).
   type: string
   enum:
-  - cell line
-  - in vitro differentiated cells
-  - primary cell
-  - cell-free sample
-  - cloning host
-  - tissue
-  - whole organisms
-  - organoid
-  - technical sample
+    - cell line
+    - in vitro differentiated cells
+    - primary cell
+    - cell-free sample
+    - cloning host
+    - tissue
+    - whole organisms
+    - organoid
+    - technical sample
 sampling_frequency:
   name: sampling_frequency
   display_name: Channel sampling frequency
@@ -404,22 +404,22 @@ sex:
     For "other", use one of these values: `other`, `o`, `O`, `OTHER`, `Other`.
   type: string
   enum:
-  - male
-  - m
-  - M
-  - MALE
-  - Male
-  - female
-  - f
-  - F
-  - FEMALE
-  - Female
-  - other
-  - o
-  - O
-  - OTHER
-  - Other
-  - n/a
+    - male
+    - m
+    - M
+    - MALE
+    - Male
+    - female
+    - f
+    - F
+    - FEMALE
+    - Female
+    - other
+    - o
+    - O
+    - OTHER
+    - Other
+    - n/a
 size:
   name: size
   display_name: Electrode size
@@ -436,10 +436,10 @@ software_filters:
     Note that parameters should be defined in the general MEG sidecar .json file.
     Indicate `n/a` in the absence of software filters applied.
   anyOf:
-  - type: string
-  - type: string
-    enum:
-    - n/a
+    - type: string
+    - type: string
+      enum:
+        - n/a
 species:
   name: species
   display_name: Species
@@ -460,9 +460,9 @@ status:
     Description of noise type SHOULD be provided in `[status_description]`.
   type: string
   enum:
-  - good
-  - bad
-  - n/a
+    - good
+    - bad
+    - n/a
 status_description:
   name: status_description
   display_name: Channel status description
@@ -533,23 +533,23 @@ type__eeg_channels:
     Note that the type MUST be in upper-case.
   type: string
   enum:
-  - AUDIO
-  - EEG
-  - EOG
-  - ECG
-  - EMG
-  - EYEGAZE
-  - GSR
-  - HEOG
-  - MISC
-  - PPG
-  - PUPIL
-  - REF
-  - RESP
-  - SYSCLOCK
-  - TEMP
-  - TRIG
-  - VEOG
+    - AUDIO
+    - EEG
+    - EOG
+    - ECG
+    - EMG
+    - EYEGAZE
+    - GSR
+    - HEOG
+    - MISC
+    - PPG
+    - PUPIL
+    - REF
+    - RESP
+    - SYSCLOCK
+    - TEMP
+    - TRIG
+    - VEOG
 type__meg_channels:
   name: type
   display_name: Channel type
@@ -558,34 +558,34 @@ type__meg_channels:
     Note that the type MUST be in upper-case.
   type: string
   enum:
-  - MEGMAG
-  - MEGGRADAXIAL
-  - MEGGRADPLANAR
-  - MEGREFMAG
-  - MEGREFGRADAXIAL
-  - MEGREFGRADPLANAR
-  - MEGOTHER
-  - EEG
-  - ECOG
-  - SEEG
-  - DBS
-  - VEOG
-  - HEOG
-  - EOG
-  - ECG
-  - EMG
-  - TRIG
-  - AUDIO
-  - PD
-  - EYEGAZE
-  - PUPIL
-  - MISC
-  - SYSCLOCK
-  - ADC
-  - DAC
-  - HLU
-  - FITERR
-  - OTHER
+    - MEGMAG
+    - MEGGRADAXIAL
+    - MEGGRADPLANAR
+    - MEGREFMAG
+    - MEGREFGRADAXIAL
+    - MEGREFGRADPLANAR
+    - MEGOTHER
+    - EEG
+    - ECOG
+    - SEEG
+    - DBS
+    - VEOG
+    - HEOG
+    - EOG
+    - ECG
+    - EMG
+    - TRIG
+    - AUDIO
+    - PD
+    - EYEGAZE
+    - PUPIL
+    - MISC
+    - SYSCLOCK
+    - ADC
+    - DAC
+    - HLU
+    - FITERR
+    - OTHER
 type__ieeg_channels:
   name: type
   display_name: Channel type
@@ -594,26 +594,26 @@ type__ieeg_channels:
     Note that the type MUST be in upper-case.
   type: string
   enum:
-  - EEG
-  - ECOG
-  - SEEG
-  - DBS
-  - VEOG
-  - HEOG
-  - EOG
-  - ECG
-  - EMG
-  - TRIG
-  - AUDIO
-  - PD
-  - EYEGAZE
-  - PUPIL
-  - MISC
-  - SYSCLOCK
-  - ADC
-  - DAC
-  - REF
-  - OTHER
+    - EEG
+    - ECOG
+    - SEEG
+    - DBS
+    - VEOG
+    - HEOG
+    - EOG
+    - ECG
+    - EMG
+    - TRIG
+    - AUDIO
+    - PD
+    - EYEGAZE
+    - PUPIL
+    - MISC
+    - SYSCLOCK
+    - ADC
+    - DAC
+    - REF
+    - OTHER
 # type column for electrodes.tsv files
 type__electrodes:
   name: type
@@ -637,8 +637,8 @@ value:
     Marker value associated with the event (for example, the value of a TTL
     trigger that was recorded at the onset of the event).
   anyOf:
-  - type: number
-  - type: string
+    - type: number
+    - type: string
 volume_type:
   name: volume_type
   display_name: ASL volume type
@@ -647,11 +647,11 @@ volume_type:
     the `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.
   type: string
   enum:
-  - control
-  - label
-  - m0scan
-  - deltam
-  - cbf
+    - control
+    - label
+    - m0scan
+    - deltam
+    - cbf
 whole_blood_radioactivity:
   name: whole_blood_radioactivity
   display_name: Whole blood radioactivity
@@ -677,7 +677,7 @@ z:
   description: |
     Recorded position along the z-axis.
   anyOf:
-  - type: number
-  - type: string
-    enum:
-    - n/a
+    - type: number
+    - type: string
+      enum:
+        - n/a

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -120,8 +120,8 @@ hemisphere:
   type: string
   format: label
   enum:
-  - "L"
-  - "R"
+    - 'L'
+    - 'R'
 inversion:
   name: inv
   display_name: Inversion Time
@@ -166,8 +166,8 @@ mtransfer:
     respectively.
   type: string
   enum:
-  - "on"
-  - "off"
+    - 'on'
+    - 'off'
 part:
   name: part
   display_name: Part
@@ -188,10 +188,10 @@ part:
     omitted.
   type: string
   enum:
-  - mag
-  - phase
-  - real
-  - imag
+    - mag
+    - phase
+    - real
+    - imag
 processing:
   name: proc
   display_name: Processed (on device)

--- a/src/schema/objects/extensions.yaml
+++ b/src/schema/objects/extensions.yaml
@@ -2,7 +2,7 @@
 # This file describes valid file extensions in the specification.
 ave:
   value: .ave
-  display_name: AVE  # not sure what ave stands for
+  display_name: AVE # not sure what ave stands for
   description: |
     File containing data averaged by segments of interest.
 
@@ -301,7 +301,7 @@ Any:
   description: |
     Any extension is allowed.
 None:
-  value: ""
+  value: ''
   display_name: No extension
   description: |
     A file with no extension.

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -59,10 +59,10 @@ AnalyticalApproach:
     under /Study/Molecular Data Type (for example, SNP Genotypes (Array) or
     Methylation (CpG).
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 AnatomicalLandmarkCoordinateSystem:
   name: AnatomicalLandmarkCoordinateSystem
   display_name: Anatomical Landmark Coordinate System
@@ -73,10 +73,10 @@ AnatomicalLandmarkCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"AnatomicalLandmarkCoordinateSystemDescription"`.
   anyOf:
-  - $ref: objects.metadata._MEGCoordSys
-  - $ref: objects.metadata._EEGCoordSys
-  - $ref: objects.metadata._StandardTemplateCoordSys
-  - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
+    - $ref: objects.metadata._MEGCoordSys
+    - $ref: objects.metadata._EEGCoordSys
+    - $ref: objects.metadata._StandardTemplateCoordSys
+    - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
 AnatomicalLandmarkCoordinateSystemDescription:
   name: AnatomicalLandmarkCoordinateSystemDescription
   display_name: Anatomical Landmark Coordinate System Description
@@ -92,10 +92,10 @@ AnatomicalLandmarkCoordinateUnits:
     Units of the coordinates of `"AnatomicalLandmarkCoordinateSystem"`.
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - n/a
+    - m
+    - mm
+    - cm
+    - n/a
 AnatomicalLandmarkCoordinates:
   name: AnatomicalLandmarkCoordinates
   display_name: Anatomical Landmark Coordinates
@@ -140,9 +140,9 @@ ArterialSpinLabelingType:
     The arterial spin labeling type.
   type: string
   enum:
-  - CASL
-  - PCASL
-  - PASL
+    - CASL
+    - PCASL
+    - PASL
 AssociatedEmptyRoom:
   name: AssociatedEmptyRoom
   display_name: Associated Empty Room
@@ -152,17 +152,17 @@ AssociatedEmptyRoom:
     Using forward-slash separated paths relative to the dataset root is
     [DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).
   anyOf:
-  - type: array
-    items:
-      anyOf:
-      - type: string
-        format: dataset_relative
-      - type: string
-        format: bids_uri
-  - type: string
-    format: dataset_relative
-  - type: string
-    format: bids_uri
+    - type: array
+      items:
+        anyOf:
+          - type: string
+            format: dataset_relative
+          - type: string
+            format: bids_uri
+    - type: string
+      format: dataset_relative
+    - type: string
+      format: bids_uri
 Atlas:
   name: Atlas
   display_name: Atlas
@@ -202,10 +202,10 @@ B0FieldIdentifier:
     DICOM tag 0018, 1030 `Protocol Name`, or DICOM tag 0018, 0024 `Sequence Name`
     when the former is not defined (for example, in GE devices.)
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 B0FieldSource:
   name: B0FieldSource
   display_name: B0 Field Source
@@ -219,10 +219,10 @@ B0FieldSource:
     are used to estimate their own B<sub>0</sub> field, for example, in "pepolar"
     acquisitions.
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 BIDSVersion:
   name: BIDSVersion
   display_name: BIDS Version
@@ -268,12 +268,12 @@ BasedOn:
     `Sources` field using [BIDS URIs](SPEC_ROOT/02-common-principles.md#bids-uri)
     to distinguish sources from different datasets.
   anyOf:
-  - type: string
-    format: participant_relative
-  - type: array
-    items:
-      type: string
+    - type: string
       format: participant_relative
+    - type: array
+      items:
+        type: string
+        format: participant_relative
 BloodDensity:
   name: BloodDensity
   display_name: Blood Density
@@ -314,14 +314,14 @@ BolusCutOffDelayTime:
     pulses are provided.
     Based on DICOM Tag 0018, 925F `ASL Bolus Cut-off Delay Time`.
   anyOf:
-  - type: number
-    minimum: 0
-    unit: s
-  - type: array
-    items:
-      type: number
-      unit: s
+    - type: number
       minimum: 0
+      unit: s
+    - type: array
+      items:
+        type: number
+        unit: s
+        minimum: 0
 BolusCutOffFlag:
   name: BolusCutOffFlag
   display_name: Bolus Cut Off Flag
@@ -356,8 +356,8 @@ CASLType:
     Describes if a separate coil is used for labeling.
   type: string
   enum:
-  - single-coil
-  - double-coil
+    - single-coil
+    - double-coil
 CapManufacturer:
   name: CapManufacturer
   display_name: Cap Manufacturer
@@ -391,24 +391,24 @@ ChunkTransformationMatrix:
     Note that non-spatial dimensions like time and channel are not included in the
     transformation matrix.
   anyOf:
-  - type: array
-    minItems: 3
-    maxItems: 3
-    items:
-      type: array
+    - type: array
       minItems: 3
       maxItems: 3
       items:
-        type: number
-  - type: array
-    minItems: 4
-    maxItems: 4
-    items:
-      type: array
+        type: array
+        minItems: 3
+        maxItems: 3
+        items:
+          type: number
+    - type: array
       minItems: 4
       maxItems: 4
       items:
-        type: number
+        type: array
+        minItems: 4
+        maxItems: 4
+        items:
+          type: number
 ChunkTransformationMatrixAxis:
   name: ChunkTransformationMatrixAxis
   display_name: Chunk Transformation Matrix Axis
@@ -481,11 +481,11 @@ ContrastBolusIngredient:
     Corresponds to DICOM Tag 0018, 1048 `Contrast/Bolus Ingredient`.
   type: string
   enum:
-  - IODINE
-  - GADOLINIUM
-  - CARBON DIOXIDE
-  - BARIUM
-  - XENON
+    - IODINE
+    - GADOLINIUM
+    - CARBON DIOXIDE
+    - BARIUM
+    - XENON
 DCOffsetCorrection:
   name: DCOffsetCorrection
   display_name: DC Offset Correction
@@ -525,8 +525,8 @@ DatasetType:
     For backwards compatibility, the default value is `"raw"`.
   type: string
   enum:
-  - raw
-  - derivative
+    - raw
+    - derivative
 DecayCorrectionFactor:
   name: DecayCorrectionFactor
   display_name: Decay Correction Factor
@@ -568,10 +568,10 @@ Density:
     If an object is used, then the keys should be values for the `den` entity
     and values should be descriptions of those `den` values.
   anyOf:
-  - type: string
-  - type: object
-    additionalProperties:
-      type: string
+    - type: string
+    - type: object
+      additionalProperties:
+        type: string
 Derivative:
   name: Derivative
   display_name: Derivative
@@ -630,10 +630,10 @@ DigitizedHeadPointsCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"DigitizedHeadPointsCoordinateSystemDescription"`.
   anyOf:
-  - $ref: objects.metadata._MEGCoordSys
-  - $ref: objects.metadata._EEGCoordSys
-  - $ref: objects.metadata._StandardTemplateCoordSys
-  - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
+    - $ref: objects.metadata._MEGCoordSys
+    - $ref: objects.metadata._EEGCoordSys
+    - $ref: objects.metadata._StandardTemplateCoordSys
+    - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
 DigitizedHeadPointsCoordinateSystemDescription:
   name: DigitizedHeadPointsCoordinateSystemDescription
   display_name: Digitized Head Points Coordinate System Description
@@ -649,10 +649,10 @@ DigitizedHeadPointsCoordinateUnits:
     Units of the coordinates of `"DigitizedHeadPointsCoordinateSystem"`.
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - n/a
+    - m
+    - mm
+    - cm
+    - n/a
 DigitizedLandmarks:
   name: DigitizedLandmarks
   display_name: Digitized Landmarks
@@ -731,10 +731,10 @@ EEGCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `EEGCoordinateSystemDescription`.
   anyOf:
-  - $ref: objects.metadata._MEGCoordSys
-  - $ref: objects.metadata._EEGCoordSys
-  - $ref: objects.metadata._StandardTemplateCoordSys
-  - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
+    - $ref: objects.metadata._MEGCoordSys
+    - $ref: objects.metadata._EEGCoordSys
+    - $ref: objects.metadata._StandardTemplateCoordSys
+    - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
 EEGCoordinateSystemDescription:
   name: EEGCoordinateSystemDescription
   display_name: EEG Coordinate System Description
@@ -750,10 +750,10 @@ EEGCoordinateUnits:
     Units of the coordinates of `EEGCoordinateSystem`.
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - n/a
+    - m
+    - mm
+    - cm
+    - n/a
 EEGGround:
   name: EEGGround
   display_name: EEG Ground
@@ -813,14 +813,14 @@ EchoTime:
     arterial-spin-labeling-perfusion-data)
     or variable echo time fMRI sequences.
   anyOf:
-  - type: number
-    unit: s
-    exclusiveMinimum: 0
-  - type: array
-    items:
-      type: number
+    - type: number
       unit: s
       exclusiveMinimum: 0
+    - type: array
+      items:
+        type: number
+        unit: s
+        exclusiveMinimum: 0
 EchoTime1:
   name: EchoTime1
   display_name: Echo Time1
@@ -938,10 +938,10 @@ FiducialsCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"FiducialsCoordinateSystemDescription"`.
   anyOf:
-  - $ref: objects.metadata._MEGCoordSys
-  - $ref: objects.metadata._EEGCoordSys
-  - $ref: objects.metadata._StandardTemplateCoordSys
-  - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
+    - $ref: objects.metadata._MEGCoordSys
+    - $ref: objects.metadata._EEGCoordSys
+    - $ref: objects.metadata._StandardTemplateCoordSys
+    - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
 FiducialsCoordinateSystemDescription:
   name: FiducialsCoordinateSystemDescription
   display_name: Fiducials Coordinate System Description
@@ -958,10 +958,10 @@ FiducialsCoordinateUnits:
     `"FiducialsCoordinateSystem"` are represented.
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - n/a
+    - m
+    - mm
+    - cm
+    - n/a
 FiducialsCoordinates:
   name: FiducialsCoordinates
   display_name: Fiducials Coordinates
@@ -1006,16 +1006,16 @@ FlipAngle:
     arterial-spin-labeling-perfusion-data)
     or variable flip angle fMRI sequences.
   anyOf:
-  - type: number
-    unit: degree
-    exclusiveMinimum: 0
-    maximum: 360
-  - type: array
-    items:
-      type: number
+    - type: number
       unit: degree
       exclusiveMinimum: 0
       maximum: 360
+    - type: array
+      items:
+        type: number
+        unit: degree
+        exclusiveMinimum: 0
+        maximum: 360
 FrameDuration:
   name: FrameDuration
   display_name: Frame Duration
@@ -1081,10 +1081,10 @@ GeneticLevel:
     Values MUST be one of `"Genetic"`, `"Genomic"`, `"Epigenomic"`,
     `"Transcriptomic"`, `"Metabolomic"`, or `"Proteomic"`.
   anyOf:
-  - $ref: objects.metadata._GeneticLevelEnum
-  - type: array
-    items:
-      $ref: objects.metadata._GeneticLevelEnum
+    - $ref: objects.metadata._GeneticLevelEnum
+    - type: array
+      items:
+        $ref: objects.metadata._GeneticLevelEnum
 Genetics:
   name: Genetics
   display_name: Genetics
@@ -1114,10 +1114,10 @@ Genetics:
         [URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)
         when possible.
       anyOf:
-      - type: string
-      - type: array
-        items:
-          type: string
+        - type: string
+        - type: array
+          items:
+            type: string
 GradientSetType:
   name: GradientSetType
   display_name: Gradient Set Type
@@ -1134,10 +1134,10 @@ HED:
     Hierarchical Event Descriptor (HED) information,
     see: [Appendix III](SPEC_ROOT/99-appendices/03-hed.md) for details.
   anyOf:
-  - type: string
-  - type: object
-    additionalProperties:
-      type: string
+    - type: string
+    - type: object
+      additionalProperties:
+        type: string
 HEDVersion:
   name: HEDVersion
   display_name: HED Version
@@ -1170,12 +1170,12 @@ HardwareFilters:
     For example, `{"Highpass RC filter": {"Half amplitude cutoff (Hz)":
     0.0159, "Roll-off": "6dB/Octave"}}`.
   anyOf:
-  - type: object
-    additionalProperties:
-      type: object
-  - type: string
-    enum:
-    - n/a
+    - type: object
+      additionalProperties:
+        type: object
+    - type: string
+      enum:
+        - n/a
 HeadCircumference:
   name: HeadCircumference
   display_name: Head Circumference
@@ -1195,10 +1195,10 @@ HeadCoilCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `HeadCoilCoordinateSystemDescription`.
   anyOf:
-  - $ref: objects.metadata._MEGCoordSys
-  - $ref: objects.metadata._EEGCoordSys
-  - $ref: objects.metadata._StandardTemplateCoordSys
-  - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
+    - $ref: objects.metadata._MEGCoordSys
+    - $ref: objects.metadata._EEGCoordSys
+    - $ref: objects.metadata._StandardTemplateCoordSys
+    - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
 HeadCoilCoordinateSystemDescription:
   name: HeadCoilCoordinateSystemDescription
   display_name: Head Coil Coordinate System Description
@@ -1213,10 +1213,10 @@ HeadCoilCoordinateUnits:
     Units of the coordinates of `HeadCoilCoordinateSystem`.
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - n/a
+    - m
+    - mm
+    - cm
+    - n/a
 HeadCoilCoordinates:
   name: HeadCoilCoordinates
   display_name: Head Coil Coordinates
@@ -1248,12 +1248,12 @@ HeadCoilFrequency:
     that track the subject's head position in the MEG helmet
     (for example, `[293, 307, 314, 321]`).
   anyOf:
-  - type: number
-    unit: Hz
-  - type: array
-    items:
-      type: number
+    - type: number
       unit: Hz
+    - type: array
+      items:
+        type: number
+        unit: Hz
 HowToAcknowledge:
   name: HowToAcknowledge
   display_name: How To Acknowledge
@@ -1332,10 +1332,10 @@ InjectedMass:
     **For those tracers in which injected mass is not available (for example FDG)
     can be set to `"n/a"`)**.
   anyOf:
-  - type: number
-  - type: string
-    enum:
-    - n/a
+    - type: number
+    - type: string
+      enum:
+        - n/a
 InjectedMassPerWeight:
   name: InjectedMassPerWeight
   display_name: Injected Mass Per Weight
@@ -1359,11 +1359,11 @@ InjectedMassUnits:
     **Note this is not required for an FDG acquisition, since it is not available,
     and SHOULD be set to `"n/a"`**.
   anyOf:
-  - type: string
-    format: unit
-  - type: string
-    enum:
-    - n/a
+    - type: string
+      format: unit
+    - type: string
+      enum:
+        - n/a
 InjectedRadioactivity:
   name: InjectedRadioactivity
   display_name: Injected Radioactivity
@@ -1441,17 +1441,17 @@ IntendedFor:
     Using forward-slash separated paths relative to the participant subdirectory is
     [DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).
   anyOf:
-  - type: string
-    format: bids_uri
-  - type: string
-    format: participant_relative
-  - type: array
-    items:
-      anyOf:
-      - type: string
-        format: bids_uri
-      - type: string
-        format: participant_relative
+    - type: string
+      format: bids_uri
+    - type: string
+      format: participant_relative
+    - type: array
+      items:
+        anyOf:
+          - type: string
+            format: bids_uri
+          - type: string
+            format: participant_relative
 IntendedFor__ds_relative:
   name: IntendedFor
   display_name: Intended For
@@ -1461,17 +1461,17 @@ IntendedFor__ds_relative:
     Using forward-slash separated paths relative to the dataset root is
     [DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).
   anyOf:
-  - type: string
-    format: bids_uri
-  - type: string
-    format: dataset_relative
-  - type: array
-    items:
-      anyOf:
-      - type: string
-        format: bids_uri
-      - type: string
-        format: dataset_relative
+    - type: string
+      format: bids_uri
+    - type: string
+      format: dataset_relative
+    - type: array
+      items:
+        anyOf:
+          - type: string
+            format: bids_uri
+          - type: string
+            format: dataset_relative
 InversionTime:
   name: InversionTime
   display_name: Inversion Time
@@ -1513,14 +1513,14 @@ LabelingDuration:
     `*_aslcontext.tsv`.
     Corresponds to DICOM Tag 0018, 9258 `ASL Pulse Train Duration`.
   anyOf:
-  - type: number
-    minimum: 0
-    unit: s
-  - type: array
-    items:
-      type: number
-      unit: s
+    - type: number
       minimum: 0
+      unit: s
+    - type: array
+      items:
+        type: number
+        unit: s
+        minimum: 0
 LabelingEfficiency:
   name: LabelingEfficiency
   display_name: Labeling Efficiency
@@ -1666,10 +1666,10 @@ M0Type:
     `"Absent"` means that no specific M0 information is present.
   type: string
   enum:
-  - Separate
-  - Included
-  - Estimate
-  - Absent
+    - Separate
+    - Included
+    - Estimate
+    - Absent
 MEGChannelCount:
   name: MEGChannelCount
   display_name: MEG Channel Count
@@ -1687,10 +1687,10 @@ MEGCoordinateSystem:
     If `"Other"`, provide definition of the coordinate system in
     `"MEGCoordinateSystemDescription"`.
   anyOf:
-  - $ref: objects.metadata._MEGCoordSys
-  - $ref: objects.metadata._EEGCoordSys
-  - $ref: objects.metadata._StandardTemplateCoordSys
-  - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
+    - $ref: objects.metadata._MEGCoordSys
+    - $ref: objects.metadata._EEGCoordSys
+    - $ref: objects.metadata._StandardTemplateCoordSys
+    - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
 MEGCoordinateSystemDescription:
   name: MEGCoordinateSystemDescription
   display_name: MEG Coordinate System Description
@@ -1706,10 +1706,10 @@ MEGCoordinateUnits:
     Units of the coordinates of `"MEGCoordinateSystem"`.
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - n/a
+    - m
+    - mm
+    - cm
+    - n/a
 MEGREFChannelCount:
   name: MEGREFChannelCount
   display_name: MEGREF Channel Count
@@ -1727,8 +1727,8 @@ MRAcquisitionType:
     Corresponds to DICOM Tag 0018, 0023 `MR Acquisition Type`.
   type: string
   enum:
-  - 2D
-  - 3D
+    - 2D
+    - 3D
 MRTransmitCoilSequence:
   name: MRTransmitCoilSequence
   display_name: MR Transmit Coil Sequence
@@ -1774,13 +1774,13 @@ MTPulseShape:
     The value `"SINCGAUSS"` refers to a sinc pulse with a Gaussian window.
   type: string
   enum:
-  - HARD
-  - GAUSSIAN
-  - GAUSSHANN
-  - SINC
-  - SINCHANN
-  - SINCGAUSS
-  - FERMI
+    - HARD
+    - GAUSSIAN
+    - GAUSSHANN
+    - SINC
+    - SINCHANN
+    - SINCGAUSS
+    - FERMI
 MTState:
   name: MTState
   display_name: MT State
@@ -2006,10 +2006,10 @@ NumberShots:
     (SPEC_ROOT/99-appendices/11-qmri.md#numbershots-metadata-field)
     in the qMRI appendix for corresponding calculations.
   anyOf:
-  - type: number
-  - type: array
-    items:
-      type: number
+    - type: number
+    - type: array
+      items:
+        type: number
 NumericalAperture:
   name: NumericalAperture
   display_name: Numerical Aperture
@@ -2045,8 +2045,8 @@ PCASLType:
     The type of gradient pulses used in the `control` condition.
   type: string
   enum:
-  - balanced
-  - unbalanced
+    - balanced
+    - unbalanced
 ParallelAcquisitionTechnique:
   name: ParallelAcquisitionTechnique
   display_name: Parallel Acquisition Technique
@@ -2083,10 +2083,10 @@ PharmaceuticalDoseAmount:
   description: |
     Dose amount of pharmaceutical coadministered with tracer.
   anyOf:
-  - type: number
-  - type: array
-    items:
-      type: number
+    - type: number
+    - type: array
+      items:
+        type: number
 PharmaceuticalDoseRegimen:
   name: PharmaceuticalDoseRegimen
   display_name: Pharmaceutical Dose Regimen
@@ -2106,12 +2106,12 @@ PharmaceuticalDoseTime:
     interpretation of `"PharmaceuticalDoseTime"`.
     Unit format of the specified pharmaceutical dose time MUST be seconds.
   anyOf:
-  - type: number
-    unit: s
-  - type: array
-    items:
-      type: number
+    - type: number
       unit: s
+    - type: array
+      items:
+        type: number
+        unit: s
 PharmaceuticalDoseUnits:
   name: PharmaceuticalDoseUnits
   display_name: Pharmaceutical Dose Units
@@ -2142,12 +2142,12 @@ PhaseEncodingDirection:
     `InPlanePhaseEncodingDirection` which can have `ROW` or `COL` values.
   type: string
   enum:
-  - i
-  - j
-  - k
-  - i-
-  - j-
-  - k-
+    - i
+    - j
+    - k
+    - i-
+    - j-
+    - k-
 PhotoDescription:
   name: PhotoDescription
   display_name: Photo Description
@@ -2179,9 +2179,9 @@ PixelSizeUnits:
     (micrometer) or `"nm"` (nanometer).
   type: string
   enum:
-  - mm
-  - um
-  - nm
+    - mm
+    - um
+    - nm
 PlasmaAvail:
   name: PlasmaAvail
   display_name: Plasma Avail
@@ -2221,14 +2221,14 @@ PostLabelingDelay:
     Based on DICOM Tags 0018, 9079 `Inversion Times` and 0018, 0082
     `InversionTime`.
   anyOf:
-  - type: number
-    exclusiveMinimum: 0
-    unit: s
-  - type: array
-    items:
-      type: number
+    - type: number
       exclusiveMinimum: 0
       unit: s
+    - type: array
+      items:
+        type: number
+        exclusiveMinimum: 0
+        unit: s
 PowerLineFrequency:
   name: PowerLineFrequency
   display_name: Power Line Frequency
@@ -2236,12 +2236,12 @@ PowerLineFrequency:
     Frequency (in Hz) of the power grid at the geographical location of the
     instrument (for example, `50` or `60`).
   anyOf:
-  - type: number
-    exclusiveMinimum: 0
-    unit: Hz
-  - type: string
-    enum:
-    - n/a
+    - type: number
+      exclusiveMinimum: 0
+      unit: Hz
+    - type: string
+      enum:
+        - n/a
 PromptRate:
   name: PromptRate
   display_name: Prompt Rate
@@ -2321,22 +2321,22 @@ ReconFilterSize:
   description: |
     Kernel size of post-recon filter (FWHM) in default units `"mm"`.
   anyOf:
-  - type: number
-    unit: mm
-  - type: array
-    items:
-      type: number
+    - type: number
       unit: mm
+    - type: array
+      items:
+        type: number
+        unit: mm
 ReconFilterType:
   name: ReconFilterType
   display_name: Recon Filter Type
   description: |
     Type of post-recon smoothing (for example, `["Shepp"]`).
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 ReconMethodImplementationVersion:
   name: ReconMethodImplementationVersion
   display_name: Recon Method Implementation Version
@@ -2390,9 +2390,9 @@ RecordingType:
     interest (for example, stimulus presentations or subject responses).
   type: string
   enum:
-  - continuous
-  - epoched
-  - discontinuous
+    - continuous
+    - epoched
+    - discontinuous
 ReferencesAndLinks:
   name: ReferencesAndLinks
   display_name: References And Links
@@ -2461,14 +2461,14 @@ RepetitionTimePreparation:
     [ASL](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md\
     #arterial-spin-labeling-perfusion-data).
   anyOf:
-  - type: number
-    minimum: 0
-    unit: s
-  - type: array
-    items:
-      type: number
+    - type: number
       minimum: 0
       unit: s
+    - type: array
+      items:
+        type: number
+        minimum: 0
+        unit: s
 Resolution:
   name: Resolution
   display_name: Resolution
@@ -2477,10 +2477,10 @@ Resolution:
     If an object is used, then the keys should be values for the `res` entity
     and values should be descriptions of those `res` values.
   anyOf:
-  - type: string
-  - type: object
-    additionalProperties:
-      type: string
+    - type: string
+    - type: object
+      additionalProperties:
+        type: string
 SEEGChannelCount:
   name: SEEGChannelCount
   display_name: SEEG Channel Count
@@ -2502,9 +2502,9 @@ SampleEnvironment:
     or `"in vitro"`.
   type: string
   enum:
-  - in vivo
-  - ex vivo
-  - in vitro
+    - in vivo
+    - ex vivo
+    - in vitro
 SampleExtractionInstitution:
   name: SampleExtractionInstitution
   display_name: Sample Extraction Institution
@@ -2534,14 +2534,14 @@ SampleOrigin:
     Describes from which tissue the genetic information was extracted.
   type: string
   enum:
-  - blood
-  - saliva
-  - brain
-  - csf
-  - breast milk
-  - bile
-  - amniotic fluid
-  - other biospecimen
+    - blood
+    - saliva
+    - brain
+    - csf
+    - breast milk
+    - bile
+    - amniotic fluid
+    - other biospecimen
 SamplePrimaryAntibody:
   name: SamplePrimaryAntibody
   display_name: Sample Primary Antibody
@@ -2554,10 +2554,10 @@ SamplePrimaryAntibody:
     `"Rabbit anti-Human HTR5A Polyclonal Antibody, Invitrogen, Catalog # PA1-2453"`).
     MAY be an array of strings if different antibodies are used in each channel of the file.
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 SampleSecondaryAntibody:
   name: SampleSecondaryAntibody
   display_name: Sample Secondary Antibody
@@ -2570,10 +2570,10 @@ SampleSecondaryAntibody:
     `"Goat anti-Mouse IgM Secondary Antibody, Invitrogen, Catalog # 31172"`).
     MAY be an array of strings if different antibodies are used in each channel of the file.
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 SampleStaining:
   name: SampleStaining
   display_name: Sample Staining
@@ -2582,10 +2582,10 @@ SampleStaining:
     MAY be an array of strings if different stains are used in each channel of the file
     (for example: `["LFB", "PLP"]`).
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 SamplingFrequency:
   name: SamplingFrequency
   display_name: Sampling Frequency
@@ -2620,10 +2620,10 @@ ScanOptions:
     Parameters of ScanningSequence.
     Corresponds to DICOM Tag 0018, 0022 `Scan Options`.
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 ScanStart:
   name: ScanStart
   display_name: Scan Start
@@ -2638,10 +2638,10 @@ ScanningSequence:
     Description of the type of data acquired.
     Corresponds to DICOM Tag 0018, 0020 `Scanning Sequence`.
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 ScatterFraction:
   name: ScatterFraction
   display_name: Scatter Fraction
@@ -2666,10 +2666,10 @@ SequenceVariant:
     Variant of the ScanningSequence.
     Corresponds to DICOM Tag 0018, 0021 `Sequence Variant`.
   anyOf:
-  - type: string
-  - type: array
-    items:
-      type: string
+    - type: string
+    - type: array
+      items:
+        type: string
 SinglesRate:
   name: SinglesRate
   display_name: Singles Rate
@@ -2701,12 +2701,12 @@ SliceEncodingDirection:
     slice index as defined by the NIfTI header.
   type: string
   enum:
-  - i
-  - j
-  - k
-  - i-
-  - j-
-  - k-
+    - i
+    - j
+    - k
+    - i-
+    - j-
+    - k-
 SliceThickness:
   name: SliceThickness
   display_name: Slice Thickness
@@ -2750,12 +2750,12 @@ SoftwareFilters:
     (for example, `{"Anti-aliasing filter":
     {"half-amplitude cutoff (Hz)": 500, "Roll-off": "6dB/Octave"}}`).
   anyOf:
-  - type: object
-    additionalProperties:
-      type: object
-  - type: string
-    enum:
-    - n/a
+    - type: object
+      additionalProperties:
+        type: object
+    - type: string
+      enum:
+        - n/a
 SoftwareName:
   name: SoftwareName
   display_name: Software Name
@@ -2824,10 +2824,10 @@ Sources:
   type: array
   items:
     anyOf:
-    - type: string
-      format: dataset_relative
-    - type: string
-      format: bids_uri
+      - type: string
+        format: dataset_relative
+      - type: string
+        format: bids_uri
 SpatialReference:
   name: SpatialReference
   display_name: Spatial Reference
@@ -2836,23 +2836,23 @@ SpatialReference:
     For images with multiple references, such as surface and volume references,
     a JSON object MUST be used.
   anyOf:
-  - type: string
-    enum:
-    - orig
-  - type: string
-    format: uri
-  - type: string
-    format: dataset_relative
-  - type: object
-    additionalProperties:
-      anyOf:
-      - type: string
-        enum:
+    - type: string
+      enum:
         - orig
-      - type: string
-        format: uri
-      - type: string
-        format: dataset_relative
+    - type: string
+      format: uri
+    - type: string
+      format: dataset_relative
+    - type: object
+      additionalProperties:
+        anyOf:
+          - type: string
+            enum:
+              - orig
+          - type: string
+            format: uri
+          - type: string
+            format: dataset_relative
 SpecificRadioactivity:
   name: SpecificRadioactivity
   display_name: Specific Radioactivity
@@ -2861,10 +2861,10 @@ SpecificRadioactivity:
     **Note this is not required for an FDG acquisition, since it is not available,
     and SHOULD be set to `"n/a"`**.
   anyOf:
-  - type: number
-  - type: string
-    enum:
-    - n/a
+    - type: number
+    - type: string
+      enum:
+        - n/a
 SpecificRadioactivityMeasTime:
   name: SpecificRadioactivityMeasTime
   display_name: Specific Radioactivity Measurement Time
@@ -2881,11 +2881,11 @@ SpecificRadioactivityUnits:
     **Note this is not required for an FDG acquisition, since it is not available,
     and SHOULD be set to `"n/a"`**.
   anyOf:
-  - type: string
-    format: unit
-  - type: string
-    enum:
-    - n/a
+    - type: string
+      format: unit
+    - type: string
+      enum:
+        - n/a
 SpoilingGradientDuration:
   name: SpoilingGradientDuration
   display_name: Spoiling Gradient Duration
@@ -2926,9 +2926,9 @@ SpoilingType:
     Specifies which spoiling method(s) are used by a spoiled sequence.
   type: string
   enum:
-  - RF
-  - GRADIENT
-  - COMBINED
+    - RF
+    - GRADIENT
+    - COMBINED
 StartTime:
   name: StartTime
   display_name: Start Time
@@ -3022,12 +3022,12 @@ TissueOrigin:
     Describes the type of tissue analyzed for `"SampleOrigin"` `brain`.
   type: string
   enum:
-  - gray matter
-  - white matter
-  - csf
-  - meninges
-  - macrovascular
-  - microvascular
+    - gray matter
+    - white matter
+    - csf
+    - meninges
+    - macrovascular
+    - microvascular
 TotalAcquiredPairs:
   name: TotalAcquiredPairs
   display_name: Total Acquired Pairs
@@ -3118,10 +3118,10 @@ Type:
     The value `"ROI"` refers to a region of interest mask.
   type: string
   enum:
-  - Brain
-  - Lesion
-  - Face
-  - ROI
+    - Brain
+    - Lesion
+    - Face
+    - ROI
 Units:
   name: Units
   display_name: Units
@@ -3148,12 +3148,12 @@ VascularCrushingVENC:
     volumes for which `VascularCrushing` was turned off.
     Corresponds to DICOM Tag 0018, 925A `ASL Crusher Flow Limit`.
   anyOf:
-  - type: number
-    unit: cm/s
-  - type: array
-    items:
-      type: number
+    - type: number
       unit: cm/s
+    - type: array
+      items:
+        type: number
+        unit: cm/s
 VolumeTiming:
   name: VolumeTiming
   display_name: Volume Timing
@@ -3190,26 +3190,26 @@ WithdrawalRate:
 _CoordUnits:
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - n/a
+    - m
+    - mm
+    - cm
+    - n/a
 _EEGCoordSys:
   type: string
   enum:
-  - CapTrak
-  - EEGLAB
-  - EEGLAB-HJ
-  - Other
+    - CapTrak
+    - EEGLAB
+    - EEGLAB-HJ
+    - Other
 _GeneticLevelEnum:
   type: string
   enum:
-  - Genetic
-  - Genomic
-  - Epigenomic
-  - Transcriptomic
-  - Metabolomic
-  - Proteomic
+    - Genetic
+    - Genomic
+    - Epigenomic
+    - Transcriptomic
+    - Metabolomic
+    - Proteomic
 _LandmarkCoordinates:
   type: object
   additionalProperties:
@@ -3221,60 +3221,60 @@ _LandmarkCoordinates:
 _MEGCoordSys:
   type: string
   enum:
-  - CTF
-  - ElektaNeuromag
-  - 4DBti
-  - KitYokogawa
-  - ChietiItab
-  - Other
+    - CTF
+    - ElektaNeuromag
+    - 4DBti
+    - KitYokogawa
+    - ChietiItab
+    - Other
 _StandardTemplateCoordSys:
   type: string
   enum:
-  - ICBM452AirSpace
-  - ICBM452Warp5Space
-  - IXI549Space
-  - fsaverage
-  - fsaverageSym
-  - fsLR
-  - MNIColin27
-  - MNI152Lin
-  - MNI152NLin2009aSym
-  - MNI152NLin2009bSym
-  - MNI152NLin2009cSym
-  - MNI152NLin2009aAsym
-  - MNI152NLin2009bAsym
-  - MNI152NLin2009cAsym
-  - MNI152NLin6Sym
-  - MNI152NLin6ASym
-  - MNI305
-  - NIHPD
-  - OASIS30AntsOASISAnts
-  - OASIS30Atropos
-  - Talairach
-  - UNCInfant
+    - ICBM452AirSpace
+    - ICBM452Warp5Space
+    - IXI549Space
+    - fsaverage
+    - fsaverageSym
+    - fsLR
+    - MNIColin27
+    - MNI152Lin
+    - MNI152NLin2009aSym
+    - MNI152NLin2009bSym
+    - MNI152NLin2009cSym
+    - MNI152NLin2009aAsym
+    - MNI152NLin2009bAsym
+    - MNI152NLin2009cAsym
+    - MNI152NLin6Sym
+    - MNI152NLin6ASym
+    - MNI305
+    - NIHPD
+    - OASIS30AntsOASISAnts
+    - OASIS30Atropos
+    - Talairach
+    - UNCInfant
 _StandardTemplateDeprecatedCoordSys:
   type: string
   enum:
-  - fsaverage3
-  - fsaverage4
-  - fsaverage5
-  - fsaverage6
-  - fsaveragesym
-  - UNCInfant0V21
-  - UNCInfant1V21
-  - UNCInfant2V21
-  - UNCInfant0V22
-  - UNCInfant1V22
-  - UNCInfant2V22
-  - UNCInfant0V23
-  - UNCInfant1V23
-  - UNCInfant2V23
+    - fsaverage3
+    - fsaverage4
+    - fsaverage5
+    - fsaverage6
+    - fsaveragesym
+    - UNCInfant0V21
+    - UNCInfant1V21
+    - UNCInfant2V21
+    - UNCInfant0V22
+    - UNCInfant1V22
+    - UNCInfant2V22
+    - UNCInfant0V23
+    - UNCInfant1V23
+    - UNCInfant2V23
 _iEEGCoordSys:
   type: string
   enum:
-  - Pixels
-  - ACPC
-  - Other
+    - Pixels
+    - ACPC
+    - Other
 iEEGCoordinateProcessingDescription:
   name: iEEGCoordinateProcessingDescription
   display_name: iEEG Coordinate Processing Description
@@ -3306,9 +3306,9 @@ iEEGCoordinateSystem:
     [2D coordinate systems](SPEC_ROOT/04-modality-specific-files/04-intracranial\
     -electroencephalography.md#allowed-2d-coordinate-systems).
   anyOf:
-  - $ref: objects.metadata._iEEGCoordSys
-  - $ref: objects.metadata._StandardTemplateCoordSys
-  - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
+    - $ref: objects.metadata._iEEGCoordSys
+    - $ref: objects.metadata._StandardTemplateCoordSys
+    - $ref: objects.metadata._StandardTemplateDeprecatedCoordSys
 iEEGCoordinateSystemDescription:
   name: iEEGCoordinateSystemDescription
   display_name: iEEG Coordinate System Description
@@ -3325,11 +3325,11 @@ iEEGCoordinateUnits:
     MUST be `"pixels"` if `iEEGCoordinateSystem` is `Pixels`.
   type: string
   enum:
-  - m
-  - mm
-  - cm
-  - pixels
-  - n/a
+    - m
+    - mm
+    - cm
+    - pixels
+    - n/a
 iEEGElectrodeGroups:
   name: iEEGElectrodeGroups
   display_name: iEEG Electrode Groups

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -362,8 +362,8 @@ T2star:
     Ambiguous, may refer to a parametric image or to a conventional image.
     **Change:** Replaced by `T2starw` or `T2starmap`.
   anyOf:
-  - unit: arbitrary
-  - unit: s
+    - unit: arbitrary
+    - unit: s
 T2starmap:
   value: T2starmap
   display_name: Observed transverse relaxation time image
@@ -688,8 +688,8 @@ phase:
     [`part-phase`](SPEC_ROOT/99-appendices/09-entities.md#part)
     in conjunction with the `bold` suffix.
   anyOf:
-  - unit: arbitrary
-  - unit: rad
+    - unit: arbitrary
+    - unit: rad
 phase1:
   value: phase1
   display_name: Phase

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -1,6 +1,5 @@
 # Rules for ASL data that are not defined in tables.
 ---
-
 # 157
 ASLLabelingDurationNiftiLength:
   issue:
@@ -19,11 +18,11 @@ ASLLabelingDurationNiftiLength:
       `*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"LabelingDuration" in sidecar'
-  - type(sidecar.LabelingDuration) == 'array'
+    - suffix == "asl"
+    - '"LabelingDuration" in sidecar'
+    - type(sidecar.LabelingDuration) == 'array'
   checks:
-  - nifti_header.dim[4] == sidecar.LabelingDuration.length
+    - nifti_header.dim[4] == sidecar.LabelingDuration.length
 
 # 165
 ASLContextConsistent:
@@ -34,10 +33,10 @@ ASLContextConsistent:
       values in the NIfTI header.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
   checks:
-  - nifti_header.dim[4] == associations.aslcontext.n_rows
+    - nifti_header.dim[4] == associations.aslcontext.n_rows
 
 # 168
 ASLFlipAngleNiftiLength:
@@ -54,11 +53,11 @@ ASLFlipAngleNiftiLength:
       angle fMRI sequences.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"FlipAngle" in sidecar'
-  - type(sidecar.FlipAngle) == 'array'
+    - suffix == "asl"
+    - '"FlipAngle" in sidecar'
+    - type(sidecar.FlipAngle) == 'array'
   checks:
-  - nifti_header.dim[4] == sidecar.FlipAngle.length
+    - nifti_header.dim[4] == sidecar.FlipAngle.length
 
 # 172
 ASLFlipAngleASLContextLength:
@@ -75,12 +74,12 @@ ASLFlipAngleASLContextLength:
       timing is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - '"FlipAngle" in sidecar'
-  - type(sidecar.FlipAngle) == 'array'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - '"FlipAngle" in sidecar'
+    - type(sidecar.FlipAngle) == 'array'
   checks:
-  - aslcontext.n_rows == sidecar.FlipAngle.length
+    - aslcontext.n_rows == sidecar.FlipAngle.length
 
 # 173
 ASLPostLabelingDelayNiftiLength:
@@ -100,11 +99,11 @@ ASLPostLabelingDelayNiftiLength:
       Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - type(sidecar.PostLabelingDelay) == 'array'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - type(sidecar.PostLabelingDelay) == 'array'
   checks:
-  - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.length
+    - nifti_header.pixdim[4] == sidecar.PostLabelingDelay.length
 
 # 174
 ASLPostLabelingDelayASLContextLength:
@@ -124,11 +123,11 @@ ASLPostLabelingDelayASLContextLength:
       Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - type(sidecar.PostLabelingDelay) == 'array'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - type(sidecar.PostLabelingDelay) == 'array'
   checks:
-  - aslcontext.n_rows == sidecar.PostLabelingDelay.length
+    - aslcontext.n_rows == sidecar.PostLabelingDelay.length
 
 # 175
 ASLLabelingDurationASLContextLength:
@@ -149,12 +148,12 @@ ASLLabelingDurationASLContextLength:
       Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - '"LabelingDuration" in sidecar'
-  - type(sidecar.LabelingDuration) == 'array'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - '"LabelingDuration" in sidecar'
+    - type(sidecar.LabelingDuration) == 'array'
   checks:
-  - aslcontext.n_rows == sidecar.LabelingDuration.length
+    - aslcontext.n_rows == sidecar.LabelingDuration.length
 
 # 177
 ASLRepetitionTimePreparationASLContextLength:
@@ -170,12 +169,12 @@ ASLRepetitionTimePreparationASLContextLength:
       volume timing is critical for interpretation of the data, such as in ASL.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - '"RepetitionTimePreparation" in sidecar'
-  - type(sidecar.RepetitionTimePreparation) == 'array'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - '"RepetitionTimePreparation" in sidecar'
+    - type(sidecar.RepetitionTimePreparation) == 'array'
   checks:
-  - aslcontext.n_rows == sidecar.RepetitionTimePreparation.length
+    - aslcontext.n_rows == sidecar.RepetitionTimePreparation.length
 
 # 180
 ASLBackgroundSuppressionNumberPulses:
@@ -188,12 +187,12 @@ ASLBackgroundSuppressionNumberPulses:
       Note that this excludes any effect of background suppression pulses applied before the labeling.
     level: warning
   selectors:
-  - suffix == "asl"
-  - '"BackgroundSuppressionNumberPulses" in sidecar'
-  - '"BackgroundSuppressionPulseTime" in sidecar'
-  - type(sidecar.BackgroundSuppressionPulseTime) == 'array'
+    - suffix == "asl"
+    - '"BackgroundSuppressionNumberPulses" in sidecar'
+    - '"BackgroundSuppressionPulseTime" in sidecar'
+    - type(sidecar.BackgroundSuppressionPulseTime) == 'array'
   checks:
-  - sidecar.BackgroundSuppressionPulseTime.length == sidecar.BackgroundSuppressionNumberPulses
+    - sidecar.BackgroundSuppressionPulseTime.length == sidecar.BackgroundSuppressionNumberPulses
 
 # 181
 ASLTotalAcquiredVolumesASLContextLength:
@@ -206,11 +205,11 @@ ASLTotalAcquiredVolumesASLContextLength:
       'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.
     level: warning
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - '"TotalAcquiredVolumes" in sidecar'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - '"TotalAcquiredVolumes" in sidecar'
   checks:
-  - aslcontext.n_rows == sidecar.TotalAcquiredVolumes
+    - aslcontext.n_rows == sidecar.TotalAcquiredVolumes
 
 # 196
 ASLEchoTimeASLContextLength:
@@ -222,12 +221,12 @@ ASLEchoTimeASLContextLength:
       'EchoTime' is the echo time (TE) for the acquisition, specified in seconds.
     level: warning
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - '"EchoTime" in sidecar'
-  - type(sidecar.EchoTime) == 'array'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - '"EchoTime" in sidecar'
+    - type(sidecar.EchoTime) == 'array'
   checks:
-  - aslcontext.n_rows == sidecar.EchoTime.length
+    - aslcontext.n_rows == sidecar.EchoTime.length
 
 # 198
 ASLM0TypeAbsentScan:
@@ -239,12 +238,12 @@ ASLM0TypeAbsentScan:
       This is not allowed, please check that this field are filled correctly.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - '"m0scan" in associations'
-  - '"M0Type" in sidecar'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - '"m0scan" in associations'
+    - '"M0Type" in sidecar'
   checks:
-  - sidecar.M0Type != "absent"
+    - sidecar.M0Type != "absent"
 
 # 199
 ASLM0TypeAbsentASLContext:
@@ -255,12 +254,12 @@ ASLM0TypeAbsentASLContext:
       This is not allowed, please check that this field are filled correctly.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - aslcontext.volume_type.includes('"m0scan")
-  - '"M0Type" in sidecar'
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - aslcontext.volume_type.includes('"m0scan")
+    - '"M0Type" in sidecar'
   checks:
-  - sidecar.M0Type != "absent"
+    - sidecar.M0Type != "absent"
 
 # 202
 ASLM0TypeIncorrect:
@@ -271,9 +270,9 @@ ASLM0TypeIncorrect:
       If 'M0Type' is equal to 'separate', the dataset should include a *_m0scan.nii[.gz] and *_m0scan.json file.
     level: error
   selectors:
-  - suffix == "asl"
-  - '"aslcontext" in associations'
-  - '"M0Type" in sidecar'
-  - sidecar.M0Type == "separate"
+    - suffix == "asl"
+    - '"aslcontext" in associations'
+    - '"M0Type" in sidecar'
+    - sidecar.M0Type == "separate"
   checks:
-  - '"m0scan" in associations'
+    - '"m0scan" in associations'

--- a/src/schema/rules/checks/dwi.yaml
+++ b/src/schema/rules/checks/dwi.yaml
@@ -1,6 +1,5 @@
 # Rules for DWI data that are not defined in tables.
 ---
-
 # 29
 DWIVolumeCount:
   code: VOLUME_COUNT_MISMATCH
@@ -9,12 +8,12 @@ DWIVolumeCount:
     corresponding .bvec and .bval files.
   level: error
   selectors:
-  - suffix == "dwi"
-  - '"bval" in associations'
-  - '"bvec" in associations'
+    - suffix == "dwi"
+    - '"bval" in associations'
+    - '"bvec" in associations'
   checks:
-  - associations.bval.n_cols == nifti_header.dim[4]
-  - associations.bvec.n_cols == nifti_header.dim[4]
+    - associations.bval.n_cols == nifti_header.dim[4]
+    - associations.bvec.n_cols == nifti_header.dim[4]
 
 # 30
 DWIBvalRows:
@@ -23,9 +22,9 @@ DWIBvalRows:
     '.bval' files should contain exactly one row of volumes.
   level: error
   selectors:
-  - extension == "bval"
+    - extension == "bval"
   checks:
-  - data.n_rows == 1
+    - data.n_rows == 1
 
 # 31
 DWIBvecRows:
@@ -34,9 +33,9 @@ DWIBvecRows:
     '.bvec' files should contain exactly three rows of volumes.
   level: error
   selectors:
-  - extension == "bvec"
+    - extension == "bvec"
   checks:
-  - data.n_rows == 3
+    - data.n_rows == 3
 
 # 32
 DWIMissingBvec:
@@ -45,9 +44,9 @@ DWIMissingBvec:
     DWI scans must have a corresponding .bvec file.
   level: error
   selectors:
-  - suffix == "dwi"
+    - suffix == "dwi"
   checks:
-  - '"bvec" in associations'
+    - '"bvec" in associations'
 
 # 33
 DWIMissingBval:
@@ -56,6 +55,6 @@ DWIMissingBval:
     DWI scans must have a corresponding .bval file.
   level: error
   selectors:
-  - suffix == "dwi"
+    - suffix == "dwi"
   checks:
-  - '"bval" in associations'
+    - '"bval" in associations'

--- a/src/schema/rules/checks/events.yaml
+++ b/src/schema/rules/checks/events.yaml
@@ -1,6 +1,5 @@
 # Rules for events data that are not defined in tables.
 ---
-
 # 25
 EventsMissing:
   issue:
@@ -8,10 +7,10 @@ EventsMissing:
     message: |
       Task scans should have a corresponding events.tsv file.
       If this is a resting state scan you can ignore this warning or rename the task to include the word "rest".
-    level: warning  # could be an error with the proper selectors, I think
+    level: warning # could be an error with the proper selectors, I think
   selectors:
-  - '"task" in entities'
-  - '!(entities.task.includes("rest"))'
-  - suffix != "events"
+    - '"task" in entities'
+    - '!(entities.task.includes("rest"))'
+    - suffix != "events"
   checks:
-  - '"events" in associations'
+    - '"events" in associations'

--- a/src/schema/rules/checks/fmap.yaml
+++ b/src/schema/rules/checks/fmap.yaml
@@ -1,6 +1,5 @@
 # Rules for fieldmap data that are not defined in tables.
 ---
-
 # 91
 FmapFieldmapWithoutMagnitude:
   issue:
@@ -9,9 +8,9 @@ FmapFieldmapWithoutMagnitude:
       '_fieldmap.nii[.gz]' file does not have accompanying '_magnitude.nii[.gz]' file.
     level: error
   selectors:
-  - suffix == "fieldmap"
+    - suffix == "fieldmap"
   checks:
-  - '"magnitude" in associations'
+    - '"magnitude" in associations'
 
 # 92
 FmapPhasediffWithoutMagnitude:
@@ -21,6 +20,6 @@ FmapPhasediffWithoutMagnitude:
       Each '_phasediff.nii[.gz]' file should be associations with a '_magnitude1.nii[.gz]' file.
     level: warning
   selectors:
-  - suffix == "phasediff"
+    - suffix == "phasediff"
   checks:
-  - '"magnitude1" in associations'
+    - '"magnitude1" in associations'

--- a/src/schema/rules/checks/func.yaml
+++ b/src/schema/rules/checks/func.yaml
@@ -11,6 +11,6 @@ PhaseSuffixDeprecated:
       part-<mag|phase> or part-<real|imag> key/value.
     level: warning
   selectors:
-  - datatype == "func"
+    - datatype == "func"
   checks:
-  - '!(suffix == "phase")'
+    - '!(suffix == "phase")'

--- a/src/schema/rules/common_derivatives_validation.yaml
+++ b/src/schema/rules/common_derivatives_validation.yaml
@@ -1,18 +1,18 @@
 ---
 ResInSidecar:
-    selectors:
+  selectors:
     - dataset.dataset_description.DatasetType == "derivative"
     - '["mri", "pet"].includes(modality)'
     - '["nii", " nii.gz"].includes(extension)'
     - type(sidecar.Resolution) == "object"
-    checks:
+  checks:
     - entities.resolution in sidecar.Resolution
 
 DenInSidecar:
-    selectors:
+  selectors:
     - dataset.dataset_description.DatasetType == "derivative"
     - '["mri", "pet"].includes(modality)'
     - '[".nii", ".nii.gz"].includes(extension)'
     - type(sidecar.Density) == "object"
-    checks:
+  checks:
     - entities.density in sidecar.Density

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -1,7 +1,7 @@
 ---
 dataset_description:
   selectors:
-  - path == "/dataset_description.json"
+    - path == "/dataset_description.json"
   fields:
     Name: required
     BIDSVersion: required
@@ -34,15 +34,15 @@ dataset_description:
 
 derivative_description:
   selectors:
-  - path == "/dataset_description.json"
-  - json.DatasetType == "derivative"
+    - path == "/dataset_description.json"
+    - json.DatasetType == "derivative"
   fields:
     GeneratedBy: required
 
 dataset_description_with_genetics:
   selectors:
-  - path == "/dataset_description.json"
-  - 'dataset.files.includes("/genetic_info.json")'
+    - path == "/dataset_description.json"
+    - 'dataset.files.includes("/genetic_info.json")'
   fields:
     Genetics: required
     Genetics{}.Dataset:
@@ -57,7 +57,7 @@ dataset_description_with_genetics:
 
 genetic_info:
   selectors:
-  - path == "/genetic_info.json"
+    - path == "/genetic_info.json"
   fields:
     GeneticLevel: required
     SampleOrigin: required

--- a/src/schema/rules/datatypes/anat.yaml
+++ b/src/schema/rules/datatypes/anat.yaml
@@ -1,24 +1,24 @@
 ---
 nonparametric:
   suffixes:
-  - T1w
-  - T2w
-  - PDw
-  - T2starw
-  - FLAIR
-  - inplaneT1
-  - inplaneT2
-  - PDT2
-  - angio
-  - T2star  # deprecated
-  - FLASH  # deprecated
-  - PD  # deprecated
+    - T1w
+    - T2w
+    - PDw
+    - T2starw
+    - FLAIR
+    - inplaneT1
+    - inplaneT2
+    - PDT2
+    - angio
+    - T2star # deprecated
+    - FLASH # deprecated
+    - PD # deprecated
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -30,29 +30,29 @@ nonparametric:
 
 parametric:
   suffixes:
-  - T1map
-  - T2map
-  - T2starmap
-  - R1map
-  - R2map
-  - R2starmap
-  - PDmap
-  - MTRmap
-  - MTsat
-  - UNIT1
-  - T1rho
-  - MWFmap
-  - MTVmap
-  - PDT2map
-  - Chimap
-  - S0map
-  - M0map
+    - T1map
+    - T2map
+    - T2starmap
+    - R1map
+    - R2map
+    - R2starmap
+    - PDmap
+    - MTRmap
+    - MTsat
+    - UNIT1
+    - T1rho
+    - MWFmap
+    - MTVmap
+    - PDT2map
+    - Chimap
+    - S0map
+    - M0map
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -63,13 +63,13 @@ parametric:
 
 defacemask:
   suffixes:
-  - defacemask
+    - defacemask
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -81,14 +81,14 @@ defacemask:
 
 multiecho:
   suffixes:
-  - MESE
-  - MEGRE
+    - MESE
+    - MEGRE
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -101,13 +101,13 @@ multiecho:
 
 multiflip:
   suffixes:
-  - VFA
+    - VFA
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -121,13 +121,13 @@ multiflip:
 
 multiinversion:
   suffixes:
-  - IRT1
+    - IRT1
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -140,13 +140,13 @@ multiinversion:
 
 mp2rage:
   suffixes:
-  - MP2RAGE
+    - MP2RAGE
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -161,14 +161,14 @@ mp2rage:
 
 vfamt:
   suffixes:
-  - MPM
-  - MTS
+    - MPM
+    - MTS
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional
@@ -183,13 +183,13 @@ vfamt:
 
 mtr:
   suffixes:
-  - MTR
+    - MTR
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - anat
+    - anat
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/beh.yaml
+++ b/src/schema/rules/datatypes/beh.yaml
@@ -1,13 +1,13 @@
 ---
 timeseries:
   suffixes:
-  - stim
-  - physio
+    - stim
+    - physio
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - beh
+    - beh
   entities:
     subject: required
     session: optional
@@ -19,13 +19,13 @@ timeseries:
 # Non-continuous data
 noncontinuous:
   suffixes:
-  - events
-  - beh
+    - events
+    - beh
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
   datatypes:
-  - beh
+    - beh
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/derivatives/common_imaging_derivatives.yaml
+++ b/src/schema/rules/datatypes/derivatives/common_imaging_derivatives.yaml
@@ -38,9 +38,9 @@ func_volumetric:
 anat_parametric_mask:
   $ref: rules.datatypes.anat.parametric
   suffixes:
-  - mask
+    - mask
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.anat.parametric.entities
     space: optional
@@ -52,9 +52,9 @@ anat_parametric_mask:
 anat_nonparametric_mask:
   $ref: rules.datatypes.anat.nonparametric
   suffixes:
-  - mask
+    - mask
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.anat.nonparametric.entities
     space: optional
@@ -66,9 +66,9 @@ anat_nonparametric_mask:
 dwi_mask:
   $ref: rules.datatypes.dwi.dwi
   suffixes:
-  - mask
+    - mask
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.dwi.dwi.entities
     space: optional
@@ -80,9 +80,9 @@ dwi_mask:
 func_mask:
   $ref: rules.datatypes.func.func
   suffixes:
-  - mask
+    - mask
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.func.func.entities
     space: optional
@@ -94,9 +94,9 @@ func_mask:
 anat_parametric_discrete_segmentation:
   $ref: rules.datatypes.anat.parametric
   suffixes:
-  - dseg
+    - dseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.anat.parametric.entities
     space: optional
@@ -106,9 +106,9 @@ anat_parametric_discrete_segmentation:
 anat_nonparametric_discrete_segmentation:
   $ref: rules.datatypes.anat.nonparametric
   suffixes:
-  - dseg
+    - dseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.anat.nonparametric.entities
     space: optional
@@ -118,9 +118,9 @@ anat_nonparametric_discrete_segmentation:
 func_discrete_segmentation:
   $ref: rules.datatypes.func.func
   suffixes:
-  - dseg
+    - dseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.func.func.entities
     space: optional
@@ -130,9 +130,9 @@ func_discrete_segmentation:
 dwi_discrete_segmentation:
   $ref: rules.datatypes.dwi.dwi
   suffixes:
-  - dseg
+    - dseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.dwi.dwi.entities
     space: optional
@@ -142,9 +142,9 @@ dwi_discrete_segmentation:
 anat_parametric_probabilistic_segmentation:
   $ref: rules.datatypes.anat.parametric
   suffixes:
-  - probseg
+    - probseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.anat.parametric.entities
     space: optional
@@ -155,9 +155,9 @@ anat_parametric_probabilistic_segmentation:
 anat_nonparametric_probabilistic_segmentation:
   $ref: rules.datatypes.anat.nonparametric
   suffixes:
-  - probseg
+    - probseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.anat.nonparametric.entities
     space: optional
@@ -168,9 +168,9 @@ anat_nonparametric_probabilistic_segmentation:
 func_probabilistic_segmentation:
   $ref: rules.datatypes.func.func
   suffixes:
-  - probseg
+    - probseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.func.func.entities
     space: optional
@@ -181,9 +181,9 @@ func_probabilistic_segmentation:
 dwi_probabilistic_segmentation:
   $ref: rules.datatypes.dwi.dwi
   suffixes:
-  - probseg
+    - probseg
   extensions:
-  - .nii.gz
+    - .nii.gz
   entities:
     $ref: rules.datatypes.dwi.dwi.entities
     space: optional
@@ -194,10 +194,10 @@ dwi_probabilistic_segmentation:
 anat_parametic_discrete_surface:
   $ref: rules.datatypes.anat.parametric
   suffixes:
-  - dseg
+    - dseg
   extensions:
-  - .label.gii
-  - .dlabel.nii
+    - .label.gii
+    - .dlabel.nii
   entities:
     $ref: rules.datatypes.anat.parametric.entities
     hemisphere: optional
@@ -208,10 +208,10 @@ anat_parametic_discrete_surface:
 anat_nonparametic_discrete_surface:
   $ref: rules.datatypes.anat.nonparametric
   suffixes:
-  - dseg
+    - dseg
   extensions:
-  - .label.gii
-  - .dlabel.nii
+    - .label.gii
+    - .dlabel.nii
   entities:
     $ref: rules.datatypes.anat.nonparametric.entities
     hemisphere: optional

--- a/src/schema/rules/datatypes/dwi.yaml
+++ b/src/schema/rules/datatypes/dwi.yaml
@@ -1,15 +1,15 @@
 ---
 dwi:
   suffixes:
-  - dwi
+    - dwi
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
-  - .bvec
-  - .bval
+    - .nii.gz
+    - .nii
+    - .json
+    - .bvec
+    - .bval
   datatypes:
-  - dwi
+    - dwi
   entities:
     subject: required
     session: optional
@@ -21,13 +21,13 @@ dwi:
 
 sbref:
   suffixes:
-  - sbref
+    - sbref
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - dwi
+    - dwi
   entities:
     subject: required
     session: optional
@@ -39,13 +39,13 @@ sbref:
 
 timeseries:
   suffixes:
-  - physio
-  - stim
+    - physio
+    - stim
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - dwi
+    - dwi
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/eeg.yaml
+++ b/src/schema/rules/datatypes/eeg.yaml
@@ -1,18 +1,18 @@
 ---
 eeg:
   suffixes:
-  - eeg
+    - eeg
   extensions:
-  - .json
-  - .edf
-  - .vhdr
-  - .vmrk
-  - .eeg
-  - .set
-  - .fdt
-  - .bdf
+    - .json
+    - .edf
+    - .vhdr
+    - .vmrk
+    - .eeg
+    - .set
+    - .fdt
+    - .bdf
   datatypes:
-  - eeg
+    - eeg
   entities:
     subject: required
     session: optional
@@ -22,12 +22,12 @@ eeg:
 
 channels:
   suffixes:
-  - channels
+    - channels
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - eeg
+    - eeg
   entities:
     subject: required
     session: optional
@@ -37,11 +37,11 @@ channels:
 
 coordsystem:
   suffixes:
-  - coordsystem
+    - coordsystem
   extensions:
-  - .json
+    - .json
   datatypes:
-  - eeg
+    - eeg
   entities:
     subject: required
     session: optional
@@ -50,12 +50,12 @@ coordsystem:
 
 electrodes:
   suffixes:
-  - electrodes
+    - electrodes
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - eeg
+    - eeg
   entities:
     subject: required
     session: optional
@@ -64,12 +64,12 @@ electrodes:
 
 events:
   suffixes:
-  - events
+    - events
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - eeg
+    - eeg
   entities:
     subject: required
     session: optional
@@ -79,13 +79,13 @@ events:
 
 photo:
   suffixes:
-  - photo
+    - photo
   extensions:
-  - .jpg
-  - .png
-  - .tif
+    - .jpg
+    - .png
+    - .tif
   datatypes:
-  - eeg
+    - eeg
   entities:
     subject: required
     session: optional
@@ -93,13 +93,13 @@ photo:
 
 timeseries:
   suffixes:
-  - physio
-  - stim
+    - physio
+    - stim
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - eeg
+    - eeg
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/fmap.yaml
+++ b/src/schema/rules/datatypes/fmap.yaml
@@ -1,19 +1,19 @@
 ---
 fieldmaps:
   suffixes:
-  - phasediff
-  - phase1
-  - phase2
-  - magnitude1
-  - magnitude2
-  - magnitude
-  - fieldmap
+    - phasediff
+    - phase1
+    - phase2
+    - magnitude1
+    - magnitude2
+    - magnitude
+    - fieldmap
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - fmap
+    - fmap
   entities:
     subject: required
     session: optional
@@ -22,14 +22,14 @@ fieldmaps:
 
 pepolar:
   suffixes:
-  - epi
-  - m0scan
+    - epi
+    - m0scan
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - fmap
+    - fmap
   entities:
     subject: required
     session: optional
@@ -40,13 +40,13 @@ pepolar:
 
 TB1DAM:
   suffixes:
-  - TB1DAM
+    - TB1DAM
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - fmap
+    - fmap
   entities:
     subject: required
     session: optional
@@ -60,13 +60,13 @@ TB1DAM:
 
 TB1EPI:
   suffixes:
-  - TB1EPI
+    - TB1EPI
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - fmap
+    - fmap
   entities:
     subject: required
     session: optional
@@ -81,16 +81,16 @@ TB1EPI:
 
 RFFieldMaps:
   suffixes:
-  - TB1AFI
-  - TB1TFL
-  - TB1RFM
-  - RB1COR
+    - TB1AFI
+    - TB1TFL
+    - TB1RFM
+    - RB1COR
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - fmap
+    - fmap
   entities:
     subject: required
     session: optional
@@ -105,13 +105,13 @@ RFFieldMaps:
 
 TB1SRGE:
   suffixes:
-  - TB1SRGE
+    - TB1SRGE
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - fmap
+    - fmap
   entities:
     subject: required
     session: optional
@@ -126,14 +126,14 @@ TB1SRGE:
 
 parametric:
   suffixes:
-  - TB1map
-  - RB1map
+    - TB1map
+    - RB1map
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - fmap
+    - fmap
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/func.yaml
+++ b/src/schema/rules/datatypes/func.yaml
@@ -1,15 +1,15 @@
 ---
 func:
   suffixes:
-  - bold
-  - cbv
-  - sbref
+    - bold
+    - cbv
+    - sbref
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - func
+    - func
   entities:
     subject: required
     session: optional
@@ -24,13 +24,13 @@ func:
 
 phase:
   suffixes:
-  - phase  # deprecated
+    - phase # deprecated
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - func
+    - func
   entities:
     subject: required
     session: optional
@@ -44,12 +44,12 @@ phase:
 
 events:
   suffixes:
-  - events
+    - events
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
   datatypes:
-  - func
+    - func
   entities:
     subject: required
     session: optional
@@ -62,13 +62,13 @@ events:
 
 timeseries:
   suffixes:
-  - physio
-  - stim
+    - physio
+    - stim
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - func
+    - func
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/ieeg.yaml
+++ b/src/schema/rules/datatypes/ieeg.yaml
@@ -1,19 +1,19 @@
 ---
 ieeg:
   suffixes:
-  - ieeg
+    - ieeg
   extensions:
-  - .mefd/
-  - .json
-  - .edf
-  - .vhdr
-  - .eeg
-  - .vmrk
-  - .set
-  - .fdt
-  - .nwb
+    - .mefd/
+    - .json
+    - .edf
+    - .vhdr
+    - .eeg
+    - .vmrk
+    - .set
+    - .fdt
+    - .nwb
   datatypes:
-  - ieeg
+    - ieeg
   entities:
     subject: required
     session: optional
@@ -23,12 +23,12 @@ ieeg:
 
 channels:
   suffixes:
-  - channels
+    - channels
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - ieeg
+    - ieeg
   entities:
     subject: required
     session: optional
@@ -38,11 +38,11 @@ channels:
 
 coordsystem:
   suffixes:
-  - coordsystem
+    - coordsystem
   extensions:
-  - .json
+    - .json
   datatypes:
-  - ieeg
+    - ieeg
   entities:
     subject: required
     session: optional
@@ -51,12 +51,12 @@ coordsystem:
 
 electrodes:
   suffixes:
-  - electrodes
+    - electrodes
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - ieeg
+    - ieeg
   entities:
     subject: required
     session: optional
@@ -65,12 +65,12 @@ electrodes:
 
 events:
   suffixes:
-  - events
+    - events
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - ieeg
+    - ieeg
   entities:
     subject: required
     session: optional
@@ -80,11 +80,11 @@ events:
 
 photo:
   suffixes:
-  - photo
+    - photo
   extensions:
-  - .jpg
-  - .png
-  - .tif
+    - .jpg
+    - .png
+    - .tif
   entities:
     subject: required
     session: optional
@@ -92,13 +92,13 @@ photo:
 
 timeseries:
   suffixes:
-  - physio
-  - stim
+    - physio
+    - stim
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - ieeg
+    - ieeg
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/meg.yaml
+++ b/src/schema/rules/datatypes/meg.yaml
@@ -1,23 +1,23 @@
 ---
 meg:
   suffixes:
-  - meg
+    - meg
   extensions:
-  - /  # corresponds to BTi/4D data
-  - .ds/
-  - .json
-  - .fif
-  - .sqd
-  - .con
-  - .raw
-  - .ave
-  - .mrk
-  - .kdf
-  - .mhd
-  - .trg
-  - .chn
+    - / # corresponds to BTi/4D data
+    - .ds/
+    - .json
+    - .fif
+    - .sqd
+    - .con
+    - .raw
+    - .ave
+    - .mrk
+    - .kdf
+    - .mhd
+    - .trg
+    - .chn
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -29,11 +29,11 @@ meg:
 
 calibration:
   suffixes:
-  - meg
+    - meg
   extensions:
-  - .dat
+    - .dat
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -41,15 +41,15 @@ calibration:
       requirement: required
       type: string
       enum:
-      - calibration
+        - calibration
 
 crosstalk:
   suffixes:
-  - meg
+    - meg
   extensions:
-  - .fif
+    - .fif
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -57,16 +57,16 @@ crosstalk:
       requirement: required
       type: string
       enum:
-      - crosstalk
+        - crosstalk
 
 headshape:
   suffixes:
-  - headshape
+    - headshape
   extensions:
-  - .*
-  - .pos
+    - .*
+    - .pos
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -74,12 +74,12 @@ headshape:
 
 markers:
   suffixes:
-  - markers
+    - markers
   extensions:
-  - .sqd
-  - .mrk
+    - .sqd
+    - .mrk
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -89,11 +89,11 @@ markers:
 
 coordsystem:
   suffixes:
-  - coordsystem
+    - coordsystem
   extensions:
-  - .json
+    - .json
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -101,12 +101,12 @@ coordsystem:
 
 channels:
   suffixes:
-  - channels
+    - channels
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -117,12 +117,12 @@ channels:
 
 events:
   suffixes:
-  - events
+    - events
   extensions:
-  - .json
-  - .tsv
+    - .json
+    - .tsv
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -132,13 +132,13 @@ events:
 
 photo:
   suffixes:
-  - photo
+    - photo
   extensions:
-  - .jpg
-  - .png
-  - .tif
+    - .jpg
+    - .png
+    - .tif
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional
@@ -146,13 +146,13 @@ photo:
 
 timeseries:
   suffixes:
-  - physio
-  - stim
+    - physio
+    - stim
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - meg
+    - meg
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/micr.yaml
+++ b/src/schema/rules/datatypes/micr.yaml
@@ -1,32 +1,32 @@
 ---
 microscopy:
   suffixes:
-  - TEM
-  - SEM
-  - uCT
-  - BF
-  - DF
-  - PC
-  - DIC
-  - FLUO
-  - CONF
-  - PLI
-  - CARS
-  - 2PE
-  - MPE
-  - SR
-  - NLO
-  - OCT
-  - SPIM
+    - TEM
+    - SEM
+    - uCT
+    - BF
+    - DF
+    - PC
+    - DIC
+    - FLUO
+    - CONF
+    - PLI
+    - CARS
+    - 2PE
+    - MPE
+    - SR
+    - NLO
+    - OCT
+    - SPIM
   extensions:
-  - .ome.tif
-  - .ome.btf
-  - .ome.zarr/
-  - .png
-  - .tif
-  - .json
+    - .ome.tif
+    - .ome.btf
+    - .ome.zarr/
+    - .png
+    - .tif
+    - .json
   datatypes:
-  - micr
+    - micr
   entities:
     subject: required
     session: optional
@@ -38,14 +38,14 @@ microscopy:
 
 photo:
   suffixes:
-  - photo
+    - photo
   extensions:
-  - .jpg
-  - .png
-  - .tif
-  - .json
+    - .jpg
+    - .png
+    - .tif
+    - .json
   datatypes:
-  - micr
+    - micr
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/perf.yaml
+++ b/src/schema/rules/datatypes/perf.yaml
@@ -1,14 +1,14 @@
 ---
 asl:
   suffixes:
-  - asl
-  - m0scan
+    - asl
+    - m0scan
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - perf
+    - perf
   entities:
     subject: required
     session: optional
@@ -19,12 +19,12 @@ asl:
 
 aslcontext:
   suffixes:
-  - aslcontext
+    - aslcontext
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
   datatypes:
-  - perf
+    - perf
   entities:
     subject: required
     session: optional
@@ -35,11 +35,11 @@ aslcontext:
 
 asllabeling:
   suffixes:
-  - asllabeling
+    - asllabeling
   extensions:
-  - .jpg
+    - .jpg
   datatypes:
-  - perf
+    - perf
   entities:
     subject: required
     session: optional
@@ -49,13 +49,13 @@ asllabeling:
 
 timeseries:
   suffixes:
-  - physio
-  - stim
+    - physio
+    - stim
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - perf
+    - perf
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/datatypes/pet.yaml
+++ b/src/schema/rules/datatypes/pet.yaml
@@ -1,13 +1,13 @@
 ---
 pet:
   suffixes:
-  - pet
+    - pet
   extensions:
-  - .nii.gz
-  - .nii
-  - .json
+    - .nii.gz
+    - .nii
+    - .json
   datatypes:
-  - pet
+    - pet
   entities:
     subject: required
     session: optional
@@ -18,12 +18,12 @@ pet:
 
 blood:
   suffixes:
-  - blood
+    - blood
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
   datatypes:
-  - pet
+    - pet
   entities:
     subject: required
     session: optional
@@ -35,12 +35,12 @@ blood:
 
 events:
   suffixes:
-  - events
+    - events
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
   datatypes:
-  - pet
+    - pet
   entities:
     subject: required
     session: optional
@@ -51,13 +51,13 @@ events:
 
 timeseries:
   suffixes:
-  - physio
-  - stim
+    - physio
+    - stim
   extensions:
-  - .tsv.gz
-  - .json
+    - .tsv.gz
+    - .json
   datatypes:
-  - pet
+    - pet
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/errors.yaml
+++ b/src/schema/rules/errors.yaml
@@ -3,250 +3,248 @@
 
 # BIDS Validator Original Issue Code #26
 NiftiHeaderUnreadable:
-    code: NIFTI_HEADER_UNREADABLE
-    message: |
-        We were unable to parse header data from this NIfTI file.
-        Please ensure it is not corrupted or mislabeled.
-    level: error
-    selectors:
+  code: NIFTI_HEADER_UNREADABLE
+  message: |
+    We were unable to parse header data from this NIfTI file.
+    Please ensure it is not corrupted or mislabeled.
+  level: error
+  selectors:
     - '[".nii", ".nii.gz"].includes(extension)'
 
 # BIDS Validator Original Issue Code #27
 JsonInvalid:
-    code: JSON_INVALID
-    message: |
-        Not a valid JSON file.
-    level: error
-    selectors:
+  code: JSON_INVALID
+  message: |
+    Not a valid JSON file.
+  level: error
+  selectors:
     - extension == ".json"
 
 # BIDS Validator Original Issue Code #28
 GzNotGzipped:
-    code: GZ_NOT_GZIPPED
-    message: |
-        This file ends in the .gz extension but is not actually gzipped.
-    level: error
-    selectors:
+  code: GZ_NOT_GZIPPED
+  message: |
+    This file ends in the .gz extension but is not actually gzipped.
+  level: error
+  selectors:
     - extension.includes(".gz")
 
 # BIDS Validator Original Issue Code #30
 BvalMultipleRows:
-    code: BVAL_MULTIPLE_ROWS
-    message: |
-        .bval files should contain exactly one row of volumes.
-    level: error
-    selectors:
+  code: BVAL_MULTIPLE_ROWS
+  message: |
+    .bval files should contain exactly one row of volumes.
+  level: error
+  selectors:
     - extension == ".bval"
 
 # BIDS Validator Original Issue Code #31
 BvecNumberRows:
-    code: BVEC_NUMBER_ROWS
-    message: |
-        .bvec files should contain exactly three rows of volumes.
-    level: error
-    selectors:
+  code: BVEC_NUMBER_ROWS
+  message: |
+    .bvec files should contain exactly three rows of volumes.
+  level: error
+  selectors:
     - extension == ".bvec"
 
 # BIDS Validator Original Issue Code #36
 NiftiTooSmall:
-    code: NIFTI_TOO_SMALL
-    message: |
-        This file is too small to contain the minimal NIfTI header.
-    level: error
-    selectors:
+  code: NIFTI_TOO_SMALL
+  message: |
+    This file is too small to contain the minimal NIfTI header.
+  level: error
+  selectors:
     - '[".nii", ".nii.gz"].includes(extension)'
 
 # BIDS Validator Original Issue Code #43
 OrphanedSymlink:
-    code: ORPHANED_SYMLINK
-    message: |
-        This file appears to be an orphaned symlink.
-        Make sure it correctly points to its referent.
-    level: error
+  code: ORPHANED_SYMLINK
+  message: |
+    This file appears to be an orphaned symlink.
+    Make sure it correctly points to its referent.
+  level: error
 
 # BIDS Validator Original Issue Code #44
 FileRead:
-    code: FILE_READ
-    message: |
-        We were unable to read this file.
-        Make sure it contains data (file size > 0 kB) and is not corrupted,
-        incorrectly named, or incorrectly symlinked.
-    level: error
+  code: FILE_READ
+  message: |
+    We were unable to read this file.
+    Make sure it contains data (file size > 0 kB) and is not corrupted,
+    incorrectly named, or incorrectly symlinked.
+  level: error
 
 # BIDS Validator Original Issue Code #46
 BvecRowLength:
-    code: BVEC_ROW_LENGTH
-    message: |
-        Each row in a .bvec file should contain the same number of values.
-    level: error
-    selectors:
+  code: BVEC_ROW_LENGTH
+  message: |
+    Each row in a .bvec file should contain the same number of values.
+  level: error
+  selectors:
     - extension == ".bvec"
 
 # BIDS Validator Original Issue Code #47
 BFile:
-    code: B_FILE
-    message: |
-        .bval and .bvec files must be single space delimited
-        and contain only numerical values.
-    level: error
-    selectors:
+  code: B_FILE
+  message: |
+    .bval and .bvec files must be single space delimited
+    and contain only numerical values.
+  level: error
+  selectors:
     - '[".bval", ".bvec"].includes(extension)'
 
 # BIDS Validator Original Issue Code #55
 JsonSchemaValidationError:
-    code: JSON_SCHEMA_VALIDATION_ERROR
-    message: |
-        Invalid JSON file. The file is not formatted according the schema.
-    level: error
-    selectors:
+  code: JSON_SCHEMA_VALIDATION_ERROR
+  message: |
+    Invalid JSON file. The file is not formatted according the schema.
+  level: error
+  selectors:
     - extension == ".json"
 
 # BIDS Validator Original Issue Code #67
 NoValidDataFoundForSubject:
-    code: NO_VALID_DATA_FOUND_FOR_SUBJECT
-    message: |
-        No BIDS compatible data found for at least one subject.
-    level: error
-
+  code: NO_VALID_DATA_FOUND_FOR_SUBJECT
+  message: |
+    No BIDS compatible data found for at least one subject.
+  level: error
 
 # BIDS Validator Original Issue Code #70
 WrongNewLine:
-    code: WRONG_NEW_LINE
-    message: |
-        All TSV files must use Line Feed '\n' characters to denote new lines.
-        This files uses Carriage Return '\r'.
-    level: error
-    selectors:
+  code: WRONG_NEW_LINE
+  message: |
+    All TSV files must use Line Feed '\n' characters to denote new lines.
+    This files uses Carriage Return '\r'.
+  level: error
+  selectors:
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #74
 MalformedBvec:
-    code: MALFORMED_BVEC
-    message: |
-        The contents of this .bvec file are undefined or severely malformed.
-    level: error
-    selectors:
+  code: MALFORMED_BVEC
+  message: |
+    The contents of this .bvec file are undefined or severely malformed.
+  level: error
+  selectors:
     - extension == ".bvec"
 
 # BIDS Validator Original Issue Code #88
 MalformedBval:
-    code: MALFORMED_BVAL
-    message: |
-        The contents of this .bval file are undefined or severely malformed.
-    level: error
-    selectors:
+  code: MALFORMED_BVAL
+  message: |
+    The contents of this .bval file are undefined or severely malformed.
+  level: error
+  selectors:
     - extension == ".bval"
 
 # BIDS Validator Original Issue Code #89
 SidecarWithoutDatafile:
-    code: SIDECAR_WITHOUT_DATAFILE
-    message: |
-        A json sidecar file was found without a corresponding data file.
-    level: error
-    selectors:
+  code: SIDECAR_WITHOUT_DATAFILE
+  message: |
+    A json sidecar file was found without a corresponding data file.
+  level: error
+  selectors:
     - extension == ".json"
 
 # BIDS Validator Original Issue Code #90
 MissingSession:
-    code: MISSING_SESSION
-    message: |
-        Not all subjects contain the same sessions.
-    level: warning
+  code: MISSING_SESSION
+  message: |
+    Not all subjects contain the same sessions.
+  level: warning
 
 # BIDS Validator Original Issue Code #98
 InaccessibleRemoteFile:
-    code: INACCESSIBLE_REMOTE_FILE
-    message: |
-        This file appears to be a symlink to a remote annexed file,
-        but could not be accessed from any of the configured remotes.
-    level: error
+  code: INACCESSIBLE_REMOTE_FILE
+  message: |
+    This file appears to be a symlink to a remote annexed file,
+    but could not be accessed from any of the configured remotes.
+  level: error
 
 # BIDS Validator Original Issue Code #99
 EmptyFile:
-    code: EMPTY_FILE
-    message: |
-        Empty files not allowed.
-    level: error
+  code: EMPTY_FILE
+  message: |
+    Empty files not allowed.
+  level: error
 
 # BIDS Validator Original Issue Code #100
 BrainvisionLinksBroken:
-    code: BRAINVISION_LINKS_BROKEN
-    message: |
-        Internal file pointers in BrainVision file triplet (*.eeg, *.vhdr,
-        and *.vmrk) are broken or some files do not exist.
-    level: error
-    selectors:
+  code: BRAINVISION_LINKS_BROKEN
+  message: |
+    Internal file pointers in BrainVision file triplet (*.eeg, *.vhdr,
+    and *.vmrk) are broken or some files do not exist.
+  level: error
+  selectors:
     - '[ ".eeg", ".vhdr", ".vmrk"].includes(extension)'
 
 # BIDS Validator Original Issue Code #104
 HedError:
-    code: HED_ERROR
-    message: |
-        The validation on this HED string returned an error.
-    level: error
-
-    selectors:
+  code: HED_ERROR
+  message: |
+    The validation on this HED string returned an error.
+  level: error
+  selectors:
     - suffix == "events"
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #105
 HedWarning:
-    code: HED_WARNING
-    message: |
-        The validation on this HED string returned a warning.
-    level: warning
-    selectors:
+  code: HED_WARNING
+  message: |
+    The validation on this HED string returned a warning.
+  level: warning
+  selectors:
     - suffix == "events"
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #106
 HedInternalError:
-    code: HED_INTERNAL_ERROR
-    message: |
-        An internal error occurred during HED validation.
-    level: error
-    selectors:
+  code: HED_INTERNAL_ERROR
+  message: |
+    An internal error occurred during HED validation.
+  level: error
+  selectors:
     - suffix == "events"
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #107
 HedInternalWarning:
-    code: HED_INTERNAL_WARNING
-    message: |
-        An internal warning occurred during HED validation.
-    level: warning
-    selectors:
+  code: HED_INTERNAL_WARNING
+  message: |
+    An internal warning occurred during HED validation.
+  level: warning
+  selectors:
     - suffix == "events"
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #108
 HedMissingValueInSidecar:
-    code: HED_MISSING_VALUE_IN_SIDECAR
-    message: |
-        The json sidecar does not contain this column value as
-        a possible key to a HED string.
-    level: warning
-    selectors:
+  code: HED_MISSING_VALUE_IN_SIDECAR
+  message: |
+    The json sidecar does not contain this column value as
+    a possible key to a HED string.
+  level: warning
+  selectors:
     - suffix == "events"
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #109
 HedVersionNotDefined:
-    code: HED_VERSION_NOT_DEFINED
-    message: |
-        You should define 'HEDVersion' for this file.
-        If you don't provide this information, the HED validation will use
-        the latest version available.
-    level: warning
-    selectors:
+  code: HED_VERSION_NOT_DEFINED
+  message: |
+    You should define 'HEDVersion' for this file.
+    If you don't provide this information, the HED validation will use
+    the latest version available.
+  level: warning
+  selectors:
     - suffix == "events"
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #123
 InvalidJsonEncoding:
-    code: INVALID_JSON_ENCODING
-    message: |
-        JSON files must be valid utf-8.
-    level: error
-    selectors:
+  code: INVALID_JSON_ENCODING
+  message: |
+    JSON files must be valid utf-8.
+  level: error
+  selectors:
     - extension == ".json"

--- a/src/schema/rules/modalities.yaml
+++ b/src/schema/rules/modalities.yaml
@@ -2,26 +2,26 @@
 # This file defines which data types fall under each modality.
 mri:
   datatypes:
-  - anat
-  - dwi
-  - fmap
-  - func
-  - perf
+    - anat
+    - dwi
+    - fmap
+    - func
+    - perf
 eeg:
   datatypes:
-  - eeg
+    - eeg
 ieeg:
   datatypes:
-  - ieeg
+    - ieeg
 meg:
   datatypes:
-  - meg
+    - meg
 beh:
   datatypes:
-  - beh
+    - beh
 pet:
   datatypes:
-  - pet
+    - pet
 micr:
   datatypes:
-  - micr
+    - micr

--- a/src/schema/rules/sidecars/anat.yaml
+++ b/src/schema/rules/sidecars/anat.yaml
@@ -4,31 +4,30 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Anatomy imaging data
 
 MRIAnatomyCommonMetadataFields:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "anat"
-    fields:
-        ContrastBolusIngredient: optional
-        RepetitionTimeExcitation: optional
-        RepetitionTimePreparation: optional
+  fields:
+    ContrastBolusIngredient: optional
+    RepetitionTimeExcitation: optional
+    RepetitionTimePreparation: optional
 
 PhaseEntityUnits:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "anat"
     - entities.part == "phase"
-    fields:
-        Units: required
+  fields:
+    Units: required
 
 PhaseSuffixUnits:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "anat"
     - suffix == "phase"
-    fields:
-        Units: required
+  fields:
+    Units: required

--- a/src/schema/rules/sidecars/asl.yaml
+++ b/src/schema/rules/sidecars/asl.yaml
@@ -4,331 +4,330 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Fields described in text, but not in tables
 MRIASLTextOnly:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    fields:
-        MagneticFieldStrength: required
-        MRAcquisitionType: required
-        EchoTime: required
-        RepetitionTimePreparation: required
+  fields:
+    MagneticFieldStrength: required
+    MRAcquisitionType: required
+    EchoTime: required
+    RepetitionTimePreparation: required
 
 MRIASLTextOnlySliceTimingRec:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.MRAcquisitionType != "2D"
-    fields:
-        SliceTiming:
-            level: recommended
-            level_addendum: required if `MRAcquisitionType` is defined as `2D`
+  fields:
+    SliceTiming:
+      level: recommended
+      level_addendum: required if `MRAcquisitionType` is defined as `2D`
 
 MRIASLTextOnlySliceTimingReq:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.MRAcquisitionType == "2D"
-    fields:
-        SliceTiming:
-            level: required
-            issue:
-                code: SLICE_TIMING_NOT_DEFINED_2D_ASL
-                message: |
-                    You should define `SliceTiming` for this file, because `SequenceType` is sets
-                    to a 2D sequence. `SliceTiming` is the time at which each slice was
-                    acquired within each volume (frame) of the acquisition. Slice timing
-                    is not slice order -- rather, it is a list of times containing the
-                    time (in seconds) of each slice acquisition in relation to the beginning
-                    of volume acquisition. The list goes through the slices along the slice
-                    axis in the slice encoding dimension (see below). Note that to ensure the
-                    proper interpretation of the `SliceTiming` field, it is important to check
-                    if the optional `SliceEncodingDirection` exists. In particular, if
-                    `SliceEncodingDirection` is negative, the entries in `SliceTiming` are
-                    defined in reverse order with respect to the slice axis, such that the
-                    final entry in the `SliceTiming` list is the time of acquisition of slice 0.
-                    Without this parameter slice time correction will not be possible.
+  fields:
+    SliceTiming:
+      level: required
+      issue:
+        code: SLICE_TIMING_NOT_DEFINED_2D_ASL
+        message: |
+          You should define `SliceTiming` for this file, because `SequenceType` is sets
+          to a 2D sequence. `SliceTiming` is the time at which each slice was
+          acquired within each volume (frame) of the acquisition. Slice timing
+          is not slice order -- rather, it is a list of times containing the
+          time (in seconds) of each slice acquisition in relation to the beginning
+          of volume acquisition. The list goes through the slices along the slice
+          axis in the slice encoding dimension (see below). Note that to ensure the
+          proper interpretation of the `SliceTiming` field, it is important to check
+          if the optional `SliceEncodingDirection` exists. In particular, if
+          `SliceEncodingDirection` is negative, the entries in `SliceTiming` are
+          defined in reverse order with respect to the slice axis, such that the
+          final entry in the `SliceTiming` list is the time of acquisition of slice 0.
+          Without this parameter slice time correction will not be possible.
 
 MRIASLTextOnlyFlipAngleRec:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - '!(LookLocker in sidecar) || sidecar.LookLocker == false'
-    fields:
-        FlipAngle:
-            level: recommended
-            level_addendum: required if `LookLocker` is `true`
+  fields:
+    FlipAngle:
+      level: recommended
+      level_addendum: required if `LookLocker` is `true`
 
 MRIASLTextOnlyFlipAngleReq:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.LookLocker == true
-    fields:
-        FlipAngle:
-            level: required
-            issue:
-                code: LOOK_LOCKER_FLIP_ANGLE_MISSING
-                message: |
-                    You should define `FlipAngle` for this file, in case of a
-                    LookLocker acquisition. `FlipAngle` is the flip angle (FA)
-                    for the acquisition, specified in degrees. Corresponds to
-                    DICOM Tag 0018, 1314 `Flip Angle`. The data type number may
-                    apply to files from any MRI modality concerned with a single
-                    value for this field, or to the files in a file collection
-                    where the value of this field is iterated using the flip entity.
-                    The data type array provides a value for each volume in a 4D
-                    dataset and should only be used when the volume timing is critical
-                    for interpretation of the data, such as in ASL or variable flip
-                    angle fMRI sequences.
+  fields:
+    FlipAngle:
+      level: required
+      issue:
+        code: LOOK_LOCKER_FLIP_ANGLE_MISSING
+        message: |
+          You should define `FlipAngle` for this file, in case of a
+          LookLocker acquisition. `FlipAngle` is the flip angle (FA)
+          for the acquisition, specified in degrees. Corresponds to
+          DICOM Tag 0018, 1314 `Flip Angle`. The data type number may
+          apply to files from any MRI modality concerned with a single
+          value for this field, or to the files in a file collection
+          where the value of this field is iterated using the flip entity.
+          The data type array provides a value for each volume in a 4D
+          dataset and should only be used when the volume timing is critical
+          for interpretation of the data, such as in ASL or variable flip
+          angle fMRI sequences.
 
 # Common metadata fields applicable to both (P)CASL and PASL
 MRIASLCommonMetadataFields:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
-    fields:
-        ArterialSpinLabelingType: required
-        PostLabelingDelay: required
-        BackgroundSuppression: required
-        M0Type: required
-        TotalAcquiredPairs: required
-        VascularCrushing: recommended
-        AcquisitionVoxelSize: recommended
-        LabelingOrientation: recommended
-        LabelingDistance: recommended
-        LabelingLocationDescription: recommended
-        LookLocker: optional
-        LabelingEfficiency: optional
+  fields:
+    ArterialSpinLabelingType: required
+    PostLabelingDelay: required
+    BackgroundSuppression: required
+    M0Type: required
+    TotalAcquiredPairs: required
+    VascularCrushing: recommended
+    AcquisitionVoxelSize: recommended
+    LabelingOrientation: recommended
+    LabelingDistance: recommended
+    LabelingLocationDescription: recommended
+    LookLocker: optional
+    LabelingEfficiency: optional
 
 MRIASLCommonMetadataFieldsM0TypeRec:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.M0Type != "Estimate"
-    fields:
-        M0Estimate:
-            level: optional
-            level_addendum: required if `M0Type` is `Estimate`
+  fields:
+    M0Estimate:
+      level: optional
+      level_addendum: required if `M0Type` is `Estimate`
 
 MRIASLCommonMetadataFieldsM0TypeReq:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.M0Type == "Estimate"
-    fields:
-        M0Estimate:
-            level: required
-            issue:
-                code: M0ESTIMATE_NOT_DEFINED
-                message: |
-                    You must define `M0Estimate` for this file, because `M0Type` is set to
-                    'Estimate'. `M0Estimate` is a single numerical whole-brain M0 value
-                    (referring to the M0 of blood), only if obtained externally (for example
-                    retrieved from CSF in a separate measurement).
+  fields:
+    M0Estimate:
+      level: required
+      issue:
+        code: M0ESTIMATE_NOT_DEFINED
+        message: |
+          You must define `M0Estimate` for this file, because `M0Type` is set to
+          'Estimate'. `M0Estimate` is a single numerical whole-brain M0 value
+          (referring to the M0 of blood), only if obtained externally (for example
+          retrieved from CSF in a separate measurement).
 
 MRIASLCommonMetadataFieldsBackgroundSuppressionOpt:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.BackgroundSuppression == false
-    fields:
-        BackgroundSuppressionNumberPulses:
-            level: optional
-            level_addendum: recommended if `BackgroundSuppression` is `true`
-        BackgroundSuppressionPulseTime:
-            level: optional
-            level_addendum: recommended if `BackgroundSuppression` is `true`
+  fields:
+    BackgroundSuppressionNumberPulses:
+      level: optional
+      level_addendum: recommended if `BackgroundSuppression` is `true`
+    BackgroundSuppressionPulseTime:
+      level: optional
+      level_addendum: recommended if `BackgroundSuppression` is `true`
 
 MRIASLCommonMetadataFieldsBackgroundSuppressionReq:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.BackgroundSuppression == true
-    fields:
-        BackgroundSuppressionNumberPulses: recommended
-        BackgroundSuppressionPulseTime: recommended
+  fields:
+    BackgroundSuppressionNumberPulses: recommended
+    BackgroundSuppressionPulseTime: recommended
 
 MRIASLCommonMetadataFieldsVascularCrushingOpt:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.VascularCrushing == false
-    fields:
-        VascularCrushingVENC:
-            level: optional
-            level_addendum: recommended if `VascularCrushing` is `true`
+  fields:
+    VascularCrushingVENC:
+      level: optional
+      level_addendum: recommended if `VascularCrushing` is `true`
 
 MRIASLCommonMetadataFieldsVascularCrushingRec:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.VascularCrushing == true
-    fields:
-        VascularCrushingVENC: recommended
+  fields:
+    VascularCrushingVENC: recommended
 
 MRIASLCaslPcaslSpecific:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - '["CASL", "PCASL"].includes(sidecar.ArterialSpinLabelingType)'
-    fields:
-        LabelingDuration: required
-        LabelingPulseAverageGradient: recommended
-        LabelingPulseMaximumGradient: recommended
-        LabelingPulseAverageB1: recommended
-        LabelingPulseDuration: recommended
-        LabelingPulseFlipAngle: recommended
-        LabelingPulseInterval: recommended
+  fields:
+    LabelingDuration: required
+    LabelingPulseAverageGradient: recommended
+    LabelingPulseMaximumGradient: recommended
+    LabelingPulseAverageB1: recommended
+    LabelingPulseDuration: recommended
+    LabelingPulseFlipAngle: recommended
+    LabelingPulseInterval: recommended
 
 MRIASLPcaslSpecific:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.ArterialSpinLabelingType == "PCASL"
-    fields:
-        PCASLType:
-            level: recommended
-            level_addendum: if `ArterialSpinLabelingType` is `"PCASL"`
+  fields:
+    PCASLType:
+      level: recommended
+      level_addendum: if `ArterialSpinLabelingType` is `"PCASL"`
 
 MRIASLCaslSpecific:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.ArterialSpinLabelingType == "CASL"
-    fields:
-        CASLType:
-            level: recommended
-            level_addendum: if `ArterialSpinLabelingType` is `"CASL"`
+  fields:
+    CASLType:
+      level: recommended
+      level_addendum: if `ArterialSpinLabelingType` is `"CASL"`
 
 MRIASLPaslSpecific:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.ArterialSpinLabelingType == "PASL"
-    fields:
-        BolusCutOffFlag: required
-        PASLType: recommended
-        LabelingSlabThickness: recommended
+  fields:
+    BolusCutOffFlag: required
+    PASLType: recommended
+    LabelingSlabThickness: recommended
 
 MRIASLPASLSpecificBolusCutOffFlagFalse:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.ArterialSpinLabelingType == "PASL"
     - sidecar.BolusCutOffFlag == false
-    fields:
-        BolusCutOffDelayTime:
-            level: optional
-            level_addendum: required if `BolusCutOffFlag` is `true`
-        BolusCutOffTechnique:
-            level: optional
-            level_addendum: required if `BolusCutOffFlag` is `true`
+  fields:
+    BolusCutOffDelayTime:
+      level: optional
+      level_addendum: required if `BolusCutOffFlag` is `true`
+    BolusCutOffTechnique:
+      level: optional
+      level_addendum: required if `BolusCutOffFlag` is `true`
 
 MRIASLPaslSpecificBolusCutOffFlagTrue:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "asl"
     - sidecar.ArterialSpinLabelingType == "PASL"
     - sidecar.BolusCutOffFlag == true
-    fields:
-        BolusCutOffDelayTime:
-            level: required
-            issue:
-                code: PASL_BOLUS_CUT_OFF_DELAY_TIME
-                message: |
-                    It is required to define 'BolusCutOffDelayTime' for this file,
-                    when 'BolusCutOffFlag' is set to true. 'BolusCutOffDelayTime' is
-                    the duration between the end of the labeling and the start of the
-                    bolus cut-off saturation pulse(s), in seconds. This can be a number
-                    or array of numbers, of which the values must be non-negative and
-                    monotonically increasing, depending on the number of bolus cut-off
-                    saturation pulses. For Q2TIPS, only the values for the first and last
-                    bolus cut-off saturation pulses are provided. Based on DICOM Tag
-                    0018,925F ASL Bolus Cut-off Delay Time.
-        BolusCutOffTechnique:
-            level: required
-            issue:
-                code: PASL_BOLUS_CUT_OFF_TECHINIQUE
-                message: |
-                    It is required to define `BolusCutOffTechnique` for this file,
-                    when `BolusCutOffFlag` is set to `true`. `BolusCutOffTechnique`,
-                    is the name of the technique used
-                    (for example, Q2TIPS, QUIPSS or QUIPSSII).
-                    Corresponds to DICOM Tag 0018,925E `ASL Bolus Cut-off Technique`.
+  fields:
+    BolusCutOffDelayTime:
+      level: required
+      issue:
+        code: PASL_BOLUS_CUT_OFF_DELAY_TIME
+        message: |
+          It is required to define 'BolusCutOffDelayTime' for this file,
+          when 'BolusCutOffFlag' is set to true. 'BolusCutOffDelayTime' is
+          the duration between the end of the labeling and the start of the
+          bolus cut-off saturation pulse(s), in seconds. This can be a number
+          or array of numbers, of which the values must be non-negative and
+          monotonically increasing, depending on the number of bolus cut-off
+          saturation pulses. For Q2TIPS, only the values for the first and last
+          bolus cut-off saturation pulses are provided. Based on DICOM Tag
+          0018,925F ASL Bolus Cut-off Delay Time.
+    BolusCutOffTechnique:
+      level: required
+      issue:
+        code: PASL_BOLUS_CUT_OFF_TECHINIQUE
+        message: |
+          It is required to define `BolusCutOffTechnique` for this file,
+          when `BolusCutOffFlag` is set to `true`. `BolusCutOffTechnique`,
+          is the name of the technique used
+          (for example, Q2TIPS, QUIPSS or QUIPSSII).
+          Corresponds to DICOM Tag 0018,925E `ASL Bolus Cut-off Technique`.
 
 # m0scan metadata fields
 MRIASLM0ScanTextOnly:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "m0scan"
-    fields:
-        EchoTime: required
-        RepetitionTimePreparation: required
+  fields:
+    EchoTime: required
+    RepetitionTimePreparation: required
 
 MRIASLM0ScanTextOnlyFlipAngleRec:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "m0scan"
     - '!(LookLocker in sidecar) || sidecar.LookLocker == false'
-    fields:
-        FlipAngle:
-            level: recommended
-            level_addendum: required if `LookLocker` is `true`
+  fields:
+    FlipAngle:
+      level: recommended
+      level_addendum: required if `LookLocker` is `true`
 
 MRIASLM0ScanTextOnlyFlipAngleReq:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "m0scan"
     - sidecar.LookLocker == true
-    fields:
-        FlipAngle:
-            level: required
-            issue:
-                code: LOOK_LOCKER_FLIP_ANGLE_MISSING
-                message: |
-                    You should define `FlipAngle` for this file, in case of a LookLocker
-                    acquisition. `FlipAngle` is the flip angle (FA) for the acquisition,
-                    specified in degrees. Corresponds to DICOM Tag 0018, 1314 `Flip Angle`.
-                    The data type number may apply to files from any MRI modality concerned
-                    with a single value for this field, or to the files in a file collection
-                    where the value of this field is iterated using the flip entity. The
-                    data type array provides a value for each volume in a 4D dataset and
-                    should only be used when the volume timing is critical for interpretation
-                    of the data, such as in ASL or variable flip angle fMRI sequences.
+  fields:
+    FlipAngle:
+      level: required
+      issue:
+        code: LOOK_LOCKER_FLIP_ANGLE_MISSING
+        message: |
+          You should define `FlipAngle` for this file, in case of a LookLocker
+          acquisition. `FlipAngle` is the flip angle (FA) for the acquisition,
+          specified in degrees. Corresponds to DICOM Tag 0018, 1314 `Flip Angle`.
+          The data type number may apply to files from any MRI modality concerned
+          with a single value for this field, or to the files in a file collection
+          where the value of this field is iterated using the flip entity. The
+          data type array provides a value for each volume in a 4D dataset and
+          should only be used when the volume timing is critical for interpretation
+          of the data, such as in ASL or variable flip angle fMRI sequences.
 
 MRIASLM0Scan:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "perf"
     - suffix == "m0scan"
-    fields:
-        IntendedFor:
-            level: required
-            description_addendum: |
-                This is used to refer to the ASL time series for which the `*_m0scan.nii[.gz]` is intended.
-        AcquisitionVoxelSize: recommended
+  fields:
+    IntendedFor:
+      level: required
+      description_addendum: |
+        This is used to refer to the ASL time series for which the `*_m0scan.nii[.gz]` is intended.
+    AcquisitionVoxelSize: recommended

--- a/src/schema/rules/sidecars/beh.yaml
+++ b/src/schema/rules/sidecars/beh.yaml
@@ -4,18 +4,17 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Metadata for either beh or events files
 BEHTabularData:
-    selectors:
+  selectors:
     - '["beh", "events"].includes(suffix)'
-    fields:
-        TaskName: recommended
-        Instructions: recommended
-        TaskDescription: recommended
-        CogAtlasID: recommended
-        CogPOID: recommended
-        InstitutionName: recommended
-        InstitutionAddress: recommended
-        InstitutionalDepartmentName: recommended
+  fields:
+    TaskName: recommended
+    Instructions: recommended
+    TaskDescription: recommended
+    CogAtlasID: recommended
+    CogPOID: recommended
+    InstitutionName: recommended
+    InstitutionAddress: recommended
+    InstitutionalDepartmentName: recommended

--- a/src/schema/rules/sidecars/continuous.yaml
+++ b/src/schema/rules/sidecars/continuous.yaml
@@ -4,23 +4,22 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Metadata for either physio or stim files
 Continuous:
-    selectors:
+  selectors:
     - '["physio", "stim"].includes(suffix)'
-    fields:
-        SamplingFrequency: required
-        StartTime: required
-        Columns: required
+  fields:
+    SamplingFrequency: required
+    StartTime: required
+    Columns: required
 
 # Other recommended metadata for physiological data
 Physio:
-    selectors:
+  selectors:
     - suffix == "physio"
-    fields:
-        Manufacturer: recommended
-        ManufacturersModelName: recommended
-        SoftwareVersions: recommended
-        DeviceSerialNumber: recommended
+  fields:
+    Manufacturer: recommended
+    ManufacturersModelName: recommended
+    SoftwareVersions: recommended
+    DeviceSerialNumber: recommended

--- a/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
@@ -1,7 +1,7 @@
 ---
 CommonDerivativeFields:
   selectors:
-  - dataset.DatasetType == "derivative"
+    - dataset.DatasetType == "derivative"
   fields:
     Description:
       level: recommended
@@ -11,26 +11,26 @@ CommonDerivativeFields:
 
 SpatialReferenceEntity:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '"space" in entities'
+    - dataset.DatasetType == "derivative"
+    - '"space" in entities'
   fields:
     SpatialReference:
       level: recommended
       level_addendum: |
-            if the derivative is aligned to a standard template listed in
-            [Standard template identifiers][templates]. Required otherwise.
+        if the derivative is aligned to a standard template listed in
+        [Standard template identifiers][templates]. Required otherwise.
 
 SpatialReferenceNonStandard:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '!(schema.objects.metadata._StandardTemplateCoordSys).includes(entities.space)'
+    - dataset.DatasetType == "derivative"
+    - '!(schema.objects.metadata._StandardTemplateCoordSys).includes(entities.space)'
   fields:
     SpatialReference: required
 
 SpatialReferenceNoEntity:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '!("space" in entities)'
+    - dataset.DatasetType == "derivative"
+    - '!("space" in entities)'
   fields:
     SpatialReference: required
 
@@ -38,8 +38,8 @@ SpatialReferenceNoEntity:
 # different way
 MaskDerivatives:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - suffix == "mask"
+    - dataset.DatasetType == "derivative"
+    - suffix == "mask"
   fields:
     Type: recommended
     Sources: recommended
@@ -47,9 +47,9 @@ MaskDerivatives:
 
 MaskDerivativesAtlas:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - suffix == "mask"
-  - '"label" in entities'
+    - dataset.DatasetType == "derivative"
+    - suffix == "mask"
+    - '"label" in entities'
   fields:
     Atlas:
       level: recommended
@@ -57,16 +57,16 @@ MaskDerivativesAtlas:
 
 SegmentationCommon:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '["dseg", "probseg"].includes(suffix)'
+    - dataset.DatasetType == "derivative"
+    - '["dseg", "probseg"].includes(suffix)'
   fields:
     Manual: optional
 
 SegmentationCommonAtlas:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '["dseg", "probseg"].includes(suffix)'
-  - '"atlas" in entities'
+    - dataset.DatasetType == "derivative"
+    - '["dseg", "probseg"].includes(suffix)'
+    - '"atlas" in entities'
   fields:
     Atlas:
       level: recommended
@@ -75,17 +75,17 @@ SegmentationCommonAtlas:
 # Derivatives -> Imaging data types
 ImageDerivatives:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '["mri", "pet"].includes(modality)'
-  - '[".nii", ".nii.gz"].includes(extension)'
+    - dataset.DatasetType == "derivative"
+    - '["mri", "pet"].includes(modality)'
+    - '[".nii", ".nii.gz"].includes(extension)'
   fields:
     SkullStripped: required
 
 ImageDerivativeResEntity:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '["mri", "pet"].includes(modality)'
-  - '"res" in entities'
+    - dataset.DatasetType == "derivative"
+    - '["mri", "pet"].includes(modality)'
+    - '"res" in entities'
   fields:
     Resolution:
       level: required
@@ -93,9 +93,9 @@ ImageDerivativeResEntity:
 
 ImageDerivativeDenEntity:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '["mri", "pet"].includes(modality)'
-  - '"den" in entities'
+    - dataset.DatasetType == "derivative"
+    - '["mri", "pet"].includes(modality)'
+    - '"den" in entities'
   fields:
     Density:
       level: required

--- a/src/schema/rules/sidecars/dwi.yaml
+++ b/src/schema/rules/sidecars/dwi.yaml
@@ -4,22 +4,21 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Multipart (split) DWI schemes
 # NOTE: I don't think this can be schemafied, since it depends on owner intent.
 MRIDiffusionMultipart:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "dwi"
-    fields:
-        MultipartID: required
+  fields:
+    MultipartID: required
 
 # Other recommended metadata
 MRIDiffusionOtherMetadata:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "dwi"
-    fields:
-        PhaseEncodingDirection: recommended
-        TotalReadoutTime: recommended
+  fields:
+    PhaseEncodingDirection: recommended
+    TotalReadoutTime: recommended

--- a/src/schema/rules/sidecars/eeg.yaml
+++ b/src/schema/rules/sidecars/eeg.yaml
@@ -4,170 +4,168 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
-
 EEGGeneric:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "eeg"
-    fields:
-        TaskName:
-            level: required
-            description_addendum: |
-                A recommended convention is to name resting state task using labels
-                beginning with `rest`.
+  fields:
+    TaskName:
+      level: required
+      description_addendum: |
+        A recommended convention is to name resting state task using labels
+        beginning with `rest`.
 
 EEGRecommended:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "eeg"
-    fields:
-        InstitutionName: recommended
-        InstitutionAddress: recommended
-        InstitutionalDepartmentName: recommended
-        Manufacturer: recommended
-        ManufacturersModelName: recommended
-        SoftwareVersions: recommended
-        TaskDescription: recommended
-        Instructions:
-            level: recommended
-            description_addendum: |
-                This is especially important in context of resting state recordings and
-                distinguishing between eyes open and eyes closed paradigms.
-        CogAtlasID: recommended
-        CogPOID: recommended
-        DeviceSerialNumber: recommended
+  fields:
+    InstitutionName: recommended
+    InstitutionAddress: recommended
+    InstitutionalDepartmentName: recommended
+    Manufacturer: recommended
+    ManufacturersModelName: recommended
+    SoftwareVersions: recommended
+    TaskDescription: recommended
+    Instructions:
+      level: recommended
+      description_addendum: |
+        This is especially important in context of resting state recordings and
+        distinguishing between eyes open and eyes closed paradigms.
+    CogAtlasID: recommended
+    CogPOID: recommended
+    DeviceSerialNumber: recommended
 
 EEGRequired:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "eeg"
-    fields:
-        EEGReference: required
-        SamplingFrequency:
-            level: required
-            description_addendum: |
-                The sampling frequency of data channels that deviate from the main sampling
-                frequency SHOULD be specified in the `channels.tsv` file.
-        PowerLineFrequency: required
-        SoftwareFilters: required
+  fields:
+    EEGReference: required
+    SamplingFrequency:
+      level: required
+      description_addendum: |
+        The sampling frequency of data channels that deviate from the main sampling
+        frequency SHOULD be specified in the `channels.tsv` file.
+    PowerLineFrequency: required
+    SoftwareFilters: required
 
 EEGMoreRecommended:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "eeg"
-    fields:
-        CapManufacturer: recommended
-        CapManufacturersModelName: recommended
-        EEGChannelCount: recommended
-        ECGChannelCount: recommended
-        EMGChannelCount: recommended
-        EOGChannelCount: recommended
-        MiscChannelCount: recommended
-        TriggerChannelCount: recommended
-        RecordingDuration: recommended
-        RecordingType: recommended
-        EpochLength: recommended
-        EEGGround: recommended
-        HeadCircumference: recommended
-        EEGPlacementScheme: recommended
-        HardwareFilters: recommended
-        SubjectArtefactDescription: recommended
+  fields:
+    CapManufacturer: recommended
+    CapManufacturersModelName: recommended
+    EEGChannelCount: recommended
+    ECGChannelCount: recommended
+    EMGChannelCount: recommended
+    EOGChannelCount: recommended
+    MiscChannelCount: recommended
+    TriggerChannelCount: recommended
+    RecordingDuration: recommended
+    RecordingType: recommended
+    EpochLength: recommended
+    EEGGround: recommended
+    HeadCircumference: recommended
+    EEGPlacementScheme: recommended
+    HardwareFilters: recommended
+    SubjectArtefactDescription: recommended
 
 # General fields
 EEGCoordsystemGeneral:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
-    fields:
-        IntendedFor:
-            level: optional
-            description_addendum: |
-                This identifies the MRI or CT scan associated with the electrodes,
-                landmarks, and fiducials.
+  fields:
+    IntendedFor:
+      level: optional
+      description_addendum: |
+        This identifies the MRI or CT scan associated with the electrodes,
+        landmarks, and fiducials.
 
 # Fields relating to the EEG electrode positions
 EEGCoordsystemPositions:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
-    fields:
-        EEGCoordinateSystem: required
-        EEGCoordinateUnits: required
-        EEGCoordinateSystemDescription:
-            level: recommended
-            level_addendum: required if `EEGCoordinateSystem` is `"Other"`
+  fields:
+    EEGCoordinateSystem: required
+    EEGCoordinateUnits: required
+    EEGCoordinateSystemDescription:
+      level: recommended
+      level_addendum: required if `EEGCoordinateSystem` is `"Other"`
 
 EEGCoordsystemOther:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
     - '"EEGCoordinateSystem" in sidecar'
     - sidecar.EEGCoordinateSystem == "Other"
-    fields:
-        EEGCoordinateSystemDescription: required
+  fields:
+    EEGCoordinateSystemDescription: required
 
 # Fields relating to the position of fiducials measured during an EEG session/run
 EEGCoordsystemFiducials:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
-    fields:
-        FiducialsDescription: optional
-        FiducialsCoordinates: recommended
-        FiducialsCoordinateSystem: recommended
-        FiducialsCoordinateUnits: recommended
-        FiducialsCoordinateSystemDescription:
-            level: recommended
-            level_addendum: required if `FiducialsCoordinateSystem` is `"Other"`
+  fields:
+    FiducialsDescription: optional
+    FiducialsCoordinates: recommended
+    FiducialsCoordinateSystem: recommended
+    FiducialsCoordinateUnits: recommended
+    FiducialsCoordinateSystemDescription:
+      level: recommended
+      level_addendum: required if `FiducialsCoordinateSystem` is `"Other"`
 
 EEGCoordsystemOtherFiducialCoordinateSystem:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
     - FiducialsCoordinateSystem == "Other"
-    fields:
-        FiducialsCoordinateSystemDescription: required
+  fields:
+    FiducialsCoordinateSystemDescription: required
 
 # Fields relating to the position of anatomical landmark measured during an EEG session/run
 EEGCoordsystemLandmark:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
-    fields:
-        AnatomicalLandmarkCoordinates: recommended
-        AnatomicalLandmarkCoordinateSystem:
-            level: recommended
-            description_addendum: Preferably the same as the `EEGCoordinateSystem`.
-        AnatomicalLandmarkCoordinateUnits: recommended
+  fields:
+    AnatomicalLandmarkCoordinates: recommended
+    AnatomicalLandmarkCoordinateSystem:
+      level: recommended
+      description_addendum: Preferably the same as the `EEGCoordinateSystem`.
+    AnatomicalLandmarkCoordinateUnits: recommended
 
 EEGCoordsystemLandmarkDescriptionRec:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
     - sidecar.AnatomicalLandmarkCoordinateSystem != "Other"
-    fields:
-        AnatomicalLandmarkCoordinateSystemDescription:
-            level: recommended
-            level_addendum: required if `AnatomicalLandmarkCoordinateSystem` is `"Other"`
+  fields:
+    AnatomicalLandmarkCoordinateSystemDescription:
+      level: recommended
+      level_addendum: required if `AnatomicalLandmarkCoordinateSystem` is `"Other"`
 
 EEGCoordsystemLandmarkDescriptionReq:
-    selectors:
+  selectors:
     - modality == "eeg"
     - datatype == "eeg"
     - suffix == "coordsystem"
     - sidecar.AnatomicalLandmarkCoordinateSystem == "Other"
-    fields:
-        AnatomicalLandmarkCoordinateSystemDescription: required
+  fields:
+    AnatomicalLandmarkCoordinateSystemDescription: required

--- a/src/schema/rules/sidecars/entity_rules.yaml
+++ b/src/schema/rules/sidecars/entity_rules.yaml
@@ -4,78 +4,76 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
-
 # Entities
 
 EntitiesTaskMetadata:
-    selectors:
+  selectors:
     - '"task" in entities'
-    fields:
-        TaskName: recommended
+  fields:
+    TaskName: recommended
 
 EntitiesCeMetadata:
-    selectors:
+  selectors:
     - '"ce" in entities'
-    fields:
-        ContrastBolusIngredient: optional
+  fields:
+    ContrastBolusIngredient: optional
 
 EntitiesTrcMetadata:
-    selectors:
+  selectors:
     - '"trc" in entities'
-    fields:
-        TracerName: required
+  fields:
+    TracerName: required
 
 EntitiesStainMetadata:
-    selectors:
+  selectors:
     - '"stain" in entities'
-    fields:
-        SampleStaining: recommended
-        SamplePrimaryAntibody: recommended
-        SampleSecondaryAntibody: recommended
+  fields:
+    SampleStaining: recommended
+    SamplePrimaryAntibody: recommended
+    SampleSecondaryAntibody: recommended
 
 EntitiesEchoMetadata:
-    selectors:
+  selectors:
     - '"echo" in entities'
-    fields:
-        EchoTime: required
+  fields:
+    EchoTime: required
 
 EntitiesFlipMetadata:
-    selectors:
+  selectors:
     - '"flip" in entities'
-    fields:
-        FlipAngle: required
+  fields:
+    FlipAngle: required
 
 EntitiesInvMetadata:
-    selectors:
+  selectors:
     - '"inv" in entities'
-    fields:
-        InversionTime: required
+  fields:
+    InversionTime: required
 
 EntitiesMTMetadata:
-    selectors:
+  selectors:
     - '"mt" in entities'
-    fields:
-        MTState: required
+  fields:
+    MTState: required
 
 EntitiesPartMetadata:
-    selectors:
+  selectors:
     - entities.part == "phase"
-    fields:
-        Units:
-            level: required
-            rules:
-            - '["rad", "arbitrary"].includes(value)'
+  fields:
+    Units:
+      level: required
+      rules:
+        - '["rad", "arbitrary"].includes(value)'
 
 EntitiesResMetadata:
-    selectors:
+  selectors:
     - '"res" in entities'
-    fields:
-        Resolution: required
+  fields:
+    Resolution: required
 
 EntitiesDenMetadata:
-    selectors:
+  selectors:
     - '"den" in entities'
-    fields:
-        Density: required
+  fields:
+    Density: required

--- a/src/schema/rules/sidecars/events.yaml
+++ b/src/schema/rules/sidecars/events.yaml
@@ -4,11 +4,10 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Metadata for events files
 StimulusPresentation:
-    selectors:
+  selectors:
     - suffix == "events"
-    fields:
-        StimulusPresentation: recommended
+  fields:
+    StimulusPresentation: recommended

--- a/src/schema/rules/sidecars/fmap.yaml
+++ b/src/schema/rules/sidecars/fmap.yaml
@@ -4,84 +4,83 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Fieldmap data
 MRIFieldmapB0FieldIdentifier:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
-    fields:
-        B0FieldIdentifier: recommended
+  fields:
+    B0FieldIdentifier: recommended
 
 MRIFieldmapIntendedFor:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
-    fields:
-        IntendedFor:
-            level: optional
-            description_addendum: |
-                This field is optional, and in case the fieldmaps do not correspond
-                to any particular scans, it does not have to be filled.
+  fields:
+    IntendedFor:
+      level: optional
+      description_addendum: |
+        This field is optional, and in case the fieldmaps do not correspond
+        to any particular scans, it does not have to be filled.
 
 # Case 1: Phase-difference map and at least one magnitude image
 MRIFieldmapPhaseDifferencePhasediff:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
     - suffix == "phasediff"
-    fields:
-        EchoTime1: required
-        EchoTime2: required
+  fields:
+    EchoTime1: required
+    EchoTime2: required
 
 MRIFieldmapPhaseDifferenceMagnitude1:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
     - suffix == "magnitude1"
-    fields:
-        EchoTime1: required
+  fields:
+    EchoTime1: required
 
 MRIFieldmapPhaseDifferenceMagnitude2:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
     - suffix == "magnitude2"
-    fields:
-        EchoTime2: required
+  fields:
+    EchoTime2: required
 
 # Case 2: Two phase maps and two magnitude images
 # NOTE: Need to check for presence of related files.
 # For example, magnitude1 needs EchoTime__fmap only if phase1 file exists,
 # but EchoTime1 if phasediff exists.
 MRIFieldmapTwoPhase:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
     - '["phase1", "phase2", "magnitude1", "magnitude2"].includes(suffix)'
-    fields:
-        EchoTime__fmap: required
+  fields:
+    EchoTime__fmap: required
 
 # Case 3: Direct field mapping
 MRIFieldmapDirectFieldMapping:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
     - '["phase", "fieldmap"].includes(suffix)'
-    fields:
-        Units:
-            level: required
-            description_addendum: |
-                Fieldmaps must be in units of Hertz (`"Hz"`),
-                radians per second (`"rad/s"`), or Tesla (`"T"`).
+  fields:
+    Units:
+      level: required
+      description_addendum: |
+        Fieldmaps must be in units of Hertz (`"Hz"`),
+        radians per second (`"rad/s"`), or Tesla (`"T"`).
 
 # Case 4: Multiple phase encoded directions ("pepolar")
 MRIFieldmapPepolar:
-    selectors:
+  selectors:
     - modality == "MRI"
     - datatype == "fmap"
     - suffix == "epi"
-    fields:
-        PhaseEncodingDirection: required
-        TotalReadoutTime: required
+  fields:
+    PhaseEncodingDirection: required
+    TotalReadoutTime: required

--- a/src/schema/rules/sidecars/func.yaml
+++ b/src/schema/rules/sidecars/func.yaml
@@ -4,128 +4,127 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Task imaging data
 
 # Required fields
 MRIFuncRequired:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '[".nii", ".nii.gz"].includes(extension)'
-    fields:
-        TaskName:
-            level: required
-            description_addendum: |
-                A recommended convention is to name resting state task using labels
-                beginning with `rest`.
+  fields:
+    TaskName:
+      level: required
+      description_addendum: |
+        A recommended convention is to name resting state task using labels
+        beginning with `rest`.
 
 MRIFuncRepetitionTime:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '!("VolumeTiming" in sidecar)'
     - '[".nii", ".nii.gz"].includes(extension)'
-    fields:
-        RepetitionTime:
-            level: required
-            level_addendum: mutually exclusive with `VolumeTiming`
+  fields:
+    RepetitionTime:
+      level: required
+      level_addendum: mutually exclusive with `VolumeTiming`
 
 MRIFuncVolumeTiming:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '!("RepetitionTime" in sidecar)'
     - '[".nii", ".nii.gz"].includes(extension)'
-    fields:
-        VolumeTiming:
-            level: required
-            level_addendum: mutually exclusive with `RepetitionTime`
+  fields:
+    VolumeTiming:
+      level: required
+      level_addendum: mutually exclusive with `RepetitionTime`
 
 # Timing Parameters
 MRIFuncTimingParameters:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
-    fields:
-        NumberOfVolumesDiscardedByScanner: recommended
-        NumberOfVolumesDiscardedByUser: recommended
-        DelayTime: recommended
-        AcquisitionDuration:
-            level: recommended
-            level_addendum: |
-                required for sequences that are described with the `VolumeTiming`
-                field and that do not have the `SliceTiming` field set to allow for
-                accurate calculation of "acquisition time"
-            issue:
-                name: VOLUME_TIMING_MISSING_ACQUISITION_DURATION
-                message: |
-                    The field 'VolumeTiming' requires 'AcquisitionDuration' or 'SliceTiming' to be defined.
-        DelayAfterTrigger: recommended
+  fields:
+    NumberOfVolumesDiscardedByScanner: recommended
+    NumberOfVolumesDiscardedByUser: recommended
+    DelayTime: recommended
+    AcquisitionDuration:
+      level: recommended
+      level_addendum: |
+        required for sequences that are described with the `VolumeTiming`
+        field and that do not have the `SliceTiming` field set to allow for
+        accurate calculation of "acquisition time"
+      issue:
+        name: VOLUME_TIMING_MISSING_ACQUISITION_DURATION
+        message: |
+          The field 'VolumeTiming' requires 'AcquisitionDuration' or 'SliceTiming' to be defined.
+    DelayAfterTrigger: recommended
 
 # The mutual exclusion table, spread across 5 definitions
 # NOTE: This introduces a prohibited level
 MRIFuncTimingParametersMutualExclusion1:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '"RepetitionTime" in sidecar'
-    fields:
-        AcquisitionDuration: prohibited
-        VolumeTiming: prohibited
+  fields:
+    AcquisitionDuration: prohibited
+    VolumeTiming: prohibited
 
 MRIFuncTimingParametersMutualExclusion2:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '"SliceTiming" in sidecar'
     - '"VolumeTiming" in sidecar'
-    fields:
-        RepetitionTime: prohibited
-        DelayTime: prohibited
+  fields:
+    RepetitionTime: prohibited
+    DelayTime: prohibited
 
 MRIFuncTimingParametersMutualExclusion3:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '"AcquisitionDuration" in sidecar'
     - '"VolumeTiming" in sidecar'
-    fields:
-        RepetitionTime: prohibited
-        DelayTime: prohibited
+  fields:
+    RepetitionTime: prohibited
+    DelayTime: prohibited
 
 MRIFuncTimingParametersMutualExclusion4:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '"RepetitionTime" in sidecar'
     - '"SliceTiming" in sidecar'
-    fields:
-        AcquisitionDuration: prohibited
-        VolumeTiming: prohibited
+  fields:
+    AcquisitionDuration: prohibited
+    VolumeTiming: prohibited
 
 MRIFuncTimingParametersMutualExclusion5:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
     - '"RepetitionTime" in sidecar'
     - '"DelayTime" in sidecar'
-    fields:
-        AcquisitionDuration: prohibited
-        VolumeTiming: prohibited
+  fields:
+    AcquisitionDuration: prohibited
+    VolumeTiming: prohibited
 
 # fMRI task information
 MRIFuncTaskInformation:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "func"
-    fields:
-        Instructions:
-            level: recommended
-            description_addendum: |
-                This is especially important in context of resting state recordings and
-                distinguishing between eyes open and eyes closed paradigms.
-        TaskDescription: recommended
-        CogAtlasID: recommended
-        CogPOID: recommended
+  fields:
+    Instructions:
+      level: recommended
+      description_addendum: |
+        This is especially important in context of resting state recordings and
+        distinguishing between eyes open and eyes closed paradigms.
+    TaskDescription: recommended
+    CogAtlasID: recommended
+    CogPOID: recommended

--- a/src/schema/rules/sidecars/ieeg.yaml
+++ b/src/schema/rules/sidecars/ieeg.yaml
@@ -4,141 +4,139 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
-
 iEEGGeneric:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "ieeg"
-    fields:
-        TaskName:
-            level: required
-            description_addendum: |
-                A recommended convention is to name resting state task using labels
-                beginning with `rest`.
+  fields:
+    TaskName:
+      level: required
+      description_addendum: |
+        A recommended convention is to name resting state task using labels
+        beginning with `rest`.
 
 iEEGRecommended:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "ieeg"
-    fields:
-        InstitutionName: recommended
-        InstitutionAddress: recommended
-        InstitutionalDepartmentName: recommended
-        Manufacturer:
-            level: recommended
-            description_addendum: For example, `"TDT"`, `"Blackrock"`.
-        ManufacturersModelName: recommended
-        SoftwareVersions: recommended
-        TaskDescription: recommended
-        Instructions:
-            level: recommended
-            description_addendum: |
-                This is especially important in context of resting state recordings and
-                distinguishing between eyes open and eyes closed paradigms.
-        CogAtlasID: recommended
-        CogPOID: recommended
-        DeviceSerialNumber: recommended
+  fields:
+    InstitutionName: recommended
+    InstitutionAddress: recommended
+    InstitutionalDepartmentName: recommended
+    Manufacturer:
+      level: recommended
+      description_addendum: For example, `"TDT"`, `"Blackrock"`.
+    ManufacturersModelName: recommended
+    SoftwareVersions: recommended
+    TaskDescription: recommended
+    Instructions:
+      level: recommended
+      description_addendum: |
+        This is especially important in context of resting state recordings and
+        distinguishing between eyes open and eyes closed paradigms.
+    CogAtlasID: recommended
+    CogPOID: recommended
+    DeviceSerialNumber: recommended
 
 # Specific iEEG fields MUST be present
 iEEGRequired:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "ieeg"
-    fields:
-        iEEGReference: required
-        SamplingFrequency:
-            level: required
-            description_addendum: |
-                The sampling frequency of data channels that deviate from the main sampling
-                frequency SHOULD be specified in the `channels.tsv` file.
-        PowerLineFrequency: required
-        SoftwareFilters: required
+  fields:
+    iEEGReference: required
+    SamplingFrequency:
+      level: required
+      description_addendum: |
+        The sampling frequency of data channels that deviate from the main sampling
+        frequency SHOULD be specified in the `channels.tsv` file.
+    PowerLineFrequency: required
+    SoftwareFilters: required
 
 # Specific iEEG fields SHOULD be present
 iEEGMoreRecommended:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "ieeg"
-    fields:
-        DCOffsetCorrection: deprecated
-        HardwareFilters: recommended
-        ElectrodeManufacturer: recommended
-        ElectrodeManufacturersModelName: recommended
-        ECOGChannelCount: recommended
-        SEEGChannelCount: recommended
-        EEGChannelCount: recommended
-        EOGChannelCount: recommended
-        ECGChannelCount: recommended
-        EMGChannelCount: recommended
-        MiscChannelCount: recommended
-        TriggerChannelCount: recommended
-        RecordingDuration: recommended
-        RecordingType: recommended
-        EpochLength: recommended
-        iEEGGround: recommended
-        iEEGPlacementScheme: recommended
-        iEEGElectrodeGroups: recommended
-        SubjectArtefactDescription: recommended
+  fields:
+    DCOffsetCorrection: deprecated
+    HardwareFilters: recommended
+    ElectrodeManufacturer: recommended
+    ElectrodeManufacturersModelName: recommended
+    ECOGChannelCount: recommended
+    SEEGChannelCount: recommended
+    EEGChannelCount: recommended
+    EOGChannelCount: recommended
+    ECGChannelCount: recommended
+    EMGChannelCount: recommended
+    MiscChannelCount: recommended
+    TriggerChannelCount: recommended
+    RecordingDuration: recommended
+    RecordingType: recommended
+    EpochLength: recommended
+    iEEGGround: recommended
+    iEEGPlacementScheme: recommended
+    iEEGElectrodeGroups: recommended
+    SubjectArtefactDescription: recommended
 
 # Specific iEEG fields MAY be present
 iEEGOptional:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "ieeg"
-    fields:
-        ElectricalStimulation: optional
-        ElectricalStimulationParameters: optional
+  fields:
+    ElectricalStimulation: optional
+    ElectricalStimulationParameters: optional
 
 # General fields
 iEEGCoordsystemGeneral:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "coordsystem"
-    fields:
-        IntendedFor__ds_relative:
-            level: optional
-            description_addendum: |
-                If only a surface reconstruction is available, this should point to
-                the surface reconstruction file.
-                Note that this file should have the same coordinate system
-                specified in `iEEGCoordinateSystem`.
-                For example, **T1**: `'bids::sub-<label>/ses-<label>/anat/sub-01_T1w.nii.gz'`
-                **Surface**: `'bids::derivatives/surfaces/sub-<label>/ses-<label>/anat/
-                sub-01_hemi-R_desc-T1w_pial.surf.gii'`
-                **Operative photo**: `'bids::sub-<label>/ses-<label>/ieeg/
-                sub-0001_ses-01_acq-photo1_photo.jpg'`
-                **Talairach**: `'bids::derivatives/surfaces/sub-Talairach/ses-01/anat/
-                sub-Talairach_hemi-R_pial.surf.gii'`
+  fields:
+    IntendedFor__ds_relative:
+      level: optional
+      description_addendum: |
+        If only a surface reconstruction is available, this should point to
+        the surface reconstruction file.
+        Note that this file should have the same coordinate system
+        specified in `iEEGCoordinateSystem`.
+        For example, **T1**: `'bids::sub-<label>/ses-<label>/anat/sub-01_T1w.nii.gz'`
+        **Surface**: `'bids::derivatives/surfaces/sub-<label>/ses-<label>/anat/
+        sub-01_hemi-R_desc-T1w_pial.surf.gii'`
+        **Operative photo**: `'bids::sub-<label>/ses-<label>/ieeg/
+        sub-0001_ses-01_acq-photo1_photo.jpg'`
+        **Talairach**: `'bids::derivatives/surfaces/sub-Talairach/ses-01/anat/
+        sub-Talairach_hemi-R_pial.surf.gii'`
 
 # Fields relating to the iEEG electrode positions
 iEEGCoordsystemPositions:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "coordsystem"
-    fields:
-        iEEGCoordinateSystem: required
-        iEEGCoordinateUnits: required
-        iEEGCoordinateSystemDescription:
-            level: recommended
-            level_addendum: required if `iEEGCoordinateSystem` is `"Other"`
-        iEEGCoordinateProcessingDescription: recommended
-        iEEGCoordinateProcessingReference: recommended
+  fields:
+    iEEGCoordinateSystem: required
+    iEEGCoordinateUnits: required
+    iEEGCoordinateSystemDescription:
+      level: recommended
+      level_addendum: required if `iEEGCoordinateSystem` is `"Other"`
+    iEEGCoordinateProcessingDescription: recommended
+    iEEGCoordinateProcessingReference: recommended
 
 iEEGCoordsystemOther:
-    selectors:
+  selectors:
     - modality == "ieeg"
     - datatype == "ieeg"
     - suffix == "coordsystem"
     - '"iEEGCoordinateSystem" in sidecar'
     - sidecar.iEEGCoordinateSystem == "Other"
-    fields:
-        iEEGCoordinateSystemDescription: required
+  fields:
+    iEEGCoordinateSystemDescription: required

--- a/src/schema/rules/sidecars/meg.yaml
+++ b/src/schema/rules/sidecars/meg.yaml
@@ -4,258 +4,257 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Magnetoencephalography
 
 # Sidecar JSON (*_meg.json)
 MEGGeneric:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "meg"
-    fields:
-        TaskName:
-            level: required
-            description_addendum: |
-                A recommended convention is to name resting state task using labels
-                beginning with `rest`.
+  fields:
+    TaskName:
+      level: required
+      description_addendum: |
+        A recommended convention is to name resting state task using labels
+        beginning with `rest`.
 
 MEGRecommended:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "meg"
-    fields:
-        InstitutionName: recommended
-        InstitutionAddress: recommended
-        InstitutionalDepartmentName: recommended
-        Manufacturer:
-            level: recommended
-            description_addendum: |
-                For MEG scanners, this must be one of:
-                `"CTF"`, `"Elekta/Neuromag"`, `"BTi/4D"`, `"KIT/Yokogawa"`,
-                `"ITAB"`, `"KRISS"`, `"Other"`.
-                See [Appendix VII](SPEC_ROOT/99-appendices/07-meg-systems.md) for
-                preferred names.
-        ManufacturersModelName:
-            level: recommended
-            description_addendum: |
-                See [Appendix VII](SPEC_ROOT/99-appendices/07-meg-systems.md) for
-                preferred names.
-        SoftwareVersions: recommended
-        TaskDescription: recommended
-        Instructions:
-            level: recommended
-            description_addendum: |
-                This is especially important in context of resting state recordings and
-                distinguishing between eyes open and eyes closed paradigms.
-        CogAtlasID: recommended
-        CogPOID: recommended
-        DeviceSerialNumber: recommended
+  fields:
+    InstitutionName: recommended
+    InstitutionAddress: recommended
+    InstitutionalDepartmentName: recommended
+    Manufacturer:
+      level: recommended
+      description_addendum: |
+        For MEG scanners, this must be one of:
+        `"CTF"`, `"Elekta/Neuromag"`, `"BTi/4D"`, `"KIT/Yokogawa"`,
+        `"ITAB"`, `"KRISS"`, `"Other"`.
+        See [Appendix VII](SPEC_ROOT/99-appendices/07-meg-systems.md) for
+        preferred names.
+    ManufacturersModelName:
+      level: recommended
+      description_addendum: |
+        See [Appendix VII](SPEC_ROOT/99-appendices/07-meg-systems.md) for
+        preferred names.
+    SoftwareVersions: recommended
+    TaskDescription: recommended
+    Instructions:
+      level: recommended
+      description_addendum: |
+        This is especially important in context of resting state recordings and
+        distinguishing between eyes open and eyes closed paradigms.
+    CogAtlasID: recommended
+    CogPOID: recommended
+    DeviceSerialNumber: recommended
 
 # Specific MEG fields MUST be present
 MEGRequired:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "meg"
-    fields:
-        SamplingFrequency:
-            level: required
-            description_addendum: |
-                The sampling frequency of data channels that deviate from the main sampling
-                frequency SHOULD be specified in the `channels.tsv` file.
-        PowerLineFrequency: required
-        DewarPosition: required
-        SoftwareFilters: required
-        DigitizedLandmarks: required
-        DigitizedHeadPoints: required
+  fields:
+    SamplingFrequency:
+      level: required
+      description_addendum: |
+        The sampling frequency of data channels that deviate from the main sampling
+        frequency SHOULD be specified in the `channels.tsv` file.
+    PowerLineFrequency: required
+    DewarPosition: required
+    SoftwareFilters: required
+    DigitizedLandmarks: required
+    DigitizedHeadPoints: required
 
 # Specific MEG fields SHOULD be present
 MEGMoreRecommended:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "meg"
-    fields:
-        MEGChannelCount: recommended
-        MEGREFChannelCount: recommended
-        EEGChannelCount: recommended
-        ECOGChannelCount: recommended
-        SEEGChannelCount: recommended
-        EOGChannelCount: recommended
-        ECGChannelCount: recommended
-        EMGChannelCount: recommended
-        MiscChannelCount: recommended
-        TriggerChannelCount: recommended
-        RecordingDuration: recommended
-        RecordingType: recommended
-        EpochLength: recommended
-        ContinuousHeadLocalization: recommended
-        HeadCoilFrequency: recommended
-        MaxMovement: recommended
-        SubjectArtefactDescription: recommended
-        AssociatedEmptyRoom: recommended
-        HardwareFilters: recommended
+  fields:
+    MEGChannelCount: recommended
+    MEGREFChannelCount: recommended
+    EEGChannelCount: recommended
+    ECOGChannelCount: recommended
+    SEEGChannelCount: recommended
+    EOGChannelCount: recommended
+    ECGChannelCount: recommended
+    EMGChannelCount: recommended
+    MiscChannelCount: recommended
+    TriggerChannelCount: recommended
+    RecordingDuration: recommended
+    RecordingType: recommended
+    EpochLength: recommended
+    ContinuousHeadLocalization: recommended
+    HeadCoilFrequency: recommended
+    MaxMovement: recommended
+    SubjectArtefactDescription: recommended
+    AssociatedEmptyRoom: recommended
+    HardwareFilters: recommended
 
 # Specific EEG fields
 # NOTE: I'm not sure if "EEG is present" is enough to indicate simultaneous EEG/MEG.
 MEGwithEEG:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "meg"
     - dataset.modalities.includes("EEG")
-    fields:
-        EEGPlacementScheme: optional
-        CapManufacturer: optional
-        CapManufacturersModelName: optional
-        EEGReference: optional
+  fields:
+    EEGPlacementScheme: optional
+    CapManufacturer: optional
+    CapManufacturersModelName: optional
+    EEGReference: optional
 
 # MEG and EEG sensors
 MEGCoordsystemWithEEG:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    fields:
-        MEGCoordinateSystem: required
-        MEGCoordinateUnits: required
-        MEGCoordinateSystemDescription:
-            level: optional
-            level_addendum: required if `MEGCoordinateSystem` is `Other`
-        EEGCoordinateSystem:
-            level: optional
-            description_addendum: |
-                See [Recording EEG simultaneously with MEG]
-                (/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).
-                Preferably the same as the `MEGCoordinateSystem`.
-        EEGCoordinateUnits: optional
-        EEGCoordinateSystemDescription:
-            level: optional
-            level_addendum: required if `EEGCoordinateSystem` is `Other`
-            description_addendum: |
-                See [Recording EEG simultaneously with MEG]
-                (/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).
+  fields:
+    MEGCoordinateSystem: required
+    MEGCoordinateUnits: required
+    MEGCoordinateSystemDescription:
+      level: optional
+      level_addendum: required if `MEGCoordinateSystem` is `Other`
+    EEGCoordinateSystem:
+      level: optional
+      description_addendum: |
+        See [Recording EEG simultaneously with MEG]
+        (/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).
+        Preferably the same as the `MEGCoordinateSystem`.
+    EEGCoordinateUnits: optional
+    EEGCoordinateSystemDescription:
+      level: optional
+      level_addendum: required if `EEGCoordinateSystem` is `Other`
+      description_addendum: |
+        See [Recording EEG simultaneously with MEG]
+        (/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).
 
 # NOTE: The JSON isn't really a sidecar, so "sidecar.MEGCoordinateSystem" is misleading.
 MEGCoordsystemWithEEGMEGCoordinateSystem:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
     - '"MEGCoordinateSystem" in sidecar'
     - sidecar.MEGCoordinateSystem == "Other"
-    fields:
-        MEGCoordinateSystemDescription: required
+  fields:
+    MEGCoordinateSystemDescription: required
 
 # NOTE: Not sure if this requires simult. EEG
 MEGCoordsystemWithEEGEEGCoordinateSystem:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
     - '"EEGCoordinateSystem" in sidecar'
     - sidecar.EEGCoordinateSystem == "Other"
-    fields:
-        EEGCoordinateSystemDescription: required
+  fields:
+    EEGCoordinateSystemDescription: required
 
 # Head localization coils
 MEGCoordsystemHeadLocalizationCoils:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    fields:
-        HeadCoilCoordinates: optional
-        HeadCoilCoordinateSystem: optional
-        HeadCoilCoordinateUnits: optional
-        HeadCoilCoordinateSystemDescription:
-            level: optional
-            level_addendum: required if `HeadCoilCoordinateSystem` is `Other`
+  fields:
+    HeadCoilCoordinates: optional
+    HeadCoilCoordinateSystem: optional
+    HeadCoilCoordinateUnits: optional
+    HeadCoilCoordinateSystemDescription:
+      level: optional
+      level_addendum: required if `HeadCoilCoordinateSystem` is `Other`
 
 MEGCoordsystemHeadLocalizationCoilsHeadCoilCoordinateSystem:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
     - '"HeadCoilCoordinateSystem" in sidecar'
     - sidecar.HeadCoilCoordinateSystem == "Other"
-    fields:
-        HeadCoilCoordinateSystemDescription: required
+  fields:
+    HeadCoilCoordinateSystemDescription: required
 
 # Digitized head points
 MEGCoordsystemDigitizedHeadPoints:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    fields:
-        DigitizedHeadPoints: optional
-        DigitizedHeadPointsCoordinateSystem: optional
-        DigitizedHeadPointsCoordinateUnits: optional
-        DigitizedHeadPointsCoordinateSystemDescription:
-            level: optional
-            level_addendum: required if `DigitizedHeadPointsCoordinateSystem` is `Other`
+  fields:
+    DigitizedHeadPoints: optional
+    DigitizedHeadPointsCoordinateSystem: optional
+    DigitizedHeadPointsCoordinateUnits: optional
+    DigitizedHeadPointsCoordinateSystemDescription:
+      level: optional
+      level_addendum: required if `DigitizedHeadPointsCoordinateSystem` is `Other`
 
 MEGCoordsystemDigitizedHeadPointsDigitizedHeadPointsCoordinateSystem:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
     - '"DigitizedHeadPointsCoordinateSystem" in sidecar'
     - sidecar.DigitizedHeadPointsCoordinateSystem == "Other"
-    fields:
-        DigitizedHeadPointsCoordinateSystemDescription: required
+  fields:
+    DigitizedHeadPointsCoordinateSystemDescription: required
 
 # Anatomical MRI
 MEGCoordsystemAnatomicalMRI:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
     - dataset.modalities.includes("anat")
-    fields:
-        IntendedFor:
-            level: optional
-            description_addendum: |
-                This is used to identify the structural MRI(s),
-                possibly of different types if a list is specified,
-                to be used with the MEG recording.
+  fields:
+    IntendedFor:
+      level: optional
+      description_addendum: |
+        This is used to identify the structural MRI(s),
+        possibly of different types if a list is specified,
+        to be used with the MEG recording.
 
 # Anatomical landmarks
 MEGCoordsystemAnatomicalLandmarks:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    fields:
-        AnatomicalLandmarkCoordinates: optional
-        AnatomicalLandmarkCoordinateSystem:
-            level: optional
-            description_addendum: |
-                Preferably the same as the `MEGCoordinateSystem`.
-        AnatomicalLandmarkCoordinateUnits: optional
-        AnatomicalLandmarkCoordinateSystemDescription:
-            level: optional
-            level_addendum: required if `AnatomicalLandmarkCoordinateSystem` is `Other`
+  fields:
+    AnatomicalLandmarkCoordinates: optional
+    AnatomicalLandmarkCoordinateSystem:
+      level: optional
+      description_addendum: |
+        Preferably the same as the `MEGCoordinateSystem`.
+    AnatomicalLandmarkCoordinateUnits: optional
+    AnatomicalLandmarkCoordinateSystemDescription:
+      level: optional
+      level_addendum: required if `AnatomicalLandmarkCoordinateSystem` is `Other`
 
 MEGCoordsystemAnatomicalLandmarksAnatomicalLandmarkCoordinateSystem:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
     - '"AnatomicalLandmarkCoordinateSystem" in sidecar'
     - sidecar.AnatomicalLandmarkCoordinateSystem == "Other"
-    fields:
-        AnatomicalLandmarkCoordinateSystemDescription: required
+  fields:
+    AnatomicalLandmarkCoordinateSystemDescription: required
 
 # Fiducials information
 MEGCoordsystemFiducialsInformation:
-    selectors:
+  selectors:
     - modality == "meg"
     - datatype == "meg"
     - suffix == "coordsystem"
-    fields:
-        FiducialsDescription: optional
+  fields:
+    FiducialsDescription: optional

--- a/src/schema/rules/sidecars/micr.yaml
+++ b/src/schema/rules/sidecars/micr.yaml
@@ -4,92 +4,91 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # Device Hardware
 MicroscopyDeviceHardware:
-    selectors:
+  selectors:
     - modality == "micr"
     - datatype == "micr"
-    fields:
-        Manufacturer: recommended
-        ManufacturersModelName: recommended
-        DeviceSerialNumber: recommended
-        StationName: recommended
-        SoftwareVersions: recommended
-        InstitutionName: recommended
-        InstitutionAddress: recommended
-        InstitutionalDepartmentName: recommended
+  fields:
+    Manufacturer: recommended
+    ManufacturersModelName: recommended
+    DeviceSerialNumber: recommended
+    StationName: recommended
+    SoftwareVersions: recommended
+    InstitutionName: recommended
+    InstitutionAddress: recommended
+    InstitutionalDepartmentName: recommended
 
 # Image Acquisition
 MicroscopyImageAcquisition:
-    selectors:
+  selectors:
     - modality == "micr"
     - datatype == "micr"
-    fields:
-        PixelSize: required
-        PixelSizeUnits: required
-        Immersion: optional
-        NumericalAperture: optional
-        Magnification: optional
-        ImageAcquisitionProtocol: optional
-        OtherAcquisitionParameters: optional
+  fields:
+    PixelSize: required
+    PixelSizeUnits: required
+    Immersion: optional
+    NumericalAperture: optional
+    Magnification: optional
+    ImageAcquisitionProtocol: optional
+    OtherAcquisitionParameters: optional
 
 # Sample
 MicroscopySample:
-    selectors:
+  selectors:
     - modality == "micr"
     - datatype == "micr"
-    fields:
-        BodyPart:
-            level: recommended
-            description_addendum: |
-                From [DICOM Body Part
-                Examined](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_L.html#chapter_L)
-                (for example `"BRAIN"`).
-        BodyPartDetails: recommended
-        BodyPartDetailsOntology: optional
-        SampleEnvironment: recommended
-        SampleEmbedding: optional
-        SampleFixation: optional
-        SampleStaining: recommended
-        SamplePrimaryAntibody: recommended
-        SampleSecondaryAntibody: recommended
-        SliceThickness: optional
-        TissueDeformationScaling: optional
-        SampleExtractionProtocol: optional
-        SampleExtractionInstitution: optional
+  fields:
+    BodyPart:
+      level: recommended
+      description_addendum: |
+        From [DICOM Body Part
+        Examined](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_L.html#chapter_L)
+        (for example `"BRAIN"`).
+    BodyPartDetails: recommended
+    BodyPartDetailsOntology: optional
+    SampleEnvironment: recommended
+    SampleEmbedding: optional
+    SampleFixation: optional
+    SampleStaining: recommended
+    SamplePrimaryAntibody: recommended
+    SampleSecondaryAntibody: recommended
+    SliceThickness: optional
+    TissueDeformationScaling: optional
+    SampleExtractionProtocol: optional
+    SampleExtractionInstitution: optional
 
 # Chunk Transformations
 MicroscopyChunkTransformations:
-    selectors:
+  selectors:
     - modality == "micr"
     - datatype == "micr"
     - '"chunk" in entities'
-    fields:
-        ChunkTransformationMatrix:
-            level: recommended
-            level_addendum: if `chunk-<index>` is used in filenames
+  fields:
+    ChunkTransformationMatrix:
+      level: recommended
+      level_addendum: if `chunk-<index>` is used in filenames
 
 MicroscopyChunkTransformationsMatrixAxis:
-    selectors:
+  selectors:
     - modality == "micr"
     - datatype == "micr"
     - '"chunk" in entities'
     - '"ChunkTransformationMatrix" in sidecar'
-    fields:
-        ChunkTransformationMatrixAxis:
-            level: required
-            level_addendum: if `ChunkTransformationMatrix` is present
+  fields:
+    ChunkTransformationMatrixAxis:
+      level: required
+      level_addendum: if `ChunkTransformationMatrix` is present
 
 Photo:
-    selectors:
+  selectors:
     - modality == "micr"
     - suffix == "photo"
-    fields:
-        PhotoDescription: optional
-        IntendedFor:
-            level: optional
-            description_addendum: |
-                This field is OPTIONAL, in case the photos do not correspond
-                to any particular images, it does not have to be filled.
+  fields:
+    PhotoDescription: optional
+    IntendedFor:
+      level: optional
+      description_addendum: |
+        This field is OPTIONAL, in case the photos do not correspond
+        to any particular images, it does not have to be filled.

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -4,196 +4,195 @@
 # Assumptions: never need disjunction of selectors
 # Assumptions: top-to-bottom overrides is sufficient logic
 
-
 ---
 # MRI Common metadata fields
 MRIScannerHardware:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        Manufacturer:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
-        ManufacturersModelName:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
-        DeviceSerialNumber:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0018, 1000 `DeviceSerialNumber`.
-        StationName:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 1010 `Station Name`.
-        SoftwareVersions:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0018, 1020 `Software Versions`.
-        HardcopyDeviceSoftwareVersion: DEPRECATED
-        MagneticFieldStrength:
-            level: recommended, but required for Arterial Spin Labeling
-        ReceiveCoilName: recommended
-        ReceiveCoilActiveElements: recommended
-        GradientSetType: recommended
-        MRTransmitCoilSequence: recommended
-        MatrixCoilMode: recommended
-        CoilCombinationMethod: recommended
+  fields:
+    Manufacturer:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
+    ManufacturersModelName:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
+    DeviceSerialNumber:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0018, 1000 `DeviceSerialNumber`.
+    StationName:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 1010 `Station Name`.
+    SoftwareVersions:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0018, 1020 `Software Versions`.
+    HardcopyDeviceSoftwareVersion: DEPRECATED
+    MagneticFieldStrength:
+      level: recommended, but required for Arterial Spin Labeling
+    ReceiveCoilName: recommended
+    ReceiveCoilActiveElements: recommended
+    GradientSetType: recommended
+    MRTransmitCoilSequence: recommended
+    MatrixCoilMode: recommended
+    CoilCombinationMethod: recommended
 
 MRISequenceSpecifics:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        PulseSequenceType: recommended
-        ScanningSequence: recommended
-        SequenceVariant: recommended
-        ScanOptions: recommended
-        SequenceName: recommended
-        PulseSequenceDetails: recommended
-        NonlinearGradientCorrection: |
-            recommended, but required if [PET](./09-positron-emission-tomography.md) data are present
-        MRAcquisitionType: recommended, but required for Arterial Spin Labeling
-        MTState: recommended
-        MTOffsetFrequency: optional
-        MTPulseBandwidth: optional
-        MTNumberOfPulses: optional
-        MTPulseShape: optional
-        MTPulseDuration: optional
-        SpoilingState: recommended
-        SpoilingType: optional
-        SpoilingRFPhaseIncrement: optional
-        SpoilingGradientMoment: optional
-        SpoilingGradientDuration: optional
+  fields:
+    PulseSequenceType: recommended
+    ScanningSequence: recommended
+    SequenceVariant: recommended
+    ScanOptions: recommended
+    SequenceName: recommended
+    PulseSequenceDetails: recommended
+    NonlinearGradientCorrection: |
+      recommended, but required if [PET](./09-positron-emission-tomography.md) data are present
+    MRAcquisitionType: recommended, but required for Arterial Spin Labeling
+    MTState: recommended
+    MTOffsetFrequency: optional
+    MTPulseBandwidth: optional
+    MTNumberOfPulses: optional
+    MTPulseShape: optional
+    MTPulseDuration: optional
+    SpoilingState: recommended
+    SpoilingType: optional
+    SpoilingRFPhaseIncrement: optional
+    SpoilingGradientMoment: optional
+    SpoilingGradientDuration: optional
 
 PETMRISequenceSpecifics:
-    selectors:
+  selectors:
     - modality == "mri"
     - dataset.modalities.includes("PET")
-    fields:
-        NonlinearGradientCorrection: required
+  fields:
+    NonlinearGradientCorrection: required
 
 ASLMRISequenceSpecifics:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "perf"
-    fields:
-        MRAcquisitionType: required
+  fields:
+    MRAcquisitionType: required
 
 MTParameters:
-    selectors:
+  selectors:
     - sidecar.MTState == true
-    fields:
-        MTOffsetFrequency: recommended
-        MTPulseBandwidth: recommended
-        MTNumberOfPulses: recommended
-        MTPulseShape: recommended
-        MTPulseDuration: recommended
+  fields:
+    MTOffsetFrequency: recommended
+    MTPulseBandwidth: recommended
+    MTNumberOfPulses: recommended
+    MTPulseShape: recommended
+    MTPulseDuration: recommended
 
 SpoilingType:
-    selectors:
+  selectors:
     - sidecar.SpoilingState == true
-    fields:
-        SpoilingType: recommended
+  fields:
+    SpoilingType: recommended
 
 SpoilingRF:
-    selectors:
+  selectors:
     - '["RF", "COMBINED"].includes(sidecar.SpoilingType)'
-    fields:
-        SpoilingRFPhaseIncrement: recommended
+  fields:
+    SpoilingRFPhaseIncrement: recommended
 
 SpoilingGradient:
-    selectors:
+  selectors:
     - '["GRADIENT", "COMBINED"].includes(sidecar.SpoilingType)'
-    fields:
-        SpoilingGradientMoment: recommended
-        SpoilingGradientDuration: recommended
+  fields:
+    SpoilingGradientMoment: recommended
+    SpoilingGradientDuration: recommended
 
 MRISpatialEncoding:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        NumberShots: recommended
-        ParallelReductionFactorInPlane: recommended
-        ParallelAcquisitionTechnique: recommended
-        PartialFourier: recommended
-        PartialFourierDirection: recommended
-        EffectiveEchoSpacing:
-            level: recommended
-            level_addendum: required if corresponding fieldmap data present
-            description_addendum: <sup>2</sup>
-        MixingTime: recommended
+  fields:
+    NumberShots: recommended
+    ParallelReductionFactorInPlane: recommended
+    ParallelAcquisitionTechnique: recommended
+    PartialFourier: recommended
+    PartialFourierDirection: recommended
+    EffectiveEchoSpacing:
+      level: recommended
+      level_addendum: required if corresponding fieldmap data present
+      description_addendum: <sup>2</sup>
+    MixingTime: recommended
 
 PhaseEncodingDirectionRec:
-    selectors:
+  selectors:
     - modality == "mri"
     - suffix != "epi"
-    fields:
-        PhaseEncodingDirection:
-            level: recommended
-            level_addendum: |
-                required if corresponding fieldmap data is present
-                or when using multiple runs with different phase encoding directions
-                (which can be later used for field inhomogeneity correction).
-        TotalReadoutTime:
-            level: recommended
-            level_addendum: |
-                required if corresponding 'field/distortion' maps
-                acquired with opposing phase encoding directions are present
-                (see [Case 4: Multiple phase encoded
-                directions](#case-4-multiple-phase-encoded-directions-pepolar))
+  fields:
+    PhaseEncodingDirection:
+      level: recommended
+      level_addendum: |
+        required if corresponding fieldmap data is present
+        or when using multiple runs with different phase encoding directions
+        (which can be later used for field inhomogeneity correction).
+    TotalReadoutTime:
+      level: recommended
+      level_addendum: |
+        required if corresponding 'field/distortion' maps
+        acquired with opposing phase encoding directions are present
+        (see [Case 4: Multiple phase encoded
+        directions](#case-4-multiple-phase-encoded-directions-pepolar))
 PhaseEncodingDirectionReq:
-    selectors:
+  selectors:
     - modality == "mri"
     - suffix == "epi"
-    fields:
-        PhaseEncodingDirection:
-            level: required
-            issue:
-                name: PHASE_ENCODING_DIRECTION_MUST_DEFINE
-                issue: |
-                    You have to define 'PhaseEncodingDirection' for this file.
-        TotalReadoutTime:
-            level: required
-            description_addendum: <sup>3</sup>
-            issue:
-                name: TOTAL_READOUT_TIME_MUST_DEFINE
-                message: |
-                    You have to define 'TotalReadoutTime' for this file.
+  fields:
+    PhaseEncodingDirection:
+      level: required
+      issue:
+        name: PHASE_ENCODING_DIRECTION_MUST_DEFINE
+        issue: |
+          You have to define 'PhaseEncodingDirection' for this file.
+    TotalReadoutTime:
+      level: required
+      description_addendum: <sup>3</sup>
+      issue:
+        name: TOTAL_READOUT_TIME_MUST_DEFINE
+        message: |
+          You have to define 'TotalReadoutTime' for this file.
 
 MRITimingParameters:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        EchoTime:
-            level: recommended
-            level_addendum: |
-                required if corresponding fieldmap data is present,
-                or the data comes from a multi-echo sequence or Arterial Spin Labeling.
-            issue:
-                name: ECHO_TIME_NOT_DEFINED
-                message: |
-                    You must define 'EchoTime' for this file. 'EchoTime' is the echo time (TE)
-                    for the acquisition, specified in seconds. Corresponds to DICOM Tag
-                    0018, 0081 Echo Time (please note that the DICOM term is in milliseconds
-                    not seconds). The data type number may apply to files from any MRI modality
-                    concerned with a single value for this field, or to the files in a file
-                    collection where the value of this field is iterated using the echo entity.
-                    The data type array provides a value for each volume in a 4D dataset and
-                    should only be used when the volume timing is critical for interpretation
-                    of the data, such as in ASL or variable echo time fMRI sequences.
-        InversionTime: recommended
-        SliceTiming:
-            level: recommended
-            level_addendum: |
-                required for sparse sequences that do not have the `DelayTime` field set,
-                and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.
-        SliceEncodingDirection: recommended
-        DwellTime: recommended
+  fields:
+    EchoTime:
+      level: recommended
+      level_addendum: |
+        required if corresponding fieldmap data is present,
+        or the data comes from a multi-echo sequence or Arterial Spin Labeling.
+      issue:
+        name: ECHO_TIME_NOT_DEFINED
+        message: |
+          You must define 'EchoTime' for this file. 'EchoTime' is the echo time (TE)
+          for the acquisition, specified in seconds. Corresponds to DICOM Tag
+          0018, 0081 Echo Time (please note that the DICOM term is in milliseconds
+          not seconds). The data type number may apply to files from any MRI modality
+          concerned with a single value for this field, or to the files in a file
+          collection where the value of this field is iterated using the echo entity.
+          The data type array provides a value for each volume in a 4D dataset and
+          should only be used when the volume timing is critical for interpretation
+          of the data, such as in ASL or variable echo time fMRI sequences.
+    InversionTime: recommended
+    SliceTiming:
+      level: recommended
+      level_addendum: |
+        required for sparse sequences that do not have the `DelayTime` field set,
+        and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.
+    SliceEncodingDirection: recommended
+    DwellTime: recommended
 
 SliceTimingASL:
-    selectors:
+  selectors:
     - modality == "mri"
     - datatype == "perf"
     - '["asl", "m0scan"].includes(suffix)'
     - sidecar.MRAcquisitionType == "2D"
-    fields:
-        SliceTiming: required
+  fields:
+    SliceTiming: required
 
 # This is technically for sparse sequences only, but I don't know how to encode that.
 # SliceTimingSparse:
@@ -203,72 +202,71 @@ SliceTimingASL:
 #        SliceTiming: required
 
 MRIRFandContrast:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        NegativeContrast: optional
+  fields:
+    NegativeContrast: optional
 
 MRIFlipAngleLookLockerFalse:
-    selectors:
+  selectors:
     - modality == "mri"
     - sidecar.LookLocker == false
-    fields:
-        FlipAngle:
-            level: recommended
-            level_addendum: required if LookLocker is set to `true`
+  fields:
+    FlipAngle:
+      level: recommended
+      level_addendum: required if LookLocker is set to `true`
 
 MRIFlipAngleLookLockerTrue:
-    selectors:
+  selectors:
     - modality == "mri"
     - sidecar.LookLocker == true
-    fields:
-        FlipAngle:
-            level: required
-            issue:
-                name: LOOK_LOCKER_FLIP_ANGLE_MISSING
-                message: |
-                    You should define 'FlipAngle' for this file, in
-                    case of a LookLocker acquisition. 'FlipAngle' is the
-                    flip angle (FA) for the acquisition, specified in degrees.
-                    Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`. The data
-                    type number may apply to files from any MRI modality concerned
-                    with a single value for this field, or to the files in a file
-                    collection where the value of this field is iterated using the
-                    flip entity. The data type array provides a value for each volume
-                    in a 4D dataset and should only be used when the volume timing is
-                    critical for interpretation of the data, such as in ASL or
-                    variable flip angle fMRI sequences.
-
+  fields:
+    FlipAngle:
+      level: required
+      issue:
+        name: LOOK_LOCKER_FLIP_ANGLE_MISSING
+        message: |
+          You should define 'FlipAngle' for this file, in
+          case of a LookLocker acquisition. 'FlipAngle' is the
+          flip angle (FA) for the acquisition, specified in degrees.
+          Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`. The data
+          type number may apply to files from any MRI modality concerned
+          with a single value for this field, or to the files in a file
+          collection where the value of this field is iterated using the
+          flip entity. The data type array provides a value for each volume
+          in a 4D dataset and should only be used when the volume timing is
+          critical for interpretation of the data, such as in ASL or
+          variable flip angle fMRI sequences.
 
 MRISliceAcceleration:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        MultibandAccelerationFactor: recommended
+  fields:
+    MultibandAccelerationFactor: recommended
 
 MRIAnatomicalLandmarks:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        AnatomicalLandmarkCoordinates__mri: recommended
+  fields:
+    AnatomicalLandmarkCoordinates__mri: recommended
 
 MRIEchoPlanarImagingAndB0Mapping:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        B0FieldIdentifier: recommended
-        B0FieldSource: recommended
+  fields:
+    B0FieldIdentifier: recommended
+    B0FieldSource: recommended
 
 MRIInstitutionInformation:
-    selectors:
+  selectors:
     - modality == "mri"
-    fields:
-        InstitutionName:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
-        InstitutionAddress:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
-        InstitutionalDepartmentName:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
+  fields:
+    InstitutionName:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
+    InstitutionAddress:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
+    InstitutionalDepartmentName:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -1,256 +1,256 @@
 ---
 # PET common metadata fields
 PETScannerHardware:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "pet"
-    fields:
-        Manufacturer:
-            level: required
-            description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
-        ManufacturersModelName:
-            level: required
-            description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
-        Units:
-            level: required
-            description_addendum: |
-                SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL").
-                Corresponds to DICOM Tag 0054, 1001 `Units`.
-        InstitutionName:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
-        InstitutionAddress:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
-        InstitutionalDepartmentName:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
-        BodyPart:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
+  fields:
+    Manufacturer:
+      level: required
+      description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
+    ManufacturersModelName:
+      level: required
+      description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
+    Units:
+      level: required
+      description_addendum: |
+        SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL").
+        Corresponds to DICOM Tag 0054, 1001 `Units`.
+    InstitutionName:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
+    InstitutionAddress:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
+    InstitutionalDepartmentName:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
+    BodyPart:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
 
 PETRadioChemistry:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "pet"
-    fields:
-        TracerName:
-            level: required
-            description_addendum: |
-                Corresponds to DICOM Tags (0008,0105) `Mapping Resource` and
-                (0008,0122) `Mapping Resource Name`.
-        TracerRadionuclide:
-            level: required
-            description_addendum: |
-                Corresponds to DICOM Tags (0008,0104) `CodeValue` and (0008,0104) `CodeMeaning`.
-        InjectedRadioactivity:
-            level: required
-        InjectedRadioactivityUnits:
-            level: required
-        InjectedMass:
-            level: required
-        InjectedMassUnits:
-            level: required
-        SpecificRadioactivity:
-            level: required
-        SpecificRadioactivityUnits:
-            level: required
-        ModeOfAdministration:
-            level: required
-        TracerRadLex:
-            level: recommended
-        TracerSNOMED:
-            level: recommended
-        TracerMolecularWeight:
-            level: recommended
-        TracerMolecularWeightUnits:
-            level: recommended
-        InjectedMassPerWeight:
-            level: recommended
-        InjectedMassPerWeightUnits:
-            level: recommended
-        SpecificRadioactivityMeasTime:
-            level: recommended
-        MolarActivity:
-            level: recommended
-        MolarActivityUnits:
-            level: recommended
-        MolarActivityMeasTime:
-            level: recommended
-        InfusionRadioactivity:
-            level: recommended
-            level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
-        InfusionStart:
-            level: recommended
-            level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
-        InfusionSpeed:
-            level: recommended
-            level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
-        InfusionSpeedUnits:
-            level: recommended
-            level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
-        InjectedVolume:
-            level: recommended
-            level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
-        Purity:
-            level: recommended
+  fields:
+    TracerName:
+      level: required
+      description_addendum: |
+        Corresponds to DICOM Tags (0008,0105) `Mapping Resource` and
+        (0008,0122) `Mapping Resource Name`.
+    TracerRadionuclide:
+      level: required
+      description_addendum: |
+        Corresponds to DICOM Tags (0008,0104) `CodeValue` and (0008,0104) `CodeMeaning`.
+    InjectedRadioactivity:
+      level: required
+    InjectedRadioactivityUnits:
+      level: required
+    InjectedMass:
+      level: required
+    InjectedMassUnits:
+      level: required
+    SpecificRadioactivity:
+      level: required
+    SpecificRadioactivityUnits:
+      level: required
+    ModeOfAdministration:
+      level: required
+    TracerRadLex:
+      level: recommended
+    TracerSNOMED:
+      level: recommended
+    TracerMolecularWeight:
+      level: recommended
+    TracerMolecularWeightUnits:
+      level: recommended
+    InjectedMassPerWeight:
+      level: recommended
+    InjectedMassPerWeightUnits:
+      level: recommended
+    SpecificRadioactivityMeasTime:
+      level: recommended
+    MolarActivity:
+      level: recommended
+    MolarActivityUnits:
+      level: recommended
+    MolarActivityMeasTime:
+      level: recommended
+    InfusionRadioactivity:
+      level: recommended
+      level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
+    InfusionStart:
+      level: recommended
+      level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
+    InfusionSpeed:
+      level: recommended
+      level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
+    InfusionSpeedUnits:
+      level: recommended
+      level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
+    InjectedVolume:
+      level: recommended
+      level_addendum: required if ModeOfAdministration is `'bolus-infusion'`
+    Purity:
+      level: recommended
 
 # PET Infusion conditionally required entities
 EntitiesBolusMetadata:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "pet"
     - sidecar.ModeOfAdministration == 'bolus-infusion'
-    fields:
-        InfusionRadioactivity:
-            level: required
-        InfusionStart:
-            level: required
-        InfusionSpeed:
-            level: required
-        InfusionSpeedUnits:
-            level: required
-        InjectedVolume:
-            level: required
+  fields:
+    InfusionRadioactivity:
+      level: required
+    InfusionStart:
+      level: required
+    InfusionSpeed:
+      level: required
+    InfusionSpeedUnits:
+      level: required
+    InjectedVolume:
+      level: required
 
 PETPharmaceuticals:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "pet"
-    fields:
-        PharmaceuticalName:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag (0008,0034) `Intervention Drug Name`.
-        PharmaceuticalDoseAmount:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag (0008,0028) `Intervention Drug Dose`.
-        PharmaceuticalDoseUnits:
-            level: recommended
-        PharmaceuticalDoseRegimen:
-            level: recommended
-        PharmaceuticalDoseTime:
-            level: recommended
-            description_addendum: |
-                Corresponds to a combination of DICOM Tags (0008,0027) `Intervention Drug Stop Time`
-                and (0008,0035) `Intervention Drug Start Time`.
-        Anaesthesia:
-            level: optional
+  fields:
+    PharmaceuticalName:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag (0008,0034) `Intervention Drug Name`.
+    PharmaceuticalDoseAmount:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag (0008,0028) `Intervention Drug Dose`.
+    PharmaceuticalDoseUnits:
+      level: recommended
+    PharmaceuticalDoseRegimen:
+      level: recommended
+    PharmaceuticalDoseTime:
+      level: recommended
+      description_addendum: |
+        Corresponds to a combination of DICOM Tags (0008,0027) `Intervention Drug Stop Time`
+        and (0008,0035) `Intervention Drug Start Time`.
+    Anaesthesia:
+      level: optional
 
 PETTime:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "pet"
-    fields:
-        TimeZero:
-            level: required
-        ScanStart:
-            level: required
-        InjectionStart:
-            level: required
-            description_addendum: Corresponds to DICOM Tag (0018,1072) `Radiopharmaceutical Start Time`.
-        FrameTimesStart:
-            level: required
-        FrameDuration:
-            level: required
-        InjectionEnd:
-            level: recommended
-            description_addendum: |
-                Corresponds to DICOM Tag (0018,1073) `Radiopharmaceutical Stop Time`
-                converted to seconds relative to TimeZero.
-        ScanDate:
-            level: deprecated
-            description_addendum: Corresponds to DICOM Tag (0008,0022) `Acquisition Date`.
+  fields:
+    TimeZero:
+      level: required
+    ScanStart:
+      level: required
+    InjectionStart:
+      level: required
+      description_addendum: Corresponds to DICOM Tag (0018,1072) `Radiopharmaceutical Start Time`.
+    FrameTimesStart:
+      level: required
+    FrameDuration:
+      level: required
+    InjectionEnd:
+      level: recommended
+      description_addendum: |
+        Corresponds to DICOM Tag (0018,1073) `Radiopharmaceutical Stop Time`
+        converted to seconds relative to TimeZero.
+    ScanDate:
+      level: deprecated
+      description_addendum: Corresponds to DICOM Tag (0008,0022) `Acquisition Date`.
 
 PETReconstruction:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "pet"
-    fields:
-        AcquisitionMode:
-            level: required
-        ImageDecayCorrected:
-            level: required
-        ImageDecayCorrectionTime:
-            level: required
-        ReconMethodName:
-            level: required
-            description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
-        ReconMethodParameterLabels:
-            level: required
-            description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
-        ReconMethodParameterUnits:
-            level: required
-            description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
-        ReconMethodParameterValues:
-            level: required
-            description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
-        ReconFilterType:
-            level: required
-            description_addendum: This partly matches the DICOM Tag (0018,1210) `Convolution Kernel`.
-        ReconFilterSize:
-            level: required
-            description_addendum: This partly matches the DICOM Tag (0018,1210) `Convolution Kernel`.
-        AttenuationCorrection:
-            level: required
-            description_addendum: This corresponds to DICOM Tag (0054,1101) `Attenuation Correction Method`.
-        ReconMethodImplementationVersion:
-            level: recommended
-        AttenuationCorrectionMethodReference:
-            level: recommended
-        ScaleFactor:
-            level: recommended
-        ScatterFraction:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag (0054,1323) `Scatter Fraction Factor`.
-        DecayCorrectionFactor:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag (0054,1321) `Decay Factor`.
-        DoseCalibrationFactor:
-            level: recommended
-            description_addendum: Corresponds to DICOM Tag (0054,1322) `Dose Calibration Factor`.
-        PromptRate:
-            level: recommended
-        SinglesRate:
-            level: recommended
+  fields:
+    AcquisitionMode:
+      level: required
+    ImageDecayCorrected:
+      level: required
+    ImageDecayCorrectionTime:
+      level: required
+    ReconMethodName:
+      level: required
+      description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
+    ReconMethodParameterLabels:
+      level: required
+      description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
+    ReconMethodParameterUnits:
+      level: required
+      description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
+    ReconMethodParameterValues:
+      level: required
+      description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
+    ReconFilterType:
+      level: required
+      description_addendum: This partly matches the DICOM Tag (0018,1210) `Convolution Kernel`.
+    ReconFilterSize:
+      level: required
+      description_addendum: This partly matches the DICOM Tag (0018,1210) `Convolution Kernel`.
+    AttenuationCorrection:
+      level: required
+      description_addendum: This corresponds to DICOM Tag (0054,1101) `Attenuation Correction Method`.
+    ReconMethodImplementationVersion:
+      level: recommended
+    AttenuationCorrectionMethodReference:
+      level: recommended
+    ScaleFactor:
+      level: recommended
+    ScatterFraction:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag (0054,1323) `Scatter Fraction Factor`.
+    DecayCorrectionFactor:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag (0054,1321) `Decay Factor`.
+    DoseCalibrationFactor:
+      level: recommended
+      description_addendum: Corresponds to DICOM Tag (0054,1322) `Dose Calibration Factor`.
+    PromptRate:
+      level: recommended
+    SinglesRate:
+      level: recommended
 
 BloodRecording:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
-    fields:
-        PlasmaAvail: required
-        MetaboliteAvail: required
-        WholeBloodAvail: required
-        DispersionCorrected: required
-        WithdrawalRate: recommended
-        TubingType: recommended
-        TubingLength: recommended
-        DispersionConstant: recommended
-        Haematocrit: recommended
-        BloodDensity: recommended
+  fields:
+    PlasmaAvail: required
+    MetaboliteAvail: required
+    WholeBloodAvail: required
+    DispersionCorrected: required
+    WithdrawalRate: recommended
+    TubingType: recommended
+    TubingLength: recommended
+    DispersionConstant: recommended
+    Haematocrit: recommended
+    BloodDensity: recommended
 
 BloodPlasmaFreeFraction:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
     - sidecar.PlasmaAvail == true
-    fields:
-        PlasmaFreeFraction:
-            level: recommended
-            level_addendum: if `PlasmaAvail` is `true`
-        PlasmaFreeFractionMethod:
-            level: recommended
-            level_addendum: if `PlasmaAvail` is `true`
+  fields:
+    PlasmaFreeFraction:
+      level: recommended
+      level_addendum: if `PlasmaAvail` is `true`
+    PlasmaFreeFractionMethod:
+      level: recommended
+      level_addendum: if `PlasmaAvail` is `true`
 
 BloodMetaboliteMethod:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
     - sidecar.MetaboliteAvail == true
-    fields:
-        MetaboliteMethod:
-            level: required
-            level_addendum: if `MetaboliteAvail` is `true`
-        MetaboliteRecoveryCorrectionApplied:
-            level: required
-            level_addendum: if `MetaboliteAvail` is `true`
+  fields:
+    MetaboliteMethod:
+      level: required
+      level_addendum: if `MetaboliteAvail` is `true`
+    MetaboliteRecoveryCorrectionApplied:
+      level: required
+      level_addendum: if `MetaboliteAvail` is `true`

--- a/src/schema/rules/tabular_data/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/tabular_data/derivatives/common_derivatives.yaml
@@ -1,8 +1,8 @@
 ---
 SegmentationLookup:
   selectors:
-  - dataset.DatasetType == "derivative"
-  - '["dseg", "probseg"].includes(suffix)'
+    - dataset.DatasetType == "derivative"
+    - '["dseg", "probseg"].includes(suffix)'
   columns:
     index: required
     name__segmentations: required

--- a/src/schema/rules/tabular_data/eeg.yaml
+++ b/src/schema/rules/tabular_data/eeg.yaml
@@ -1,43 +1,43 @@
 ---
 EEGChannels:
-    selectors:
+  selectors:
     - datatype == "eeg"
     - suffix == "channels"
     - extension == ".tsv"
-    initial_columns:
+  initial_columns:
     - name__channels
     - type__eeg_channels
     - units
-    columns:
-        name__channels: required
-        type__eeg_channels: required
-        units: required
-        description: optional
-        sampling_frequency: optional
-        reference__eeg: optional
-        low_cutoff: optional
-        high_cutoff: optional
-        notch: optional
-        status: optional
-        status_description: optional
-    additional_columns: allowed_if_defined
+  columns:
+    name__channels: required
+    type__eeg_channels: required
+    units: required
+    description: optional
+    sampling_frequency: optional
+    reference__eeg: optional
+    low_cutoff: optional
+    high_cutoff: optional
+    notch: optional
+    status: optional
+    status_description: optional
+  additional_columns: allowed_if_defined
 
 EEGElectrodes:
-    selectors:
+  selectors:
     - datatype == "eeg"
     - suffix == "electrodes"
     - extension == ".tsv"
-    initial_columns:
+  initial_columns:
     - name__electrodes
     - x
     - y
     - z
-    columns:
-        name__electrodes: required
-        x: required
-        y: required
-        z: required
-        type__electrodes: recommended
-        material: recommended
-        impedance: recommended
-    additional_columns: allowed_if_defined
+  columns:
+    name__electrodes: required
+    x: required
+    y: required
+    z: required
+    type__electrodes: recommended
+    material: recommended
+    impedance: recommended
+  additional_columns: allowed_if_defined

--- a/src/schema/rules/tabular_data/ieeg.yaml
+++ b/src/schema/rules/tabular_data/ieeg.yaml
@@ -1,49 +1,49 @@
 ---
 iEEGChannels:
-    selectors:
+  selectors:
     - datatype == "ieeg"
     - suffix == "channels"
     - extension == ".tsv"
-    initial_columns:
+  initial_columns:
     - name__channels
     - type__ieeg_channels
     - units
-    columns:
-        name__channels: required
-        type__ieeg_channels: required
-        units: required
-        low_cutoff: required
-        high_cutoff: required
-        reference__ieeg: optional
-        group__channel: optional
-        sampling_frequency: optional
-        description: optional
-        notch: optional
-        status: optional
-        status_description: optional
-    additional_columns: allowed_if_defined
+  columns:
+    name__channels: required
+    type__ieeg_channels: required
+    units: required
+    low_cutoff: required
+    high_cutoff: required
+    reference__ieeg: optional
+    group__channel: optional
+    sampling_frequency: optional
+    description: optional
+    notch: optional
+    status: optional
+    status_description: optional
+  additional_columns: allowed_if_defined
 
 iEEGElectrodes:
-    selectors:
+  selectors:
     - datatype == "ieeg"
     - suffix == "electrodes"
     - extension == ".tsv"
-    initial_columns:
+  initial_columns:
     - name__electrodes
     - x
     - y
     - z
-    columns:
-        name__electrodes: required
-        x: required
-        y: required
-        z: required
-        size: required
-        material: recommended
-        manufacturer: recommended
-        group__channel: recommended
-        hemisphere: recommended
-        type__electrodes: optional
-        impedance: optional
-        dimension: optional
-    additional_columns: allowed_if_defined
+  columns:
+    name__electrodes: required
+    x: required
+    y: required
+    z: required
+    size: required
+    material: recommended
+    manufacturer: recommended
+    group__channel: recommended
+    hemisphere: recommended
+    type__electrodes: optional
+    impedance: optional
+    dimension: optional
+  additional_columns: allowed_if_defined

--- a/src/schema/rules/tabular_data/meg.yaml
+++ b/src/schema/rules/tabular_data/meg.yaml
@@ -1,23 +1,23 @@
 ---
 MEGChannels:
-    selectors:
+  selectors:
     - datatype == "meg"
     - suffix == "channels"
     - extension == ".tsv"
-    initial_columns:
+  initial_columns:
     - name__channels
     - type__meg_channels
     - units
-    columns:
-        name__channels: required
-        type__meg_channels: required
-        units: required
-        description: optional
-        sampling_frequency: optional
-        low_cutoff: optional
-        high_cutoff: optional
-        notch: optional
-        software_filters: optional
-        status: optional
-        status_description: optional
-    additional_columns: allowed_if_defined
+  columns:
+    name__channels: required
+    type__meg_channels: required
+    units: required
+    description: optional
+    sampling_frequency: optional
+    low_cutoff: optional
+    high_cutoff: optional
+    notch: optional
+    software_filters: optional
+    status: optional
+    status_description: optional
+  additional_columns: allowed_if_defined

--- a/src/schema/rules/tabular_data/perf.yaml
+++ b/src/schema/rules/tabular_data/perf.yaml
@@ -1,8 +1,8 @@
 ---
 ASLContext:
-    selectors:
+  selectors:
     - datatype == "perf"
     - suffix == "aslcontext"
-    columns:
-        volume_type: required
-    additional_columns: not_allowed
+  columns:
+    volume_type: required
+  additional_columns: not_allowed

--- a/src/schema/rules/tabular_data/pet.yaml
+++ b/src/schema/rules/tabular_data/pet.yaml
@@ -1,52 +1,52 @@
 ---
 Blood:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
-    columns:
-        time: required
-        plasma_radioactivity: optional
-        metabolite_parent_fraction: optional
-        metabolite_polar_fraction: optional
-        hplc_recovery_fractions: optional
-        whole_blood_radioactivity: optional
+  columns:
+    time: required
+    plasma_radioactivity: optional
+    metabolite_parent_fraction: optional
+    metabolite_polar_fraction: optional
+    hplc_recovery_fractions: optional
+    whole_blood_radioactivity: optional
 
 BloodPlasma:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
     - '"PlasmaAvail" in sidecar'
-    columns:
-        plasma_radioactivity: required
+  columns:
+    plasma_radioactivity: required
 
 BloodMetabolite:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
     - '"MetaboliteAvail" in sidecar'
-    columns:
-        metabolite_parent_fraction: required
-        metabolite_polar_fraction: recommended
+  columns:
+    metabolite_parent_fraction: required
+    metabolite_polar_fraction: recommended
 
 BloodMetaboliteCorrection:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
     - '"MetaboliteRecoveryCorrectionApplied" in sidecar'
     - sidecar.MetaboliteRecoveryCorrectionApplied == true
-    columns:
-        hplc_recovery_fractions: required
+  columns:
+    hplc_recovery_fractions: required
 
 BloodWholeBlood:
-    selectors:
+  selectors:
     - modality == "pet"
     - suffix == "blood"
     - extension == ".tsv"
     - '"WholeBloodAvail" in sidecar'
     - sidecar.WholeBloodAvail == true
-    columns:
-        whole_blood_radioactivity: required
+  columns:
+    whole_blood_radioactivity: required

--- a/src/schema/rules/tabular_data/physio.yaml
+++ b/src/schema/rules/tabular_data/physio.yaml
@@ -1,9 +1,9 @@
 ---
 PhysioColumns:
-    selectors:
+  selectors:
     - suffix == "physio"
-    columns:
-        cardiac: optional
-        respiratory: optional
-        trigger: optional
-    additional_columns: allowed
+  columns:
+    cardiac: optional
+    respiratory: optional
+    trigger: optional
+  additional_columns: allowed

--- a/src/schema/rules/tabular_data/task.yaml
+++ b/src/schema/rules/tabular_data/task.yaml
@@ -1,18 +1,18 @@
 ---
 TaskEvents:
-    selectors:
+  selectors:
     - '"task" in entities'
     - suffix == "events"
-    columns:
-        onset: required
-        duration: required
-        sample: optional
-        trial_type: optional
-        response_time: optional
-        value: optional
-        HED: optional
-        stim_file: optional
-    additional_columns: allowed
-    initial_columns:
+  columns:
+    onset: required
+    duration: required
+    sample: optional
+    trial_type: optional
+    response_time: optional
+    value: optional
+    HED: optional
+    stim_file: optional
+  additional_columns: allowed
+  initial_columns:
     - onset
     - duration

--- a/src/schema/rules/tabular_metadata.yaml
+++ b/src/schema/rules/tabular_metadata.yaml
@@ -1,18 +1,18 @@
 ---
 scans:
   suffixes:
-  - scans
+    - scans
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
   entities:
     subject: required
-    session: optional  # session is required if session is present in the dataset.
-sessions:  # This file may only exist if session is present in the dataset.
+    session: optional # session is required if session is present in the dataset.
+sessions: # This file may only exist if session is present in the dataset.
   suffixes:
-  - sessions
+    - sessions
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
   entities:
     subject: required

--- a/src/schema/rules/top_level_files.yaml
+++ b/src/schema/rules/top_level_files.yaml
@@ -2,33 +2,33 @@
 README:
   required: true
   extensions:
-  - ""
-  - .md
-  - .rst
-  - .txt
+    - ''
+    - .md
+    - .rst
+    - .txt
 CHANGES:
   required: false
   extensions:
-  - ""
+    - ''
 LICENSE:
   required: false
   extensions:
-  - ""
+    - ''
 dataset_description:
   required: true
   extensions:
-  - .json
+    - .json
 genetic_info:
   required: false
   extensions:
-  - .json
+    - .json
 participants:
   required: false
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json
 samples:
   required: false
   extensions:
-  - .tsv
-  - .json
+    - .tsv
+    - .json


### PR DESCRIPTION
This PR updates the options passed to the yamllinter to make it more amenable to code formatting tools such as prettier. Additionally settings relating to formatting are stored in an `.editorconfig` file manage prettier and text editor behavior.

One side effect of this is to eliminate the non-nestedness that was enforced in our 2-space formatted yaml files, e.g.:
```yaml
MyCoolExample:
  CheckOutThisCooList:
  - a
  - b
  - c
```
is now displayed as:
```yaml
MyCoolExample:
  CheckOutThisCooList:
    - a
    - b
    - c
```

Be horrified.