### PR TITLE
RF: allow for any "recording" file to be listed in _scans.tsv not just "neural recording"

### DIFF
--- a/src/modality-agnostic-files.md
+++ b/src/modality-agnostic-files.md
@@ -429,7 +429,7 @@ sub-<label>/
 
 Optional: Yes
 
-The purpose of this file is to describe timing and other properties of each neural recording *file* within one session.
+The purpose of this file is to describe timing and other properties of each recording *file* within one session.
 In general, each of these files SHOULD be described by exactly one row.
 
 For *file formats* that are based on several files of different extensions,


### PR DESCRIPTION
I think this would be more appropriate since we could have _beh and other files with their acq_time.  I kept it as "recording file" (not e.g. just "data file") to keep better alignment with acq_time name of the column.

So could also be "acquisition time" instead of "recording time".
