### PR TITLE
[STY] Link to glossary in tables with many valid values

### DIFF
--- a/tools/schemacode/bidsschematools/render.py
+++ b/tools/schemacode/bidsschematools/render.py
@@ -669,7 +669,12 @@ def make_suffix_table(schema, suffixes, src_path=None, tablefmt="github"):
 
 
 def make_obj_table(
-    subschema, field_info, field_type, src_path=None, tablefmt="github", n_values_to_combine=15
+    subschema,
+    field_info,
+    field_type,
+    src_path=None,
+    tablefmt="github",
+    n_values_to_combine=15,
 ):
     """Make a generic table describing objects in the schema."""
     # Use the "name" field in the table, to allow for filenames to not match
@@ -901,7 +906,13 @@ def make_subobject_table(schema, object_tuple, field_info, src_path=None, tablef
     return table_str
 
 
-def make_columns_table(schema, column_info, src_path=None, tablefmt="github", n_values_to_combine=15):
+def make_columns_table(
+    schema,
+    column_info,
+    src_path=None,
+    tablefmt="github",
+    n_values_to_combine=15,
+):
     """Produce columns table (markdown) based on requested fields.
 
     Parameters

--- a/tools/schemacode/bidsschematools/render.py
+++ b/tools/schemacode/bidsschematools/render.py
@@ -19,6 +19,7 @@ logging.basicConfig(format="%(asctime)-15s [%(levelname)8s] %(message)s")
 
 ENTITIES_PATH = "SPEC_ROOT/99-appendices/09-entities.html"
 GLOSSARY_PATH = "SPEC_ROOT/99-appendices/14-glossary.html"
+GLOSSARY_PATH_MD = "SPEC_ROOT/99-appendices/14-glossary.md"
 TYPE_CONVERTER = {
     "associated_data": "associated data",
     "columns": "column",
@@ -707,7 +708,7 @@ def make_obj_table(
             "enum" in subschema[field].keys()
             and len(subschema[field]["enum"]) >= n_values_to_combine
         ):
-            glossary_entry = f"{GLOSSARY_PATH}#objects.{field}"
+            glossary_entry = f"{GLOSSARY_PATH_MD}#objects.{field}"
             valid_values_str = (
                 "For a list of valid values for this field, see the "
                 f"[associated glossary entry]({glossary_entry})."
@@ -976,7 +977,7 @@ def make_columns_table(
             "enum" in subschema[field].keys()
             and len(subschema[field]["enum"]) >= n_values_to_combine
         ):
-            glossary_entry = f"{GLOSSARY_PATH}#objects.{field_type}.{field}"
+            glossary_entry = f"{GLOSSARY_PATH_MD}#objects.{field_type}.{field}"
             valid_values_str = (
                 "For a list of valid values for this field, see the "
                 f"[associated glossary entry]({glossary_entry})."


### PR DESCRIPTION
Closes None. Stems from https://github.com/bids-standard/bids-specification/pull/802#discussion_r957695260.

Changes proposed:

- In cases where metadata fields or columns allow only certain values (i.e., `enum`s) and there are a large number of those valid values (>15), link to the associated glossary entry instead.