### PR TITLE
[FIX] make references to Neuromag/Elekta/MEGIN consistent

### DIFF
--- a/src/appendices/meg-file-formats.md
+++ b/src/appendices/meg-file-formats.md
@@ -438,7 +438,7 @@ A guide for using macros can be found at
 ## Aalto MEG–MRI
 
 For stand-alone MEG data, the Aalto hybrid device uses the standard `.fif` data
-format and follows the conventions of Elekta/Neuromag as described
+format and follows the conventions of Neuromag/Elekta/MEGIN as described
 [above](#neuromagelektamegin). The `.fif` files may
 contain unreconstructed MRI data. The inclusion of MRI data and information for
 accurate reconstruction will be fully standardized at a later stage.

--- a/src/modality-specific-files/magnetoencephalography.md
+++ b/src/modality-specific-files/magnetoencephalography.md
@@ -77,7 +77,7 @@ for general information on how to deal with such manufacturer specifics and to s
 The [`proc-<label>`](../appendices/entities.md#proc) entity is analogous to the
 [`rec-<label>`](../appendices/entities.md#rec) entity for MRI,
 and denotes a variant of a file that was a result of particular processing performed on the device.
-This is useful for files produced in particular by Elekta's MaxFilter
+This is useful for files produced in particular by Neuromag/Elekta/MEGIN's MaxFilter
 (for example, sss, tsss, trans, quat, mc),
 which some installations impose to be run on raw data prior to analysis.
 Such processing steps are needed for example because of active shielding software corrections

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -218,8 +218,8 @@ processing:
     The proc label is analogous to rec for MR and denotes a variant of
     a file that was a result of particular processing performed on the device.
 
-    This is useful for files produced in particular by Elekta's MaxFilter
-    (for example, `sss`, `tsss`, `trans`, `quat` or `mc`),
+    This is useful for files produced in particular by Neuromag/Elekta/MEGIN's
+    MaxFilter (for example, `sss`, `tsss`, `trans`, `quat` or `mc`),
     which some installations impose to be run on raw data because of active
     shielding software corrections before the MEG data can actually be
     exploited.

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -638,7 +638,7 @@ DigitizedHeadPoints__coordsystem:
     Relative path to the file containing the locations of digitized head points
     collected during the session (for example, `"sub-01_headshape.pos"`).
     RECOMMENDED for all MEG systems, especially for CTF and BTi/4D.
-    For Elekta/Neuromag the head points will be stored in the fif file.
+    For Neuromag/Elekta/MEGIN, the head points will be stored in the `.fif` file.
   type: string
   format: file_relative
 DigitizedHeadPointsCoordinateSystem:
@@ -1286,8 +1286,8 @@ HeadCoilCoordinates:
     (for example, `{"NAS": [12.7,21.3,13.9], "LPA": [5.2,11.3,9.6],
     "RPA": [20.2,11.3,9.1]}`).
     Note that coils are not always placed at locations that have a known
-    anatomical name (for example, for Elekta, Yokogawa systems); in that case
-    generic labels can be used
+    anatomical name (for example, for Neuromag/Elekta/MEGIN, Yokogawa systems);
+    in that case generic labels can be used
     (for example, `{"coil1": [12.2,21.3,12.3], "coil2": [6.7,12.3,8.6],
     "coil3": [21.9,11.0,8.1]}`).
     Each array MUST contain three numeric values corresponding to x, y, and z
@@ -1304,7 +1304,7 @@ HeadCoilFrequency:
   display_name: Head Coil Frequency
   description: |
     List of frequencies (in Hz) used by the head localisation coils
-    ('HLC' in CTF systems, 'HPI' in Elekta, 'COH' in BTi/4D)
+    ('HLC' in CTF systems, 'HPI' in Neuromag/Elekta/MEGIN, 'COH' in BTi/4D)
     that track the subject's head position in the MEG helmet
     (for example, `[293, 307, 314, 321]`).
   anyOf:


### PR DESCRIPTION
picking uncontroversial fixes from #1310 to improve consistency. Does **not** resolve the question whether to:

1. deprecate items that are *not* `Neuromag/Elekta/MEGIN` OR
2. treat `Neuromag`, `Elekta`, `MEGIN` and ``-separated combinations thereof as synonyms for `Neuromag/Elekta/MEGIN` (and to introduce this for other MEG systems where the name is made up of different manufacturer names)