### PR TITLE
[DOC] link to steering group section on bids website

### DIFF
--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -12,6 +12,8 @@ The document outlining our governance structure is hosted on the BIDS website:
 In the following, we list the current members of subgroups detailed in the
 BIDS governance.
 
+### Steering Group
+
 Curent and past members of the steering group can be found
 [here](https://bids.neuroimaging.io/governance.html#bids-steering-group).
 


### PR DESCRIPTION
- easier to do this than update both repo every year.

@ericearl and I also talked about refactoring our decision making page and remove things that are duplicated in it and in the governance page, I could use this PR to do this or do it in another PR if preferred.