### PR TITLE
[ENH] Recommend gzip header fields be set to empty values

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -368,7 +368,8 @@ datasets and non-compliant derivatives.
 ### Imaging files
 
 All imaging data MUST be stored using the NIfTI file format. We RECOMMEND using
-compressed NIfTI files (.nii.gz), either version 1.0 or 2.0. Imaging data SHOULD
+compressed NIfTI files (.nii.gz), either version 1.0 or 2.0. If using compressed files,
+the gzip header MUST lack source filenames timestamps. Imaging data SHOULD
 be converted to the NIfTI format using a tool that provides as much of the NIfTI
 header information (such as orientation and slice timing information) as
 possible. Since the NIfTI standard offers limited support for the various image

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -369,7 +369,7 @@ datasets and non-compliant derivatives.
 
 All imaging data MUST be stored using the NIfTI file format. We RECOMMEND using
 compressed NIfTI files (.nii.gz), either version 1.0 or 2.0. If using compressed files,
-the gzip header MUST lack source filenames timestamps. Imaging data SHOULD
+the gzip header SHOULD lack source filenames and timestamps. Imaging data SHOULD
 be converted to the NIfTI format using a tool that provides as much of the NIfTI
 header information (such as orientation and slice timing information) as
 possible. Since the NIfTI standard offers limited support for the various image


### PR DESCRIPTION
By removing extraneous metadata, pipelines generating BIDS datasets can avoid making unnecessary changes.

We are motivated to this since we are working on combining BIDS with [datalad](https://www.datalad.org/) in our workflows, and if a pipeline regenerates hundreds of images with no real change, then we rapidly bloat our storage costs and obscures real changes in `git log`. datalad (thanks to its dependency [git-annex](https://git-annex.branchable.com/)) avoids the bandwidth/storage costs of downstream users, since most of our users download once only, or are always downloading fresh HEAD copies to processing nodes, but our internal storage costs are a big factor for us.

This can be implemented with `gzip -n` in most environments, or equally by running [`strip-nondeterminism`](https://salsa.debian.org/reproducible-builds/strip-nondeterminism) over a BIDS dataset before publishing.

closes #136 