### PR TITLE
add more subheadings, improve consistency

### DIFF
--- a/src/04-modality-specific-files/02-magnetoencephalography.md
+++ b/src/04-modality-specific-files/02-magnetoencephalography.md
@@ -162,7 +162,7 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_sidecar_table("meg.MEGwithEEG") }}
 
-Example:
+#### Example `*_meg.json`
 
 ```JSON
 {
@@ -268,12 +268,18 @@ Note that upper-case is REQUIRED:
 | FITERR           | Fit error signal from each head localization coil    |
 | OTHER            | Any other type of channel                            |
 
-Example of free text for field `description`:
+Examples of free text for field `description`:
 
--   stimulus, response, vertical EOG, horizontal EOG, skin conductance, sats,
-    intracranial, eyetracker
+-   stimulus
+-   response
+-   vertical EOG
+-   horizontal EOG
+-   skin conductance
+-   sats
+-   intracranial
+-   eyetracker
 
-Example:
+### Example `*_channels.tsv`
 
 ```Text
 name type units description
@@ -418,6 +424,8 @@ The [`acq-<label>`](../appendices/entities.md#acq) entity can be used to indicat
 the same face (or other body part in different angles to show, for example, the
 location of the nasion (NAS) as opposed to the right periauricular point (RPA)).
 
+### Example `*_photo.jpg`
+
 Example of the NAS fiducial placed between the eyebrows, rather than at the
 actual anatomical nasion: `sub-0001_ses-001_acq-NAS_photo.jpg`
 
@@ -443,7 +451,7 @@ a session, for example when the head points are in a separate file from the EEG
 locations. These files are stored in the specific format of the 3-D digitizer’s
 manufacturer (see the [MEG File Formats Appendix](../appendices/meg-file-formats.md)).
 
-Example:
+For example:
 
 <!-- This block generates a file tree.
 A guide for using macros can be found at
@@ -470,8 +478,8 @@ Empty-room MEG recordings capture the environmental and recording system's noise
 
 It is RECOMMENDED to explicitly specify which empty-room recording should be used with which experimental run(s) or session(s). This can be done via the [`AssociatedEmptyRoom`](../glossary.md#associatedemptyroom-metadata) field in the `*_meg.json` sidecar files.
 
-Empty-room recordings may be collected once per day, where a single empty-room recording may be shared between multiple subjects and/or sessions (see example 1).
-Empty-room recordings can also be collected for each individual experimental session (see example 2).
+Empty-room recordings may be collected once per day, where a single empty-room recording may be shared between multiple subjects and/or sessions (see [Example 1](#example-1)).
+Empty-room recordings can also be collected for each individual experimental session (see [Example 2](#example-2)).
 
 In the case of empty-room recordings being associated with multiple subjects and/or sessions, it is RECOMMENDED to store the empty-room recording inside a subject directory named `sub-emptyroom`.
 If a [`session-<label>`](../appendices/entities.md#ses) entity is present, its label SHOULD be the date of the empty-room recording in the format `YYYYMMDD`, that is `ses-YYYYMMDD`.
@@ -483,7 +491,7 @@ In the case of empty-room recordings being collected for the individual experime
 
 In either case, the label for the [`task-<label>`](../appendices/entities.md#task) entity in the empty-room recording SHOULD be set to `noise`.
 
-Example 1:
+### Example 1
 
 One empty-room recording per day, applying to all subjects for that day.
 
@@ -508,7 +516,7 @@ A guide for using macros can be found at
    }
 ) }}
 
-Example 2:
+### Example 2
 
 One recording per session, stored within the session folder.
 
@@ -533,5 +541,3 @@ A guide for using macros can be found at
       },
    }
 ) }}
-
-<!-- Link Definitions -->

--- a/src/04-modality-specific-files/03-electroencephalography.md
+++ b/src/04-modality-specific-files/03-electroencephalography.md
@@ -135,7 +135,7 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_sidecar_table("eeg.EEGMoreRecommended") }}
 
