### PR TITLE
[MISC][SCHEMA] Add schema-code sphinx generated read the docs to CI; pushes to bids-standard/schema-docs

### DIFF
--- a/.github/workflows/schema_docs.yaml
+++ b/.github/workflows/schema_docs.yaml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
 
 
-    - name: Update schema-docs repo from bids-specification
+    - name: Pull schema-docs and reqs from bids-specification
       run: |
         
         pushd $HOME
@@ -57,12 +57,12 @@ jobs:
       with:
         limit-access-to-actor: true
     
-    - name: Finish
+    - name: Push Updates to schema-docs
       run: |    
       
         pushd $HOME/schema-docs
         
-        git diff --exit-code 
+        git diff --exit-code > $HOME/gitdiff.log
         if [[ $? == 0 ]]; then
           echo "No changes found schema code, this workflow should only run when changes are made to schema-*."
           echo "You must be up to no good."

--- a/.github/workflows/schema_docs.yaml
+++ b/.github/workflows/schema_docs.yaml
@@ -6,9 +6,6 @@ on:
       - "master"
     tags:
       - "schema-*"
-  pull_request:
-    branches:
-      - "*"
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/schema_docs.yaml
+++ b/.github/workflows/schema_docs.yaml
@@ -35,12 +35,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Debug
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-      timeout-minutes: 15
-      with:
-        limit-access-to-actor: true
 
     - name: Update schema-docs repo from bids-specification
       run: |
@@ -56,6 +50,16 @@ jobs:
         sort $HOME/schema-docs/requirements.txt | uniq > $HOME/schema-docs/requirements.txt.tmp
         mv $HOME/schema-docs/requirements.txt.tmp $HOME/schema-docs/requirements.txt
 
+    - name: Debug
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      timeout-minutes: 15
+      with:
+        limit-access-to-actor: true
+    
+    - name: Finish
+      run: |    
+      
         pushd $HOME/schema-docs
         
         git diff --exit-code 

--- a/.github/workflows/schema_docs.yaml
+++ b/.github/workflows/schema_docs.yaml
@@ -1,0 +1,69 @@
+name: "schemacode_docs"
+
+on:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "schema-*"
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  push_schema_for_docs:
+    runs-on: ${{ matrix.os }}
+    name: Push Schema to Schema Docs
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Debug
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      timeout-minutes: 15
+      with:
+        limit-access-to-actor: true
+
+    - name: Update schema-docs repo from bids-specification
+      run: |
+        
+        pushd $HOME
+        git config --global user.name "${{ github.actor }}"
+        git config --global user.email "${{ github.actor}}@noreply.com"
+        git clone https://${{ github.repository_owner }}:${{ secrets.SCHEMA_DOCS_GITHUB_API_TOKEN }}@github.com/${{ github.repository_owner }}/schema-docs
+        popd
+        rsync --recursive --copy-links ${{ github.workspace }}/tools/schemacode/bidsschematools $HOME/schema-docs/
+        rsync --recursive --copy-links ${{ github.workspace }}/tools/schemacode/docs $HOME/schema-docs/
+        cat ${{ github.workspace }}/requirements.txt | grep -v tools/schemacode >> $HOME/schema-docs/requirements.txt
+        sort $HOME/schema-docs/requirements.txt | uniq > $HOME/schema-docs/requirements.txt.tmp
+        mv $HOME/schema-docs/requirements.txt.tmp $HOME/schema-docs/requirements.txt
+
+        pushd $HOME/schema-docs
+        
+        git diff --exit-code 
+        if [[ $? == 0 ]]; then
+          echo "No changes found schema code, this workflow should only run when changes are made to schema-*."
+          echo "You must be up to no good."
+        else
+          git add --all
+          git commit -m "Auto update from bids-specification ${{ github.sha }}"
+          git push origin main
+        fi

--- a/.github/workflows/schema_docs.yaml
+++ b/.github/workflows/schema_docs.yaml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Debug
       uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      if: ${{ inputs.debug_enabled }}
       timeout-minutes: 15
       with:
         limit-access-to-actor: true

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# schema docs documentation
+tools/schemacode/build/*
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/tools/schemacode/docs/Makefile
+++ b/tools/schemacode/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = 
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tools/schemacode/docs/bidsschematools.rst
+++ b/tools/schemacode/docs/bidsschematools.rst
@@ -1,0 +1,41 @@
+.. bidsschematools:
+
+render
+------
+
+.. automodule:: bidsschematools.render
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+schema
+------
+
+.. automodule:: bidsschematools.schema
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+utils
+-----
+
+.. automodule:: bidsschematools.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+validator
+---------
+
+.. automodule:: bidsschematools.validator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+types
+-----
+
+.. automodule:: bidsschematools.types
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tools/schemacode/docs/conf.py
+++ b/tools/schemacode/docs/conf.py
@@ -1,0 +1,61 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+import pathlib
+
+schemacode_path = pathlib.Path(os.path.abspath('bidsschematools'))
+sys.path.insert(0, str(schemacode_path))
+#sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'bidsschematools'
+copyright = '2022, bids-specification'
+author = 'bids-specification'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.duration',
+    'sphinx.ext.doctest',
+    'sphinx_rtd_theme',
+    'sphinx.ext.coverage',
+    'sphinx.ext.napoleon'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'tests']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+#html_static_path = ['_static']

--- a/tools/schemacode/docs/conf.py
+++ b/tools/schemacode/docs/conf.py
@@ -14,16 +14,16 @@ import os
 import sys
 import pathlib
 
-schemacode_path = pathlib.Path(os.path.abspath('bidsschematools'))
+schemacode_path = pathlib.Path(os.path.abspath("bidsschematools"))
 sys.path.insert(0, str(schemacode_path))
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'bidsschematools'
-copyright = '2022, bids-specification'
-author = 'bids-specification'
+project = "bidsschematools"
+copyright = "2022, bids-specification"
+author = "bids-specification"
 
 
 # -- General configuration ---------------------------------------------------
@@ -32,20 +32,20 @@ author = 'bids-specification'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.duration',
-    'sphinx.ext.doctest',
-    'sphinx_rtd_theme',
-    'sphinx.ext.coverage',
-    'sphinx.ext.napoleon'
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx_rtd_theme",
+    "sphinx.ext.coverage",
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'tests']
+exclude_patterns = ["_build", "tests"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -53,9 +53,9 @@ exclude_patterns = ['_build', 'tests']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/tools/schemacode/docs/conf.py
+++ b/tools/schemacode/docs/conf.py
@@ -11,8 +11,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
 import pathlib
+import sys
 
 schemacode_path = pathlib.Path(os.path.abspath("bidsschematools"))
 sys.path.insert(0, str(schemacode_path))

--- a/tools/schemacode/docs/index.rst
+++ b/tools/schemacode/docs/index.rst
@@ -1,0 +1,15 @@
+Welcome to bidsschematools's documentation!
+===========================================
+
+.. toctree::
+   modules
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/tools/schemacode/docs/make.bat
+++ b/tools/schemacode/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tools/schemacode/docs/modules.rst
+++ b/tools/schemacode/docs/modules.rst
@@ -1,0 +1,7 @@
+bidsschematools
+===============
+
+.. toctree::
+    :maxdepth: 4
+
+    bidsschematools


### PR DESCRIPTION
Setup sphinx to generate RTD page for schema-code and push changes to separate repo at `bids-standard/schema-docs` to trigger build on readthedocs page.

Need to follow up w/ creation of a RTD page as current page [schemadocsplaceholder](https://schemadocsplaceholder.readthedocs.io/en/latest/) is under my account  not bids-standard.

