### PR TITLE
[SCHEMA] Refactor namespace

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: "Run tests"
         run: |
           python -m pytest -vs --pyargs bidsschematools -m "not validate_schema" \
-              --cov-append --cov-report=xml --cov=bidsschematools
+              --cov-append --cov-report=xml --cov=bidsschematools --doctest-modules
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/tools/schemacode/bidsschematools/schema.py
+++ b/tools/schemacode/bidsschematools/schema.py
@@ -8,9 +8,8 @@ from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path
 
-import yaml
-
 from . import __bids_version__, __version__, utils
+from .types import Namespace
 
 lgr = utils.get_logger()
 # Basic settings for output, for now just basic
@@ -45,124 +44,6 @@ def _get_bids_version(bids_schema_dir):
             # Then we don't know, really.
             bids_version = bids_schema_dir
     return bids_version
-
-
-def _expand_dots(entry):
-    # Helper function for expand
-    key, val = entry
-    if "." in key:
-        init, post = key.split(".", 1)
-        return init, dict([_expand_dots((post, val))])
-    return key, expand(val)
-
-
-def expand(element):
-    """Expand a dict, recursively, to replace dots in keys with recursive dictionaries
-
-    Examples
-    --------
-    >>> expand({"a": 1, "b.c": 2, "d": [{"e": 3, "f.g": 4}]})
-    {'a': 1, 'b': {'c': 2}, 'd': [{'e': 3, 'f': {'g': 4}}]}
-    """
-    if isinstance(element, dict):
-        return {key: val for key, val in map(_expand_dots, element.items())}
-    elif isinstance(element, list):
-        return [expand(el) for el in element]
-    return element
-
-
-class Namespace(Mapping):
-    """Provides recursive attribute style access to a dict-like structure
-
-    Examples
-    --------
-    >>> ns = Namespace.build({"a": 1, "b.c": "val"})
-    >>> ns.a
-    1
-    >>> ns["a"]
-    1
-    >>> ns.b
-    <Namespace {'c': 'val'}>
-    >>> ns["b"]
-    <Namespace {'c': 'val'}>
-    >>> ns.b.c
-    'val'
-    >>> ns["b.c"]
-    'val'
-    >>> ns["b"]["c"]
-    'val'
-    >>> ns.b["c"]
-    'val'
-    >>> ns["b"].c
-    'val'
-    """
-
-    def __init__(self, *args, **kwargs):
-        self._properties = dict(*args, **kwargs)
-
-    def to_dict(self):
-        ret = {}
-        for key, val in self._properties.items():
-            if isinstance(val, Namespace):
-                val = val.to_dict()
-            ret[key] = val
-        return ret
-
-    def __deepcopy__(self, memo):
-        return self.build(self.to_dict())
-
-    @classmethod
-    def build(cls, mapping):
-        """Expand mapping recursively and return as namespace"""
-        return cls(expand(mapping))
-
-    def __getattribute__(self, key):
-        # Return actual properties first
-        err = None
-        try:
-            return super().__getattribute__(key)
-        except AttributeError as e:
-            err = e
-
-        # Utilize __getitem__ but keep original error on failure
-        try:
-            return self[key]
-        except KeyError:
-            raise err
-
-    def __getitem__(self, key):
-        key, dot, subkey = key.partition(".")
-        val = self._properties[key]
-        if isinstance(val, dict):
-            val = self.__class__(val)
-        if dot:
-            # Recursive step
-            val = val[subkey]
-        return val
-
-    def __repr__(self):
-        return f"<Namespace {self._properties}>"
-
-    def __len__(self):
-        return len(self._properties)
-
-    def __iter__(self):
-        return iter(self._properties)
-
-    @classmethod
-    def from_directory(cls, path, fmt="yaml"):
-        mapping = {}
-        fullpath = Path(path)
-        if fmt == "yaml":
-            for subpath in sorted(fullpath.iterdir()):
-                if subpath.is_dir():
-                    submapping = cls.from_directory(subpath)
-                    if submapping:
-                        mapping[subpath.name] = submapping
-                elif subpath.name.endswith("yaml"):
-                    mapping[subpath.stem] = yaml.safe_load(subpath.read_text())
-            return cls.build(mapping)
-        raise NotImplementedError(f"Unknown format: {fmt}")
 
 
 def dereference_mapping(schema, struct):

