### PR TITLE
CI: Skip PyPI tests on PR builds

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -91,6 +91,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Publish Python Package
     needs: [test]
+    if: github.event_name == 'push'
     strategy:
       matrix:
         os: ["ubuntu-latest"]
@@ -109,7 +110,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
       - name: "Upload to PyPI (on tags)"
-        if: ${{ startsWith(github.ref, 'refs/tags/schema-') }}
+        if: startsWith(github.ref, 'refs/tags/schema-')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
Secrets aren't shared with PRs for good reason. Only run PyPI tests on push builds.