### PR TITLE
SCHEMA: Use lazy loading

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,3 @@
 ignore:
-    - "*/*/tests/*"
     - "**/tests/*"
+    - "*/_lazy.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,3 @@
 ignore:
     - "**/tests/*"
-    - "*/_lazy.py"
+    - "**/_lazy.py"

--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install build dependencies"
         run: pip install --upgrade build twine
       - name: "Install test dependencies on tag"
-        run: pip install --upgrade pytest pyyaml pandas tabulate markdown-it-py
+        run: pip install --upgrade pytest
         if: ${{ startsWith(github.ref, 'refs/tags/schema-') }}
       - name: "Build archive on tag"
         run: pytest tools/schemacode/bidsschematools -k make_archive

--- a/tools/schemacode/bidsschematools/__init__.py
+++ b/tools/schemacode/bidsschematools/__init__.py
@@ -1,5 +1,5 @@
 """A Python package for working with the BIDS schema."""
-import lazy_loader as lazy
+from . import _lazy
 
 try:
     from importlib.resources import as_file, files
@@ -21,4 +21,4 @@ subpackages = [
     "utils",
     "validator",
 ]
-__getattr__, __dir__, _ = lazy.attach(__name__, subpackages)
+__getattr__, __dir__, _ = _lazy.attach(__name__, subpackages)

--- a/tools/schemacode/bidsschematools/__init__.py
+++ b/tools/schemacode/bidsschematools/__init__.py
@@ -1,4 +1,6 @@
 """A Python package for working with the BIDS schema."""
+import lazy_loader as lazy
+
 try:
     from importlib.resources import as_file, files
 except ImportError:  # PY<3.9
@@ -11,3 +13,12 @@ with as_file(version_file) as f:
 bids_version_file = files("bidsschematools.data") / "schema" / "BIDS_VERSION"
 with as_file(bids_version_file) as f:
     __bids_version__ = f.read_text().strip()
+
+subpackages = [
+    "render",
+    "schema",
+    "types",
+    "utils",
+    "validator",
+]
+__getattr__, __dir__, _ = lazy.attach(__name__, subpackages)

