### PR TITLE
[ENH] Add BEP032 (microelectrode electrophysiology) specification

### DIFF
--- a/src/schema/objects/extensions.yaml
+++ b/src/schema/objects/extensions.yaml
@@ -187,6 +187,11 @@ niigz:
   display_name: Compressed NIfTI
   description: |
     A compressed Neuroimaging Informatics Technology Initiative (NIfTI) data file.
+nix:
+  value: .nix
+  display_name: Neuroscience Information Exchange Format
+  description: |
+    A [Neuroscience Information Exchange](https://nixio.readthedocs.io) file.
 nwb:
   value: .nwb
   display_name: Neurodata Without Borders Format

--- a/src/schema/objects/modalities.yaml
+++ b/src/schema/objects/modalities.yaml
@@ -31,3 +31,6 @@ micr:
 nirs:
   display_name: Near-Infrared Spectroscopy
   description: Data acquired with NIRS.
+ephys:
+  display_name: Electrophysiology
+  description: Data acquired using microelectrodes.

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -579,6 +579,11 @@ electrodes:
   display_name: Electrodes
   description: |
     File that gives the location of (i)EEG electrodes.
+ephys:
+  value: ephys
+  display_name: Electrophysiology
+  description: |
+    Extra- or intracellular microelectrode recording data.
 epi:
   value: epi
   display_name: EPI
@@ -730,6 +735,11 @@ physio:
   display_name: Physiological recording
   description: |
     Physiological recordings such as cardiac and respiratory signals.
+probe:
+  value: probe
+  display_name: A recording probe
+  description: |
+    A probe with one or more recording contacts.
 probseg:
   value: probseg
   display_name: Probabilistic Segmentation


### PR DESCRIPTION
Add specification for microelectrode electrohpysiology datasets based on the [BEP032 proposal](https://bids.neuroimaging.io/bep032)

- To use this WiP schema on sample datasets, see https://deno.land/x/bids_validator@v1.13.2-dev.0#modifying-and-building-a-new-schema on how to use "stock" `bids-validator` with a custom schema.


ToDos
- [ ] Please ensure your name is credited on our [Contributors appendix](https://github.com/bids-standard/bids-specification/blob/master/src/appendices/contributors.md).
  To add your name, please edit our [Contributors wiki](https://github.com/bids-standard/bids-specification/wiki/Contributors) and add your name with the type of contribution.
  For assistance, please tag @bids-standard/maintainers.
- [ ] After opening the PR, our continuous integration services will automatically check your contribution  for formatting errors and render a preview of the BIDS specification with your changes.
  To see the checks and preview, scroll down and click on the `show all checks` link.
  From the list, select the `Details` link of the `ci/circleci: build_docs artifact` check to see the preview of the BIDS specification.
- [ ] Add CI action (likely github) to run `bids-validator` on sample datasets and this modified schema (@yarikoptic)

