### PR TITLE
BF: sizes were decided to be in meters. Fix examples

### DIFF
--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -269,10 +269,10 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
         "SoftwareRRID": "SCR_002881",
         "SoftwareVersion": "3.0.14",
         "Code": "doi:10.5281/zenodo.3361717",
-        "ScreenDistance": 180,
+        "ScreenDistance": 1.8,
         "ScreenRefreshRate": 60,
         "ScreenResolution": [1920, 1200],
-        "ScreenSize": [47.2, 29.5]
+        "ScreenSize": [0.472, 0.295]
     }
 }
 ```

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2863,8 +2863,8 @@ ScreenSize:
   name: ScreenSize
   display_name: Screen Size
   description: |
-    Screen size in cm, excluding potential screen borders
-    (for example `[47.2, 29.5]` for a screen of 47.2-width by 29.5-height cm),
+    Screen size in m, excluding potential screen borders
+    (for example `[0.472, 0.295]` for a screen of 47.2-width by 29.5-height cm),
     if no screen use `n/a`.
   anyOf:
     - type: array


### PR DESCRIPTION
Follow up to https://github.com/bids-standard/bids-specification/pull/1369
