### PR TITLE
[INFRA] auto ignore dependencies update from change log

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
+# Documentation
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "exclude-from-changelog"


### PR DESCRIPTION
I suspect we will ignore from the changelog most the dependabot PRs rather than the other way around, so this should do the trick.