### PR TITLE
[FIX] Updated links and fixed typos in hed appendix

### DIFF
--- a/src/appendices/hed.md
+++ b/src/appendices/hed.md
@@ -122,7 +122,7 @@ Pathname/images/red_square.jpg
 Another tagging strategy is to annotate individual events directly by
 including a `HED` column in the `events.tsv` file.
 This approach is necessary when each event has annotations that are unique
-and do not fit into a standard set of patterns, 
+and do not fit into a standard set of patterns,
 such as during manual annotation of artifacts or signal features.
 
 Some acquisition or presentation software systems may produce

--- a/src/appendices/hed.md
+++ b/src/appendices/hed.md
@@ -167,7 +167,7 @@ This allows for a proper validation of the HED annotations
 
 Example: The following `dataset_description.json` file specifies that the
 [`HED8.1.0.xml`](https://github.com/hed-standard/hed-schemas/blob/main/standard_schema/hedxml/HED8.1.0.xml)
-file from the `hedxml` directory of the
+file from the `standard_schema/hedxml` directory of the
 [`hed-schemas`](https://github.com/hed-standard/hed-schemas)
 repository on GitHub should be used to validate the study event annotations.
 
@@ -180,7 +180,10 @@ repository on GitHub should be used to validate the study event annotations.
 ```
 
 If you omit the `HEDVersion` field from the dataset description file,
-an error will result.
+a warning will be generated and
+any present HED information will be validated using the latest version of the HED schema.
+This is bound to result in problems, and hence, it is strongly RECOMMENDED that the
+`HEDVersion` field be included when using HED in a BIDS dataset.
 
 ### Using HED library schemas
 


### PR DESCRIPTION
HED repos and docs have been reorganized. 

The main location of the HED schemas and library schemas is now the `hed-schemas` repository.
Copies of the HED standard schema will remain in the `hed-specification` repository for continuity.
Documentation has been consolidated at [https://www.hed-resources.org](https://www.hed-resources.org).

An example was simplified and a few typos also corrected.