--- a/tools/schemacode/bidsschematools/schema.py
+++ b/tools/schemacode/bidsschematools/schema.py
@@ -1,5 +1,4 @@
 """Schema loading- and processing-related functions."""
-import json
 import logging
 import os
 import re
@@ -114,10 +113,9 @@ def load_schema(schema_path=None):
 
 
 def export_schema(schema):
-    schema_dict = schema.to_dict()
-    schema_dict["schema_version"] = __version__
-    schema_dict["bids_version"] = __bids_version__
-    return json.dumps(schema_dict)
+    versioned = Namespace.build({"schema_version": __version__, "bids_version": __bids_version__})
+    versioned.update(schema)
+    return versioned.to_json()
 
 
 def filter_schema(schema, **kwargs):

--- a/tools/schemacode/bidsschematools/schema.py
+++ b/tools/schemacode/bidsschematools/schema.py
@@ -5,7 +5,6 @@ import re
 from collections.abc import Mapping
 from copy import deepcopy
 from functools import lru_cache
-from pathlib import Path
 
 from . import __bids_version__, __version__, utils
 from .types import Namespace
@@ -102,7 +101,7 @@ def load_schema(schema_path=None):
     """
     if schema_path is None:
         schema_path = utils.get_schema_path()
-    schema = Namespace.from_directory(Path(schema_path))
+    schema = Namespace.from_directory(schema_path)
     if not schema.objects:
         raise ValueError(f"objects subdirectory path not found in {schema_path}")
     if not schema.rules:

--- a/tools/schemacode/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/bidsschematools/tests/test_schema.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 
 import pytest
 
-from bidsschematools import __bids_version__, schema
+from bidsschematools import __bids_version__, schema, types
 
 
 def test__get_bids_version(tmp_path):
@@ -220,8 +220,8 @@ def test_dereferencing():
         },
     }
 
-    sch = schema.Namespace.build(orig)
-    expanded = schema.expand(orig)
+    sch = types.Namespace.build(orig)
+    expanded = types.namespace.expand(orig)
     dereffed = schema.dereference_mapping(sch, expanded)
     assert dereffed == {
         "raw": {
@@ -278,8 +278,8 @@ def test_dereferencing():
         },
     }
 
-    sch = schema.Namespace.build(orig)
-    expanded = schema.expand(orig)
+    sch = types.Namespace.build(orig)
+    expanded = types.namespace.expand(orig)
     dereffed = schema.dereference_mapping(sch, expanded)
     assert dereffed == {
         "_DERIV_ENTS": {

--- a/tools/schemacode/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/bidsschematools/tests/test_schema.py
@@ -186,7 +186,7 @@ def test_dereferencing():
             "Property2": "value4",
         },
     }
-    dereffed = schema.dereference_mapping(orig, orig.copy())
+    dereffed = schema.dereference(orig)
     assert dereffed == {
         "ReferencedObject": {
             "Property1": "value1",
@@ -221,8 +221,7 @@ def test_dereferencing():
     }
 
     sch = types.Namespace.build(orig)
-    expanded = types.namespace.expand(orig)
-    dereffed = schema.dereference_mapping(sch, expanded)
+    dereffed = schema.dereference(sch)
     assert dereffed == {
         "raw": {
             "func": {
@@ -279,8 +278,7 @@ def test_dereferencing():
     }
 
     sch = types.Namespace.build(orig)
-    expanded = types.namespace.expand(orig)
-    dereffed = schema.dereference_mapping(sch, expanded)
+    dereffed = schema.dereference(sch)
     assert dereffed == {
         "_DERIV_ENTS": {
             "space": "optional",

--- a/tools/schemacode/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/bidsschematools/tests/test_schema.py
@@ -41,6 +41,9 @@ def test_load_schema(schema_dir):
     schema_obj = schema.load_schema(schema_dir)
     assert isinstance(schema_obj, Mapping)
 
+    # Check that it is fully dereferenced
+    assert "$ref" not in str(schema_obj)
+
 
 def test_object_definitions(schema_obj):
     """Ensure that object definitions in the schema contain required fields."""

--- a/tools/schemacode/bidsschematools/types/__init__.py
+++ b/tools/schemacode/bidsschematools/types/__init__.py
@@ -1,0 +1,1 @@
+from .namespace import Namespace

--- a/tools/schemacode/bidsschematools/types/namespace.py
+++ b/tools/schemacode/bidsschematools/types/namespace.py
@@ -235,15 +235,16 @@ class Namespace(MutableMapping):
 
     @classmethod
     def from_directory(cls, path, fmt="yaml"):
-        mapping = {}
-        fullpath = Path(path)
         if fmt == "yaml":
-            for subpath in sorted(fullpath.iterdir()):
-                if subpath.is_dir():
-                    submapping = cls.from_directory(subpath)
-                    if submapping:
-                        mapping[subpath.name] = submapping
-                elif subpath.name.endswith("yaml"):
-                    mapping[subpath.stem] = yaml.safe_load(subpath.read_text())
-            return cls.build(mapping)
+            return cls.build(_read_yaml_dir(Path(path)))
         raise NotImplementedError(f"Unknown format: {fmt}")
+
+
+def _read_yaml_dir(path: Path) -> dict:
+    mapping = {}
+    for subpath in sorted(path.iterdir()):
+        if subpath.is_dir():
+            mapping[subpath.name] = _read_yaml_dir(subpath)
+        elif subpath.name.endswith("yaml"):
+            mapping[subpath.stem] = yaml.safe_load(subpath.read_text())
+    return mapping

--- a/tools/schemacode/bidsschematools/types/namespace.py
+++ b/tools/schemacode/bidsschematools/types/namespace.py
@@ -1,0 +1,123 @@
+"""Namespace types"""
+from collections.abc import Mapping
+from pathlib import Path
+
+import yaml
+
+
+def _expand_dots(entry):
+    # Helper function for expand
+    key, val = entry
+    if "." in key:
+        init, post = key.split(".", 1)
+        return init, dict([_expand_dots((post, val))])
+    return key, expand(val)
+
+
+def expand(element):
+    """Expand a dict, recursively, to replace dots in keys with recursive dictionaries
+
+    Examples
+    --------
+    >>> expand({"a": 1, "b.c": 2, "d": [{"e": 3, "f.g": 4}]})
+    {'a': 1, 'b': {'c': 2}, 'd': [{'e': 3, 'f': {'g': 4}}]}
+    """
+    if isinstance(element, dict):
+        return {key: val for key, val in map(_expand_dots, element.items())}
+    elif isinstance(element, list):
+        return [expand(el) for el in element]
+    return element
+
+
+class Namespace(Mapping):
+    """Provides recursive attribute style access to a dict-like structure
+
+    Examples
+    --------
+    >>> ns = Namespace.build({"a": 1, "b.c": "val"})
+    >>> ns.a
+    1
+    >>> ns["a"]
+    1
+    >>> ns.b
+    <Namespace {'c': 'val'}>
+    >>> ns["b"]
+    <Namespace {'c': 'val'}>
+    >>> ns.b.c
+    'val'
+    >>> ns["b.c"]
+    'val'
+    >>> ns["b"]["c"]
+    'val'
+    >>> ns.b["c"]
+    'val'
+    >>> ns["b"].c
+    'val'
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._properties = dict(*args, **kwargs)
+
+    def to_dict(self):
+        ret = {}
+        for key, val in self._properties.items():
+            if isinstance(val, Namespace):
+                val = val.to_dict()
+            ret[key] = val
+        return ret
+
+    def __deepcopy__(self, memo):
+        return self.build(self.to_dict())
+
+    @classmethod
+    def build(cls, mapping):
+        """Expand mapping recursively and return as namespace"""
+        return cls(expand(mapping))
+
+    def __getattribute__(self, key):
+        # Return actual properties first
+        err = None
+        try:
+            return super().__getattribute__(key)
+        except AttributeError as e:
+            err = e
+
+        # Utilize __getitem__ but keep original error on failure
+        try:
+            return self[key]
+        except KeyError:
+            raise err
+
+    def __getitem__(self, key):
+        key, dot, subkey = key.partition(".")
+        val = self._properties[key]
+        if isinstance(val, dict):
+            val = self.__class__(val)
+        if dot:
+            # Recursive step
+            val = val[subkey]
+        return val
+
+    def __repr__(self):
+        return f"<Namespace {self._properties}>"
+
+    def __len__(self):
+        return len(self._properties)
+
+    def __iter__(self):
+        return iter(self._properties)
+
+    @classmethod
+    def from_directory(cls, path, fmt="yaml"):
+        mapping = {}
+        fullpath = Path(path)
+        if fmt == "yaml":
+            for subpath in sorted(fullpath.iterdir()):
+                if subpath.is_dir():
+                    submapping = cls.from_directory(subpath)
+                    if submapping:
+                        mapping[subpath.name] = submapping
+                elif subpath.name.endswith("yaml"):
+                    mapping[subpath.stem] = yaml.safe_load(subpath.read_text())
+            return cls.build(mapping)
+        raise NotImplementedError(f"Unknown format: {fmt}")

