### PR TITLE
[FIX] remove redundant entity definitions in behavioral page

### DIFF
--- a/src/modality-specific-files/behavioral-experiments.md
+++ b/src/modality-specific-files/behavioral-experiments.md
@@ -21,17 +21,6 @@ Additionally, events files that do not include the mandatory `onset` and
 `duration` columns can still be included, but should be labeled `_beh.tsv`
 rather than `_events.tsv`.
 
-Each task has a unique label that MUST only consist of letters and/or numbers
-(other characters, including spaces and underscores, are not allowed) with the
-[`task-<label>`](../appendices/entities.md#task) entity.
-Those labels MUST be consistent across subjects and sessions.
-
-The OPTIONAL [`acq-<label>`](../appendices/entities.md#acq) entity corresponds to a custom label to
-distinguish different conditions present during multiple runs of the same task.
-For example, if a study includes runs of an n-back task, with deep brain
-stimulation turned on or off, the data files may be labelled
-`sub-01_task-nback_acq-dbson_beh.tsv` and `sub-01_task-nback_acq-dbsoff_beh.tsv`.
-
 ## RECOMMENDED metadata
 
 In addition to the metadata that is either:


### PR DESCRIPTION
relates to #1194 