### PR TITLE
[SCHEMA] Invert logic of bold onset hints

### DIFF
--- a/src/schema/rules/checks/hints.yaml
+++ b/src/schema/rules/checks/hints.yaml
@@ -10,7 +10,7 @@ SuspiciouslyLongBOLDDesign:
     - suffix == "bold"
     - associations.events != null
   checks:
-    - max(associations.events.onset) > nifti_header.pixdim[4] * nifti_header.dim[4]
+    - max(associations.events.onset) < nifti_header.pixdim[4] * nifti_header.dim[4]
 
 SuspiciouslyShortBOLDDesign:
   issue:
@@ -23,4 +23,4 @@ SuspiciouslyShortBOLDDesign:
     - suffix == "bold"
     - associations.events != null
   checks:
-    - max(associations.events.onset) < nifti_header.pixdim[4] * nifti_header.dim[4] / 2
+    - max(associations.events.onset) > nifti_header.pixdim[4] * nifti_header.dim[4] / 2


### PR DESCRIPTION
We only want to generate these messages when the check returns false.