### PR TITLE
[FIX][SCHEMA] Conditionals for PET Recon and Single Frame Support

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2655,11 +2655,16 @@ ScatterFraction:
   display_name: Scatter Fraction
   description: |
     Scatter fraction for each frame (Units: 0-100%).
-  type: array
-  items:
-    type: number
+  anyOf:
+  - type: array
+    items:
+      type: number
+      minimum: 0
+      maximum: 100
+  - type: number
     minimum: 0
     maximum: 100
+
 SequenceName:
   name: SequenceName
   display_name: Sequence Name

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -150,6 +150,9 @@ PETReconstruction:
       description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
     ReconMethodParameterValues:
       level: required
+      level_addendum: |
+        Required if `ReconMethodParameterLabels` does not contain 'none', optional if 
+        no labels exist.
       description_addendum: This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`.
     ReconFilterType:
       level: required
@@ -175,6 +178,14 @@ PETReconstruction:
     PromptRate: recommended
     SinglesRate: recommended
     RandomRate: recommended
+
+EntitiesReconMethodParameterValues:
+  selectors:
+    - modality == "pet"
+    - suffix == "pet"
+    - 'none' in sidecar.ReconMethodParameterLabels
+  fields:
+    ReconMethodParameterValues: optional
 
 BloodRecording:
   selectors:


### PR DESCRIPTION
Updates conditionals for:

`ReconMethodParameterValues`

Attempts to change schema to be amenable to numbers where an array would be a length of 1.

E.g. for single frame images -> `ScatterFraction=1.5` and would both be valid `ScatterFraction[1.5]`.

Not married to that second change, I think it would be better to update the wording of the spec so we only ever look for arrays, see changes to `ScatterFraction` in `src.schema.objects.metadata` in this PR.