### PR TITLE
[FIX] Use SPEC_ROOT/src_path in `make_filename_template`

### DIFF
--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -61,7 +61,7 @@ def _get_source_path(level=1):
     return caller.f_locals["_Context__self"]["page"].file.src_path
 
 
-def make_filename_template(pdf_format=False, **kwargs):
+def make_filename_template(src_path=None, pdf_format=False, **kwargs):
     """Generate a filename template snippet from the schema, based on specific filters.
 
     Parameters
@@ -83,9 +83,13 @@ def make_filename_template(pdf_format=False, **kwargs):
         A multiline string containing the filename templates for file types
         in the schema, after filtering.
     """
+    if src_path is None:
+        src_path = _get_source_path()
+
     schema_obj = schema.load_schema()
     codeblock = render.make_filename_template(
         schema_obj,
+        src_path=src_path,
         pdf_format=pdf_format,
         **kwargs,
     )

--- a/tools/schemacode/bidsschematools/render.py
+++ b/tools/schemacode/bidsschematools/render.py
@@ -281,17 +281,15 @@ def make_filename_template(
 
     Notes
     -----
-    This function doesn't use src_path, because the hyperlinks use absolute paths to HTML files.
-    It would be nice, at some point, to use src_path in conjunction with paths to markdown files,
-    like other functions do, instead.
+    This function links to HTML files, rather than markdown files.
     """
     if not schema:
         schema = load_schema()
 
     schema = Namespace(filter_schema(schema.to_dict(), **kwargs))
     entity_order = schema["rules"]["entities"]
-    entities_path = "/99-appendices/09-entities.html"
-    glossary_path = "/99-appendices/14-glossary.html"
+    entities_path = "SPEC_ROOT/99-appendices/09-entities.html"
+    glossary_path = "SPEC_ROOT/99-appendices/14-glossary.html"
 
     paragraph = ""
     # Parent directories


### PR DESCRIPTION
Closes None, but fixes an error introduced in #1228.

Changes proposed:

- Use relative paths in links to glossary and entities pages created by `make_filename_template`.