--- a/tools/schemacode/bidsschematools/types/namespace.py
+++ b/tools/schemacode/bidsschematools/types/namespace.py
@@ -1,11 +1,12 @@
 """Namespace types"""
+import typing as ty
 from collections.abc import ItemsView, KeysView, Mapping, MutableMapping, ValuesView
 from pathlib import Path
 
 import yaml
 
 
-def _expand_dots(entry):
+def _expand_dots(entry: ty.Tuple[str, ty.Any]) -> ty.Tuple[str, ty.Any]:
     # Helper function for expand
     key, val = entry
     if "." in key:
@@ -149,7 +150,7 @@ class Namespace(MutableMapping):
     def __init__(self, *args, **kwargs):
         self._properties = dict(*args, **kwargs)
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         ret = {}
         for key, val in self._properties.items():
             if isinstance(val, Namespace):
@@ -175,13 +176,13 @@ class Namespace(MutableMapping):
         """Expand mapping recursively and return as namespace"""
         return cls(expand(mapping))
 
-    def items(self, *, level=1):
+    def items(self, *, level=1) -> NsItemsView:
         return NsItemsView(self, level)
 
-    def keys(self, *, level=1):
+    def keys(self, *, level=1) -> NsKeysView:
         return NsKeysView(self, level)
 
