### PR TITLE
[SCHEMA] Change modalities to instruments

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -36,8 +36,8 @@ context:
                 ignored:
                     description: "Set of ignored files"
                     type: array
-                modalities:
-                    description: "Modalities present in the dataset"
+                instruments:
+                    description: "Instruments used in the dataset"
                     type: array
                 subjects:
                     description: "Collections of subjects in dataset"

--- a/src/schema/objects/common_principles.yaml
+++ b/src/schema/objects/common_principles.yaml
@@ -83,6 +83,18 @@ index:
   description: |
     A nonnegative integer, possibly prefixed with arbitrary number of 0s for consistent indentation,
     for example, it is `01` in `run-01` following `run-<index>` specification.
+instrument:
+  name: Instrument
+  display_name: Instrument
+  description: |
+    The class of technology used to record data to a file.
+    For example, both EEG and iEEG are data types using biopotential amplification.
+
+    Instrument is not directly reflected in the BIDS filesystem,
+    though the specification itself generally nests **data type**-specific sections within
+    **instrument**-specific chapters.
+
+    **Data types** reflects specific applications of **instruments**.
 label:
   name: label
   display_name: label

--- a/src/schema/objects/instruments.yaml
+++ b/src/schema/objects/instruments.yaml
@@ -1,17 +1,13 @@
 ---
-# This file describes modalities supported by BIDS.
+# This file describes instruments (technologies) supported by BIDS.
 mri:
   display_name: Magnetic Resonance Imaging
   description: |
     Data acquired with an MRI scanner.
-eeg:
-  display_name: Electroencephalography
+bioamp:
+  display_name: Biopotential Amplification
   description: |
-    Data acquired with EEG.
-ieeg:
-  display_name: Intracranial Electroencephalography
-  description: |
-    Data acquired with iEEG.
+    Data acquired with (i)EEG.
 meg:
   display_name: Magnetoencephalography
   description: |

--- a/src/schema/rules/instruments.yaml
+++ b/src/schema/rules/instruments.yaml
@@ -7,11 +7,9 @@ mri:
   - fmap
   - func
   - perf
-eeg:
+bioamp:
   datatypes:
   - eeg
-ieeg:
-  datatypes:
   - ieeg
 meg:
   datatypes:


### PR DESCRIPTION
Closes #593 and possibly closes #1141. The problem that this PR attempts to address is that the definition of "modality" in Common Principles conflicts with its use in the schema.

Changes proposed:

- Rename `schema/objects/modalities.yaml` to `schema/objects/instruments.yaml`.
- Rename `schema/rules/modalities.yaml` to `schema/rules/instruments.yaml`.
- Add a new "Instrument" element to the Common Principles.