### PR TITLE
[SCHEMA] Add click to bidsschematools requirements

### DIFF
--- a/tools/schemacode/setup.cfg
+++ b/tools/schemacode/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
+    click
     pyyaml
     importlib_resources; python_version < "3.9"
 packages = find:


### PR DESCRIPTION
The `bst` command provided by the bidsschematools package requires click in order to run, yet click is not listed as a dependency in `setup.cfg`.  This PR fixes that.