### PR TITLE
NF: Add GZIP_HEADER_DATA issue, following gh-1349

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -215,6 +215,19 @@ context:
     json:
       description: 'Contents of the current JSON file'
       type: object
+    gzip:
+      description: 'Parsed contents of gzip header'
+      type: object
+      properties:
+        timestamp:
+          description: 'Modification time, unix timestamp'
+          type: number
+        filename:
+          description: 'File name'
+          type: string
+        comment:
+          description: 'Comment'
+          type: string
     nifti_header:
       name: 'NIfTI Header'
       description: 'Parsed contents of NIfTI header referenced elsewhere in schema.'

--- a/src/schema/rules/checks/privacy.yaml
+++ b/src/schema/rules/checks/privacy.yaml
@@ -1,0 +1,15 @@
+---
+GzipHeaderFields:
+  issue:
+    code: GZIP_HEADER_DATA
+    message: |
+      The gzip header contains a non-zero timestamp or a non-empty filename
+      and/or comment field. These may leak sensitive information or indicate
+      a non-reproducible conversion process.
+    level: warning
+  selectors:
+    - match(extension, ".gz$")
+  checks:
+    - gzip.timestamp == 0
+    - gzip.filename == ""
+    - gzip.comment == ""


### PR DESCRIPTION
Adds a `gzip` property to the context object and a check that timestamp, filename and comment are all null.