--- a/tools/schemacode/bidsschematools/_lazy.py
+++ b/tools/schemacode/bidsschematools/_lazy.py
@@ -1,0 +1,260 @@
+"""
+lazy_loader
+===========
+
+Makes it easy to load subpackages and functions on demand.
+
+Vendored on 2022.10.14 from https://github.com/scientific-python/lazy_loader
+
+This file is an unmodified copy of lazy_loader/__init__.py @ cb22eba
+
+This file is released under the 3-Clause BSD License, which may be
+found in full at
+https://github.com/scientific-python/lazy_loader/blob/cb22eba/LICENSE.md
+
+Copyright (c) 2022, Scientific Python project All rights reserved.
+"""
+import ast
+import importlib
+import importlib.util
+import inspect
+import os
+import sys
+import types
+
+__all__ = ["attach", "load", "attach_stub"]
+
+
+def attach(package_name, submodules=None, submod_attrs=None):
+    """Attach lazily loaded submodules, functions, or other attributes.
+
+    Typically, modules import submodules and attributes as follows::
+
+      import mysubmodule
+      import anothersubmodule
+
+      from .foo import someattr
+
+    The idea is to replace a package's `__getattr__`, `__dir__`, and
+    `__all__`, such that all imports work exactly the way they would
+    with normal imports, except that the import occurs upon first use.
+
+    The typical way to call this function, replacing the above imports, is::
+
+      __getattr__, __dir__, __all__ = lazy.attach(
+        __name__,
+        ['mysubmodule', 'anothersubmodule'],
+        {'foo': ['someattr']}
+      )
+
+    This functionality requires Python 3.7 or higher.
+
+    Parameters
+    ----------
+    package_name : str
+        Typically use ``__name__``.
+    submodules : set
+        List of submodules to attach.
+    submod_attrs : dict
+        Dictionary of submodule -> list of attributes / functions.
+        These attributes are imported as they are used.
+
+    Returns
+    -------
+    __getattr__, __dir__, __all__
+
+    """
+    if submod_attrs is None:
+        submod_attrs = {}
+
+    if submodules is None:
+        submodules = set()
+    else:
+        submodules = set(submodules)
+
+    attr_to_modules = {
+        attr: mod for mod, attrs in submod_attrs.items() for attr in attrs
+    }
+
+    __all__ = list(sorted(submodules | attr_to_modules.keys()))
+
+    def __getattr__(name):
+        if name in submodules:
+            return importlib.import_module(f"{package_name}.{name}")
+        elif name in attr_to_modules:
+            submod_path = f"{package_name}.{attr_to_modules[name]}"
+            submod = importlib.import_module(submod_path)
+            attr = getattr(submod, name)
+
+            # If the attribute lives in a file (module) with the same
+            # name as the attribute, ensure that the attribute and *not*
+            # the module is accessible on the package.
+            if name == attr_to_modules[name]:
+                pkg = sys.modules[package_name]
+                pkg.__dict__[name] = attr
+
+            return attr
+        else:
+            raise AttributeError(f"No {package_name} attribute {name}")
+
+    def __dir__():
+        return __all__
+
+    if os.environ.get("EAGER_IMPORT", ""):
+        for attr in set(attr_to_modules.keys()) | submodules:
+            __getattr__(attr)
+
+    return __getattr__, __dir__, list(__all__)
+
+
+class DelayedImportErrorModule(types.ModuleType):
+    def __init__(self, frame_data, *args, **kwargs):
+        self.__frame_data = frame_data
+        super().__init__(*args, **kwargs)
+
+    def __getattr__(self, x):
+        if x in ("__class__", "__file__", "__frame_data"):
+            super().__getattr__(x)
+        else:
+            fd = self.__frame_data
+            raise ModuleNotFoundError(
+                f"No module named '{fd['spec']}'\n\n"
+                "This error is lazily reported, having originally occured in\n"
+                f'  File {fd["filename"]}, line {fd["lineno"]}, in {fd["function"]}\n\n'
+                f'----> {"".join(fd["code_context"]).strip()}'
+            )
+
+
+def load(fullname, error_on_import=False):
+    """Return a lazily imported proxy for a module.
+
+    We often see the following pattern::
+
+      def myfunc():
+          from numpy import linalg as la
+          la.norm(...)
+          ....
+
+    This is to prevent a module, in this case `numpy`, from being
+    imported at function definition time, since that can be slow.
+
+    This function provides a proxy module that, upon access, imports
+    the actual module.  So the idiom equivalent to the above example is::
+
+      la = lazy.load("numpy.linalg")
+
+      def myfunc():
+          la.norm(...)
+          ....
+
+    The initial import time is fast because the actual import is delayed
+    until the first attribute is requested. The overall import time may
+    decrease as well for users that don't make use of large portions
+    of the library.
+
+    Parameters
+    ----------
+    fullname : str
+        The full name of the module or submodule to import.  For example::
+
+          sp = lazy.load('scipy')  # import scipy as sp
+          spla = lazy.load('scipy.linalg')  # import scipy.linalg as spla
+    error_on_import : bool
+        Whether to postpone raising import errors until the module is accessed.
+        If set to `True`, import errors are raised as soon as `load` is called.
+
+    Returns
+    -------
+    pm : importlib.util._LazyModule
+        Proxy module.  Can be used like any regularly imported module.
+        Actual loading of the module occurs upon first attribute request.
+
+    """
+    try:
+        return sys.modules[fullname]
+    except KeyError:
+        pass
+
+    spec = importlib.util.find_spec(fullname)
+    if spec is None:
+        if error_on_import:
+            raise ModuleNotFoundError(f"No module named '{fullname}'")
+        else:
+            try:
+                parent = inspect.stack()[1]
+                frame_data = {
+                    "spec": fullname,
+                    "filename": parent.filename,
+                    "lineno": parent.lineno,
+                    "function": parent.function,
+                    "code_context": parent.code_context,
+                }
+                return DelayedImportErrorModule(frame_data, "DelayedImportErrorModule")
+            finally:
+                del parent
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[fullname] = module
+
+    loader = importlib.util.LazyLoader(spec.loader)
+    loader.exec_module(module)
+
+    return module
+
+
+class _StubVisitor(ast.NodeVisitor):
+    """AST visitor to parse a stub file for submodules and submod_attrs."""
+
+    def __init__(self):
+        self._submodules = set()
+        self._submod_attrs = {}
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        if node.level != 1:
+            raise ValueError(
+                "Only within-module imports are supported (`from .* import`)"
+            )
+        if node.module:
+            attrs: list = self._submod_attrs.setdefault(node.module, [])
+            attrs.extend(alias.name for alias in node.names)
+        else:
+            self._submodules.update(alias.name for alias in node.names)
+
+
+def attach_stub(package_name: str, filename: str):
+    """Attach lazily loaded submodules, functions from a type stub.
+
+    This is a variant on ``attach`` that will parse a `.pyi` stub file to
+    infer ``submodules`` and ``submod_attrs``. This allows static type checkers
+    to find imports, while still providing lazy loading at runtime.
+
+    Parameters
+    ----------
+    package_name : str
+        Typically use ``__name__``.
+    filename : str
+        Path to `.py` file which has an adjacent `.pyi` file.
+        Typically use ``__file__``.
+
+    Returns
+    -------
+    __getattr__, __dir__, __all__
+        The same output as ``attach``.
+
+    Raises
+    ------
+    ValueError
+        If a stub file is not found for `filename`, or if the stubfile is formmated
+        incorrectly (e.g. if it contains an relative import from outside of the module)
+    """
+    stubfile = filename if filename.endswith("i") else f"{filename}i"
+
+    if not os.path.exists(stubfile):
+        raise ValueError(f"Cannot load imports from non-existent stub {stubfile!r}")
+
+    with open(stubfile) as f:
+        stub_node = ast.parse(f.read())
+
+    visitor = _StubVisitor()
+    visitor.visit(stub_node)
+    return attach(package_name, visitor._submodules, visitor._submod_attrs)