-Example:
+#### Example `*_eeg.json`
 
 ```JSON
 {
@@ -238,11 +238,15 @@ Note that upper-case is REQUIRED:
 | TRIG        | System triggers                                              |
 | VEOG        | Vertical EOG (eye)                                           |
 
-Example of free-form text for field `description`
+Examples of free-form text for field `description`
 
--   n/a, stimulus, response, skin conductance, battery status
+-   n/a
+-   stimulus
+-   response
+-   skin conductance
+-   battery status
 
-### Example `channels.tsv`
+### Example `*_channels.tsv`
 
 See also the corresponding [`electrodes.tsv` example](#example-electrodestsv).
 
@@ -280,7 +284,7 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_columns_table("eeg.EEGElectrodes") }}
 
-### Example `electrodes.tsv`
+### Example `*_electrodes.tsv`
 
 See also the corresponding [`electrodes.tsv` example](#example-channelstsv).
 
@@ -405,7 +409,7 @@ landmarks or fiducials during an EEG session/run, must be stored separately in
 the corresponding `*_T1w.json` or `*_T2w.json` file and should be expressed in
 voxels (starting from `[0, 0, 0]`).
 
-Example:
+### Example `*_coordsystem.json`
 
 ```JSON
 {
@@ -440,7 +444,7 @@ indicate acquisition of different photos of
 the same face (or other body part in different angles to show, for example, the
 location of the nasion (NAS) as opposed to the right periauricular point (RPA).
 
-Example:
+### Example `*_photo.jpg`
 
 Picture of a NAS fiducial placed between the eyebrows, rather than at the
 actual anatomical nasion: `sub-0001_ses-001_acq-NAS_photo.jpg`

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -265,7 +265,7 @@ Examples of free-form text for field `description`:
 -   vertical EOG
 -   skin conductance
 
-### Example `*_channels.tsv`:
+### Example `*_channels.tsv`
 
 ```Text
 name  type  units low_cutoff  high_cutoff status  status_description

--- a/src/04-modality-specific-files/04-intracranial-electroencephalography.md
+++ b/src/04-modality-specific-files/04-intracranial-electroencephalography.md
@@ -162,7 +162,11 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_sidecar_table("ieeg.iEEGOptional") }}
 
-Example:
+Note that the date and time information SHOULD be stored in the study key file
+([`scans.tsv`](../03-modality-agnostic-files.md#scans-file)).
+Date time information MUST be expressed as indicated in [Units](../02-common-principles.md#units)
+
+#### Example `*_ieeg.json`
 
 ```JSON
 {
@@ -195,10 +199,6 @@ Example:
 }
 ```
 
-Note that the date and time information SHOULD be stored in the Study key file
-([`scans.tsv`](../03-modality-agnostic-files.md#scans-file)).
-Date time information MUST be expressed as indicated in [Units](../02-common-principles.md#units)
-
 ## Channels description (`*_channels.tsv`)
 
 <!--
@@ -230,17 +230,6 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_columns_table("ieeg.iEEGChannels") }}
 
-**Example** `sub-01_channels.tsv`:
-
-```Text
-name  type  units low_cutoff  high_cutoff status  status_description
-LT01  ECOG  uV    300         0.11        good    n/a
-LT02  ECOG  uV    300         0.11        bad     broken
-H01   SEEG  uV    300         0.11        bad     line_noise
-ECG1  ECG   uV    n/a         0.11        good    n/a
-TR1   TRIG  n/a   n/a         n/a         good    n/a
-```
-
 Restricted keyword list for field type in alphabetic order (shared with the MEG
 and EEG modality; however, only types that are common in iEEG data are listed here).
 Note that upper-case is REQUIRED:
@@ -268,9 +257,24 @@ Note that upper-case is REQUIRED:
 | REF         | Reference channel                                                      |
 | OTHER       | Any other type of channel                                              |
 
-Example of free-form text for field `description`:
+Examples of free-form text for field `description`:
 
--   intracranial, stimulus, response, vertical EOG, skin conductance
+-   intracranial
+-   stimulus
+-   response
+-   vertical EOG
+-   skin conductance
+
+### Example `*_channels.tsv`:
+
+```Text
+name  type  units low_cutoff  high_cutoff status  status_description
+LT01  ECOG  uV    300         0.11        good    n/a
+LT02  ECOG  uV    300         0.11        bad     broken
+H01   SEEG  uV    300         0.11        bad     line_noise
+ECG1  ECG   uV    n/a         0.11        good    n/a
+TR1   TRIG  n/a   n/a         n/a         good    n/a
+```
 
 ## Electrode description (`*_electrodes.tsv`)
 
@@ -299,10 +303,10 @@ are acceptable for `<label>`.
 
 For examples:
 
--   `_space-MNI152Lin` (electrodes are coregistred and scaled to a specific MNI
+-   `*_space-MNI152Lin` (electrodes are coregistred and scaled to a specific MNI
     template)
 
--   `_space-Talairach` (electrodes are coregistred and scaled to Talairach
+-   `*_space-Talairach` (electrodes are coregistred and scaled to Talairach
     space)
 
 When referring to the `*_electrodes.tsv` file in a certain _space_ as defined
@@ -337,7 +341,7 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_columns_table("ieeg.iEEGElectrodes") }}
 
-Example:
+### Example `*_electrodes.tsv`
 
 ```Text
 name  x   y    z    size   manufacturer
@@ -357,7 +361,7 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_filename_template("raw", datatypes=["ieeg"], suffixes=["coordsystem"]) }}
 
