### PR TITLE
CI: limit circleci redirector check

### DIFF
--- a/.github/workflows/redirect_circleci_artifacts.yml
+++ b/.github/workflows/redirect_circleci_artifacts.yml
@@ -2,6 +2,7 @@ on: [status]
 
 jobs:
   circleci_artifacts_redirector_job:
+    if: "${{ github.event.context.startswith('ci/circleci: build_docs_pdf') }}"
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:


### PR DESCRIPTION
following:

- https://github.com/mne-tools/mne-python/pull/11156

@Remi-Gau I think you recently noted that there are so many of the checks for this CI step. Perhaps this is a solution.