### PR TITLE
[SCHEMA] Add tsv to extensions for any file with dseg suffix.

### DIFF
--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -94,9 +94,7 @@ anat_parametric_discrete_segmentation:
     density: optional
     description: optional
   extensions:
-    - .nii.gz
-    - .nii
-    - .json
+    - $ref: rules.files.raw.anat.parametric.extensions
     - .tsv
 
 

--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -94,7 +94,9 @@ anat_parametric_discrete_segmentation:
     density: optional
     description: optional
   extensions:
-    - $ref: rules.files.raw.anat.parametric.extensions
+    - .nii.gz
+    - .nii
+    - .json
     - .tsv
 
 

--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -93,6 +93,12 @@ anat_parametric_discrete_segmentation:
     resolution: optional
     density: optional
     description: optional
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+    - .tsv
+
 
 anat_nonparametric_discrete_segmentation:
   $ref: rules.files.raw.anat.nonparametric
@@ -104,6 +110,11 @@ anat_nonparametric_discrete_segmentation:
     resolution: optional
     density: optional
     description: optional
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+    - .tsv
 
 func_discrete_segmentation:
   $ref: rules.files.raw.func.func
@@ -183,6 +194,7 @@ anat_parametic_discrete_surface:
     - .label.gii
     - .dlabel.nii
     - .json
+    - .tsv
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     hemisphere: optional
@@ -199,6 +211,7 @@ anat_nonparametic_discrete_surface:
     - .label.gii
     - .dlabel.nii
     - .json
+    - .tsv
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     hemisphere: optional


### PR DESCRIPTION
These tsv files aren't listed in the filename templates for segmentations but are specified as allowed here:
https://bids-specification.readthedocs.io/en/stable/05-derivatives/03-imaging.html#common-image-derived-labels