-This `_coordsystem.json` file contains the coordinate system in which electrode
+This `*_coordsystem.json` file contains the coordinate system in which electrode
 positions are expressed. The associated MRI, CT, X-Ray, or operative photo can
 also be specified.
 
@@ -413,7 +417,7 @@ Note that the [`space-<label>`](../appendices/entities.md#space) fields must cor
 between `*_electrodes.tsv` and `*_coordsystem.json` if they refer to the same
 data.
 
-Example:
+### Example `*_coordsystem.json`
 
 ```json
 {
@@ -458,6 +462,8 @@ with:
 
 The [`ses-<label>`](../appendices/entities.md#ses) entity may be used to specify when the photo was taken.
 
+### Example `*_photo.jpg`
+
 Example of the operative photo of ECoG electrodes (here is an annotated example in
 which electrodes and vasculature are marked, taken from Hermes et al.,
 JNeuroMeth 2010).
@@ -496,16 +502,16 @@ EEG technician and provided to the epileptologists (for example, see Burneo JG e
 
 In case of electrical stimulation of brain tissue by passing current through the
 iEEG electrodes, and the electrical stimulation has an event structure (on-off,
-onset, duration), the `_events.tsv` file can contain the electrical stimulation
+onset, duration), the `*_events.tsv` file can contain the electrical stimulation
 parameters in addition to other events. Note that these can be intermixed with
 other task events. Electrical stimulation parameters can be described in columns
 called `electrical_stimulation_<label>`, with labels chosen by the researcher and
-optionally defined in more detail in an accompanying `_events.json` file (as
+optionally defined in more detail in an accompanying `*_events.json` file (as
 per the main BIDS spec). Functions for complex stimulation patterns can, similar
 as when a video is presented, be stored in a directory in the `/stimuli/` directory.
 For example: `/stimuli/electrical_stimulation_functions/biphasic.tsv`
 
-Example:
+### Example `*_events.tsv`
 
 ```Text
 onset duration trial_type             electrical_stimulation_type electrical_stimulation_site electrical_stimulation_current

--- a/src/04-modality-specific-files/11-near-infrared-spectroscopy.md
+++ b/src/04-modality-specific-files/11-near-infrared-spectroscopy.md
@@ -134,7 +134,7 @@ Specific NIRS fields that SHOULD be present:
 
 {{ MACROS___make_sidecar_table("nirs.NirsRecommend") }}
 
-Example:
+#### Example `*_nirs.json`
 
 ```JSON
 {
@@ -219,7 +219,7 @@ Note that upper-case is REQUIRED.
 | MAGN                        | Magnetomenter channel, one channel for each orientation. An extra column `component` for the axis of the orientation MUST be added to the `*_channels.tsv` file (x, y or z). |
 | MISC                        | Miscellaneous                                                                                                                                                                |
 
-Example:
+### Example `*_channels.tsv`
 
 ```Text
 Name         type                   source      detector      wavelength_nominal   units
@@ -255,7 +255,8 @@ The columns of the optodes description table stored in `*_optodes.tsv` are:
 
 {{ MACROS___make_columns_table("nirs.nirsOptodes") }}
 
-Example:
+### Example `*_optodes.tsv`
+
 ```Text
 name    type         x          y         z          template_x    template_y   template_z
 A1      source       -0.0707    0.0000    -0.0707    -0.07         0.00         0.07
@@ -302,8 +303,9 @@ Fields relating to the position of anatomical landmarks measured during an NIRS 
 
 {{ MACROS___make_sidecar_table(["nirs.AnatomicalLandmark", "nirs.AnatomicalLandmarkCoordinateSystemDescriptionRec"]) }}
 
-Example:
-```text
+### Example `*_coordsystem.json`
+
+```json
 {
   "NIRSCoordinateSystem": "Other",
   "NIRSCoordinateUnits": "mm",


### PR DESCRIPTION
I recently wanted to link to examples in the modality specific specs and saw that only for EEG that was possible (because examples are already subheadings there).

Here I make those examples where it "makes sense" subheadings for all ephys+nirs modalities.