### PR TITLE
[CI] add codecov token

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -165,4 +165,5 @@ jobs:
       - name: Upload to CodeCov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}  # not required but might help API rate limits
           fail_ci_if_error: true


### PR DESCRIPTION
this might help to fix the codecov failures that we have observed for some time now ... because when using a token, API rate limits may be different.

Note I added `CODECOV_TOKEN` as a "secret" in the GitHub settings for this repo.

xref:
- https://github.com/codecov/codecov-action/issues/557#issuecomment-1216781115