--- a/tools/schemacode/bidsschematools/_lazy.py
+++ b/tools/schemacode/bidsschematools/_lazy.py
@@ -6,7 +6,10 @@ Makes it easy to load subpackages and functions on demand.
 
 Vendored on 2022.10.14 from https://github.com/scientific-python/lazy_loader
 
-This file is an unmodified copy of lazy_loader/__init__.py @ cb22eba
+This file is a copy of lazy_loader/__init__.py @ cb22eba
+
+Modifications:
+    * Fix spelling of "occurred" in DelayedImportErrorModule to pacify codespell
 
 This file is released under the 3-Clause BSD License, which may be
 found in full at
@@ -119,7 +122,7 @@ class DelayedImportErrorModule(types.ModuleType):
             fd = self.__frame_data
             raise ModuleNotFoundError(
                 f"No module named '{fd['spec']}'\n\n"
-                "This error is lazily reported, having originally occured in\n"
+                "This error is lazily reported, having originally occurred in\n"
                 f'  File {fd["filename"]}, line {fd["lineno"]}, in {fd["function"]}\n\n'
                 f'----> {"".join(fd["code_context"]).strip()}'
             )

--- a/tools/schemacode/bidsschematools/render/tables.py
+++ b/tools/schemacode/bidsschematools/render/tables.py
@@ -4,10 +4,10 @@ import os
 import typing as ty
 from collections.abc import Mapping
 
-import lazy_loader as lazy
+from .. import _lazy
 
-pd = lazy.load("pandas")
-tab = lazy.load("tabulate")
+pd = _lazy.load("pandas")
+tab = _lazy.load("tabulate")
 
 from bidsschematools.render import utils
 from bidsschematools.schema import BIDSSchemaError, Namespace, filter_schema

--- a/tools/schemacode/bidsschematools/render/tables.py
+++ b/tools/schemacode/bidsschematools/render/tables.py
@@ -4,8 +4,10 @@ import os
 import typing as ty
 from collections.abc import Mapping
 
-import pandas as pd
-from tabulate import tabulate
+import lazy_loader as lazy
+
+pd = lazy.load("pandas")
+tab = lazy.load("tabulate")
 
 from bidsschematools.render import utils
 from bidsschematools.schema import BIDSSchemaError, Namespace, filter_schema
