### PR TITLE
SCHEMA: Refactor filename template rendering, normalize requirement level in entity overrides

### DIFF
--- a/src/schema/rules/datatypes/meg.yaml
+++ b/src/schema/rules/datatypes/meg.yaml
@@ -38,8 +38,7 @@ calibration:
     subject: required
     session: optional
     acquisition:
-      requirement: required
-      type: string
+      level: required
       enum:
         - calibration
 
@@ -54,8 +53,7 @@ crosstalk:
     subject: required
     session: optional
     acquisition:
-      requirement: required
-      type: string
+      level: required
       enum:
         - crosstalk
 

--- a/tools/schemacode/bidsschematools/render.py
+++ b/tools/schemacode/bidsschematools/render.py
@@ -375,7 +375,7 @@ def make_filename_template(
             # we use the "suffix" variable and expect a table later in the spec
             if len(group["suffixes"]) >= n_dupes_to_combine:
                 suffixes = [
-                    f"_{lt}"
+                    lt
                     + utils._link_with_html(
                         "suffix",
                         html_path=GLOSSARY_PATH + ".html",

--- a/tools/schemacode/bidsschematools/render.py
+++ b/tools/schemacode/bidsschematools/render.py
@@ -340,36 +340,40 @@ def make_filename_template(
         for group in datatypes[datatype].values():
             ent_string = ""
             for ent in schema.rules.entities:
-                if ent in group.entities:
-                    ent_obj = group.entities[ent]
-                    if isinstance(ent_obj, str):
-                        ent_obj = {"level": ent_obj}
-                    entity = {**schema.objects.entities[ent], **ent_obj}
-                    if "enum" in entity:
-                        # Link full entity
-                        pattern = utils._link_with_html(
-                            _format_entity(entity, lt, gt),
-                            html_path=f"{ENTITIES_PATH}.html",
-                            heading=entity["name"],
-                            pdf_format=pdf_format,
-                        )
-                    else:
-                        # Link entity and format separately
-                        entity["name"] = utils._link_with_html(
-                            entity["name"],
-                            html_path=f"{ENTITIES_PATH}.html",
-                            heading=entity["name"],
-                            pdf_format=pdf_format,
-                        )
-                        entity["format"] = utils._link_with_html(
-                            entity.get("format", "label"),
-                            html_path=f"{ENTITIES_PATH}.html",
-                            heading=entity.get("format", "label"),
-                            pdf_format=pdf_format,
-                        )
-                        pattern = _format_entity(entity, lt, gt)
+                if ent not in group.entities:
+                    continue
 
-                    ent_string = _add_entity(ent_string, pattern, entity["level"])
+                # Add level and any overrides to entity
+                ent_obj = group.entities[ent]
+                if isinstance(ent_obj, str):
+                    ent_obj = {"level": ent_obj}
+                entity = {**schema.objects.entities[ent], **ent_obj}
+
+                if "enum" in entity:
+                    # Link full entity
+                    pattern = utils._link_with_html(
+                        _format_entity(entity, lt, gt),
+                        html_path=f"{ENTITIES_PATH}.html",
+                        heading=entity["name"],
+                        pdf_format=pdf_format,
+                    )
+                else:
+                    # Link entity and format separately
+                    entity["name"] = utils._link_with_html(
+                        entity["name"],
+                        html_path=f"{ENTITIES_PATH}.html",
+                        heading=entity["name"],
+                        pdf_format=pdf_format,
+                    )
+                    entity["format"] = utils._link_with_html(
+                        entity.get("format", "label"),
+                        html_path=f"{ENTITIES_PATH}.html",
+                        heading=entity.get("format", "label"),
+                        pdf_format=pdf_format,
+                    )
+                    pattern = _format_entity(entity, lt, gt)
+
+                ent_string = _add_entity(ent_string, pattern, entity["level"])
 
             # In cases of large numbers of suffixes,
             # we use the "suffix" variable and expect a table later in the spec

--- a/tools/schemacode/bidsschematools/render.py
+++ b/tools/schemacode/bidsschematools/render.py
@@ -372,22 +372,17 @@ def make_filename_template(
                     )
                     ent_format += ">" if pdf_format else "&gt;"
 
-                if ent in group["entities"]:
-                    if isinstance(group["entities"][ent], dict):
-                        if "enum" in group["entities"][ent].keys():
-                            # Overwrite the filename pattern using valid values
-                            ent_format = "{}-&lt;{}&gt;".format(
-                                schema["objects"]["entities"][ent]["name"],
-                                "|".join(group["entities"][ent]["enum"]),
-                            )
-
-                        string = _add_entity(
-                            string,
-                            ent_format,
-                            group["entities"][ent]["requirement"],
-                        )
-                    else:
-                        string = _add_entity(string, ent_format, group["entities"][ent])
+                if ent in group.entities:
+                    level = group.entities[ent]
+                    if isinstance(level, dict):
+                        fmt = level.get("format")
+                        enum = level.get("enum")
+                        level = level["level"]
+                        if enum is not None:
+                            fmt = "|".join(enum)
+                        if fmt is not None:
+                            ent_format = f"{objects.entities[ent].name}-&lt;{fmt}&gt;"
+                    string = _add_entity(string, ent_format, level)
 
             # In cases of large numbers of suffixes,
             # we use the "suffix" variable and expect a table later in the spec
@@ -580,7 +575,7 @@ def make_entity_table(schema, tablefmt="github", src_path=None, **kwargs):
             dtype_row = [dtype] + ([""] * len(all_entities))
             for ent, ent_info in dtype_spec.get("entities", {}).items():
                 if isinstance(ent_info, Mapping):
-                    requirement_level = ent_info["requirement"]
+                    requirement_level = ent_info["level"]
                 else:
                     requirement_level = ent_info
 

--- a/tools/schemacode/bidsschematools/render.py
+++ b/tools/schemacode/bidsschematools/render.py
@@ -305,30 +305,20 @@ def make_filename_template(
     suffix_key_table = value_key_table(schema.objects.suffixes)
     ext_key_table = value_key_table(schema.objects.extensions)
 
-    paragraph = ""
     # Parent directories
-    sub_string = (
-        f'{schema["objects"]["entities"]["subject"]["name"]}-'
-        f'<{schema["objects"]["entities"]["subject"]["format"]}>'
-    )
-    paragraph += utils._link_with_html(
-        sub_string,
+    sub_string = utils._link_with_html(
+        _format_entity(schema.objects.entities.subject, lt, gt),
         html_path=ENTITIES_PATH + ".html",
         heading="sub",
         pdf_format=pdf_format,
     )
-    paragraph += "/\n\t["
-    ses_string = (
-        f'{schema["objects"]["entities"]["session"]["name"]}-'
-        f'<{schema["objects"]["entities"]["session"]["format"]}>'
-    )
-    paragraph += utils._link_with_html(
-        ses_string,
+    ses_string = utils._link_with_html(
+        _format_entity(schema.objects.entities.session, lt, gt),
         html_path=ENTITIES_PATH + ".html",
         heading="ses",
         pdf_format=pdf_format,
     )
-    paragraph += "/]\n"
+    lines = [f"{sub_string}/", f"\t[{ses_string}/]"]
 
     datatypes = schema.rules.datatypes
 
@@ -338,14 +328,13 @@ def make_filename_template(
         if datatype == "derivatives":
             continue
 
-        paragraph += "\t\t"
-        paragraph += utils._link_with_html(
+        datatype_string = utils._link_with_html(
             datatype,
             html_path=GLOSSARY_PATH + ".html",
             heading=f"{datatype.lower()}-datatypes",
             pdf_format=pdf_format,
         )
-        paragraph += "/\n"
+        lines.append(f"\t\t{datatype_string}/")
 
         # Unique filename patterns
         for group in datatypes[datatype].values():
@@ -433,13 +422,13 @@ def make_filename_template(
                 pdf_format=pdf_format,
             )
 
-            paragraph += "".join(
-                f"\t\t\t{ent_string}_{suffix}{extension}\n"
+            lines.extend(
+                f"\t\t\t{ent_string}_{suffix}{extension}"
                 for suffix in sorted(suffixes)
                 for extension in sorted(extensions)
             )
 
-    paragraph = paragraph.rstrip()
+    paragraph = "\n".join(lines)
     if pdf_format:
         codeblock = f"Template:\n```Text\n{paragraph}\n```"
     else:


### PR DESCRIPTION
In #1112, I noticed that the overrides of entity formats in MEG used `requirement` instead of the `level` we use elsewhere. They also redundantly include `type: string`, as all entities are string-typed.

When working on the rendering fixes, it seemed we were repeating ourselves a bit and one thing led to another. The fundamental changes:

1) Instead of constructing a `paragraph` string bit by bit, we now build entire lines and create a `lines` list that can be joined once at the end.
2) The functionality in `_format_entity()` function was written several times, so that's abstracted.
3) Constructing the filename line is made simpler by collecting the entity stem, set of suffixes and set of extensions, and iterating at the last moment.