### PR TITLE
[INFRA] test bidsschematools  against osx and windows as well

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -51,8 +51,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: macos-latest
+            python-version: 3
+          - os: windows-latest
+            python-version: 3
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
Inspired by https://github.com/bids-standard/bids-specification/issues/1294 and thus should fail one test on windows ATM.

attn @TheChymera . I am ok if fix for #1294 would simply absorb this PR