@@ -125,7 +127,7 @@ def _make_object_table(
     df.index.name = first_column
 
     # Print it as markdown
-    table_str = tabulate(df, headers="keys", tablefmt=tablefmt)
+    table_str = tab.tabulate(df, headers="keys", tablefmt=tablefmt)
 
     # Spec internal links need to be replaced
     table_str = table_str.replace("SPEC_ROOT", utils.get_relpath(src_path))
@@ -345,7 +347,7 @@ def make_entity_table(schema, tablefmt="github", src_path=None, **kwargs):
     table = table.set_index(table.index.name, drop=True).sort_index()
 
     # Print it as markdown
-    table_str = tabulate(table, headers="keys", tablefmt=tablefmt)
+    table_str = tab.tabulate(table, headers="keys", tablefmt=tablefmt)
     table_str = table_str.replace("SPEC_ROOT", utils.get_relpath(src_path))
     return table_str
 
@@ -399,7 +401,7 @@ def make_suffix_table(schema, suffixes, src_path=None, tablefmt="github"):
     df = df[["`suffix`", "**Description**"]]
 
     # Print it as markdown
-    table_str = tabulate(df, headers="keys", tablefmt=tablefmt)
+    table_str = tab.tabulate(df, headers="keys", tablefmt=tablefmt)
     # Spec internal links need to be replaced
     table_str = table_str.replace("SPEC_ROOT", utils.get_relpath(src_path))
     return table_str

--- a/tools/schemacode/bidsschematools/render/text.py
+++ b/tools/schemacode/bidsschematools/render/text.py
@@ -2,8 +2,10 @@
 import logging
 import os
 
-import yaml
-from markdown_it import MarkdownIt
+import lazy_loader as lazy
+
+yaml = lazy.load("yaml")
+markdown_it = lazy.load("markdown_it")
 
 from bidsschematools.render import utils
 from bidsschematools.schema import Namespace, filter_schema, load_schema
@@ -438,7 +440,7 @@ def append_filename_template_legend(text, pdf_format=False):
 
 """
     else:
-        md = MarkdownIt()
+        md = markdown_it.MarkdownIt()
         text += f"""
 <details>
 <summary><strong>Legend:</strong></summary>

--- a/tools/schemacode/bidsschematools/render/text.py
+++ b/tools/schemacode/bidsschematools/render/text.py
@@ -2,10 +2,10 @@
 import logging
 import os
 
-import lazy_loader as lazy
+from .. import _lazy
 
-yaml = lazy.load("yaml")
-markdown_it = lazy.load("markdown_it")
+yaml = _lazy.load("yaml")
+markdown_it = _lazy.load("markdown_it")
 
 from bidsschematools.render import utils
 from bidsschematools.schema import Namespace, filter_schema, load_schema

--- a/tools/schemacode/bidsschematools/types/namespace.py
+++ b/tools/schemacode/bidsschematools/types/namespace.py
@@ -4,7 +4,9 @@ import typing as ty
 from collections.abc import ItemsView, KeysView, Mapping, MutableMapping, ValuesView
 from pathlib import Path
 
-import yaml
+import lazy_loader as lazy
+
+yaml = lazy.load("yaml")
 
 
 def _expand_dots(entry: ty.Tuple[str, ty.Any]) -> ty.Tuple[str, ty.Any]:

--- a/tools/schemacode/bidsschematools/types/namespace.py
+++ b/tools/schemacode/bidsschematools/types/namespace.py
@@ -4,9 +4,9 @@ import typing as ty
 from collections.abc import ItemsView, KeysView, Mapping, MutableMapping, ValuesView
 from pathlib import Path
 
-import lazy_loader as lazy
+from .. import _lazy
 
-yaml = lazy.load("yaml")
+yaml = _lazy.load("yaml")
 
 
 def _expand_dots(entry: ty.Tuple[str, ty.Any]) -> ty.Tuple[str, ty.Any]:

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -5,19 +5,9 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 99
 target-version = ['py37']
-include = '\.pyi?$'
-exclude = '''
+extend-exclude = '''
 (
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.github
-    | \.hg
-    | \.pytest_cache
-    | _build
-    | build
-    | dist
-  )/
+  _lazy.py
 )
 '''
 

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -23,6 +23,6 @@ markers = [
 [tool.coverage.run]
 parallel = true
 omit = [
-  "*/*/tests/*",
-  "**/tests/*"
+  "**/tests/*",
+  "*/_lazy.py"
 ]


### PR DESCRIPTION
This ~~uses~~vendors the [lazy_loader](https://github.com/scientific-python/lazy_loader) package to do two things:

1) Import our submodules so they are accessible in the root namespace without being individually imported. For example:

```Python
import bidsschematools as bst
schema = bst.schema.load_schema()
```

2) Lazy-load non-stdlib modules, so that they only get imported when used. This makes it a bit easier to do imports and selective tests without setting up an environment where we install `bidsschematools[all]`.

The new dependency is extremely lightweight and is very likely to become ubiquitous in the scientific Python ecosystem.

Discussed this with @TheChymera back in August, but wanted to wait until `lazy_loader` had a non-alpha release.