-    def values(self, *, level=1):
+    def values(self, *, level=1) -> NsValuesView:
         return NsValuesView(self, level)
 
     def __getattribute__(self, key):
@@ -198,7 +199,7 @@ class Namespace(MutableMapping):
         except KeyError:
             raise err
 
-    def _get_mapping(self, key: str) -> tuple:
+    def _get_mapping(self, key: str) -> ty.Tuple[Mapping, str]:
         subkeys = key.split(".")
         mapping = self._properties
         for subkey in subkeys[:-1]:

--- a/tools/schemacode/bidsschematools/validator.py
+++ b/tools/schemacode/bidsschematools/validator.py
@@ -845,10 +845,13 @@ def validate_bids(
 
     Examples
     --------
-    >>> from bidsschematools import validator
-    >>> bids_paths = '~/.data2/datalad/000026/rawdata'
-    >>> schema_version='{module_path}/data/schema/'
-    >>> validator.validate_bids(bids_paths, schema_version=schema_version)"
+
+    ::
+
+        from bidsschematools import validator
+        bids_paths = '~/.data2/datalad/000026/rawdata'
+        schema_version='{module_path}/data/schema/'
+        validator.validate_bids(bids_paths, schema_version=schema_version)
 
     Notes
     -----


### PR DESCRIPTION
While working on #1288 a few changes to namespace became necessary/convenient. However, since these are bug-fixes and enhancements, not backwards-incompatible changes, I wanted to break these changes out into their own PR, to keep that one focused.

The changes are:

1) Making it a mutable mapping makes chains of references more tractable. e.g. if objB refers to objA and objC refers to objB, updating the reference schema during dereferencing becomes necessary to avoid multiple passes.
2) Adding a `level` keyword to items/keys/values allows you to do something like `schema.objects.keys(level=2)` to get things like `metadata.RepetitionTime` and `columns.participant_id`.