### PR TITLE
[MISC] Sort subsections within sections alphabetically

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,47 +6,47 @@ nav:
       - Introduction: introduction.md
       - Common principles: common-principles.md
       - Modality agnostic files: modality-agnostic-files.md
-      - Modality specific files:
-          - Magnetic Resonance Imaging: modality-specific-files/magnetic-resonance-imaging-data.md
-          - Magnetoencephalography: modality-specific-files/magnetoencephalography.md
-          - Electroencephalography: modality-specific-files/electroencephalography.md
-          - Intracranial Electroencephalography: modality-specific-files/intracranial-electroencephalography.md
-          - Task events: modality-specific-files/task-events.md
-          - Physiological recordings: modality-specific-files/physiological-recordings.md
+      - Modality specific files:  # keep sections in sorted order when adding/editing
           - Behavioral experiments (with no neural recordings): modality-specific-files/behavioral-experiments.md
+          - Electroencephalography: modality-specific-files/electroencephalography.md
           - Genetic Descriptor: modality-specific-files/genetic-descriptor.md
-          - Positron Emission Tomography: modality-specific-files/positron-emission-tomography.md
-          - Microscopy: modality-specific-files/microscopy.md
-          - Near-Infrared Spectroscopy: modality-specific-files/near-infrared-spectroscopy.md
-          - Motion: modality-specific-files/motion.md
+          - Intracranial Electroencephalography: modality-specific-files/intracranial-electroencephalography.md
+          - Magnetic Resonance Imaging: modality-specific-files/magnetic-resonance-imaging-data.md
           - Magnetic Resonance Spectroscopy: modality-specific-files/magnetic-resonance-spectroscopy.md
-      - Derivatives:
+          - Magnetoencephalography: modality-specific-files/magnetoencephalography.md
+          - Microscopy: modality-specific-files/microscopy.md
+          - Motion: modality-specific-files/motion.md
+          - Near-Infrared Spectroscopy: modality-specific-files/near-infrared-spectroscopy.md
+          - Physiological recordings: modality-specific-files/physiological-recordings.md
+          - Positron Emission Tomography: modality-specific-files/positron-emission-tomography.md
+          - Task events: modality-specific-files/task-events.md
+      - Derivatives:  # keep sections in sorted order when adding/editing
           - BIDS Derivatives: derivatives/introduction.md
           - Common data types and metadata: derivatives/common-data-types.md
           - Imaging data types: derivatives/imaging.md
       - Longitudinal and multi-site studies: longitudinal-and-multi-site-studies.md
       - Glossary: glossary.md
       - BIDS Extension Proposals: extensions.md
-      - Appendix:
-          - Schema: appendices/schema.md
+      - Appendix:  # keep sections in sorted order when adding/editing
+          - Arterial Spin Labeling: appendices/arterial-spin-labeling.md
           - Contributors: appendices/contributors.md
-          - Licenses: appendices/licenses.md
-          - Entity table: appendices/entity-table.md
+          - Coordinate systems: appendices/coordinate-systems.md
+          - Cross modality correspondence: appendices/cross-modality-correspondence.md
           - Entities: appendices/entities.md
+          - Entity table: appendices/entity-table.md
           - File collections: appendices/file-collections.md
-          - Units: appendices/units.md
           - Hierarchical Event Descriptors: appendices/hed.md
+          - Licenses: appendices/licenses.md
           - MEG file formats: appendices/meg-file-formats.md
           - MEG systems: appendices/meg-systems.md
-          - Coordinate systems: appendices/coordinate-systems.md
           - Quantitative MRI: appendices/qmri.md
-          - Arterial Spin Labeling: appendices/arterial-spin-labeling.md
-          - Cross modality correspondence: appendices/cross-modality-correspondence.md
+          - Schema: appendices/schema.md
+          - Units: appendices/units.md
       - Changelog: CHANGES.md
-  - The BIDS Starter Kit:
-      - Website: https://bids-standard.github.io/bids-starter-kit/
-      - Tutorials: https://bids-standard.github.io/bids-starter-kit/tutorials/tutorials.html
+  - The BIDS Starter Kit:  # keep sections in sorted order when adding/editing
       - GitHub repository: https://github.com/bids-standard/bids-starter-kit
+      - Tutorials: https://bids-standard.github.io/bids-starter-kit/tutorials/tutorials.html
+      - Website: https://bids-standard.github.io/bids-starter-kit/
 theme:
   name: material
   favicon: images/favicon.png


### PR DESCRIPTION
I was feeling the need for it each time I was navigating BIDS, but seeing
https://github.com/bids-standard/bids-specification/pull/1128/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2 suggesting the same made me propose it.

I think having subsections sorted where there is no really really a requirement for order helps visitor to navigate the document/website instead of doing linear search among all subsections.
