### PR TITLE
[SCHEMA] Remove rule requiring space metadata for every derivative file without space entity.

### DIFF
--- a/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
@@ -27,13 +27,6 @@ SpatialReferenceNonStandard:
   fields:
     SpatialReference: required
 
-SpatialReferenceNoEntity:
-  selectors:
-    - dataset.dataset_description.DatasetType == "derivative"
-    - '!("space" in entities)'
-  fields:
-    SpatialReference: required
-
 # this needs to come before density and resolution overrides selected in a
 # different way
 MaskDerivatives:


### PR DESCRIPTION
This rule is intended to apply to spatial reference images:
https://bids-specification.readthedocs.io/en/stable/05-derivatives/02-common-data-types.html#spatial-references

These are under specified in the specification, so this rule ended up hitting most everything in some derivative datasets.