### PR TITLE
SCHEMA: Add DuplicateFiles rule that must be implemented by each validator

### DIFF
--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -214,30 +214,33 @@ These are to be populated by an *interpreter* of the schema, and provide the
 
 The following operators should be defined by an interpreter:
 
-| Operator  | Definition                                                    | Example                                       |
-| --------- | ------------------------------------------------------------- | --------------------------------------------- |
-| `==`      | equality                                                      | `suffix == "T1w"`                             |
-| `!=`      | inequality                                                    | `entities.task != "rest"`                     |
-| `<`/`>`   | less-than / greater-than                                      | `sidecar.EchoTime < 0.5`                      |
-| `<=`/`>=` | less-than-or-equal / greater-than-or-equal                    | `0 <= 4`                                      |
-| `in`      | object lookup, true if RHS is a subfield of LHS               | `"Units" in sidecar`                          |
-| `!`       | negation, true if the following value is false, or vice versa | `!true == false`                              |
-| `&&`      | conjunction, true if both RHS and LHS are true                | `"Units" in sidecar && sidecar.Units == "mm"` |
-| `\|\|`    | disjunction, true if either RHS or LHS is true                | `a < mn \|\| a > mx`                          |
-| `.`       | object query, returns value of subfield                       | `sidecar.Units`                               |
-| `[]`      | array index, returns value of Nth element (0-indexed) of list | `columns.participant_label[0]`                |
+| Operator    | Definition                                                    | Example                                       |
+| ----------- | ------------------------------------------------------------- | --------------------------------------------- |
+| `==`        | equality                                                      | `suffix == "T1w"`                             |
+| `!=`        | inequality                                                    | `entities.task != "rest"`                     |
+| `<`/`>`     | less-than / greater-than                                      | `sidecar.EchoTime < 0.5`                      |
+| `<=`/`>=`   | less-than-or-equal / greater-than-or-equal                    | `0 <= 4`                                      |
+| `in`        | object lookup, true if RHS is a subfield of LHS               | `"Units" in sidecar`                          |
+| `!`         | negation, true if the following value is false, or vice versa | `!true == false`                              |
+| `&&`        | conjunction, true if both RHS and LHS are true                | `"Units" in sidecar && sidecar.Units == "mm"` |
+| `\|\|`      | disjunction, true if either RHS or LHS is true                | `a < mn \|\| a > mx`                          |
+| `.`         | object query, returns value of subfield                       | `sidecar.Units`                               |
+| `[]`        | array index, returns value of Nth element (0-indexed) of list | `columns.participant_label[0]`                |
+| `+`         | numeric addition / string concatenation                       | `x + 1`, `stem + "suffix"`                    |
+| `-`/`*`/`/` | numeric operators (division coerces to float)                 | `length(array) - 2`, `x * 2`, `1 / 2 == 0.5`  |
 
 The following functions should be defined by an interpreter:
 
-| Function                                 | Definition                                                                    | Example                                          | Note                                                                           |
-| ---------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------ |
-| `match(arg: str, pattern: str) -> bool`  | `true` if `arg` matches the regular expression `pattern` (anywhere in string) | `match(extension, ".gz$")`                       | True if the file extension ends with `.gz`                                     |
-| `type(arg: Any) -> str`                  | The name of the type, including `"array"`, `"object"`, `"null"`               | `type(datatypes)`                                | Returns `"array"`                                                              |
-| `intersects(a: array, b: array) -> bool` | `true` if arguments contain any shared elements                               | `intersects(dataset.modalities, ["pet", "mri"])` | True if either PET or MRI data is found in dataset                             |
-| `length(arg: array) -> int`              | Number of elements in an array                                                | `length(columns.onset) > 0`                      | True if there is at least one value in the onset column                        |
-| `count(arg: array, val: any)`            | Number of elements in an array equal to `val`                                 | `count(columns.type, "EEG")`                     | The number of times "EEG" appears in the column "type" of the current TSV file |
-| `min(arg: array)`                        | The smallest non-`n/a` value in an array                                      | `min(sidecar.SliceTiming) == 0`                  | A check that the onset of the first slice is 0s                                |
-| `max(arg: array)`                        | The largest non-`n/a` value in an array                                       | `max(columns.onset)`                             | The time of the last onset in an events.tsv file                               |
+| Function                                        | Definition                                                                    | Example                                          | Note                                                                           |
+| ----------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `match(arg: str, pattern: str) -> bool`         | `true` if `arg` matches the regular expression `pattern` (anywhere in string) | `match(extension, ".gz$")`                       | True if the file extension ends with `.gz`                                     |
+| `substr(arg: str, start: int, end: int) -> str` | The portion of the input string spanning from start position to end position  | `substr(path, 0, length(path) - 3)`              | `path` with the last three characters dropped                                  |
+| `type(arg: Any) -> str`                  	  | The name of the type, including `"array"`, `"object"`, `"null"`               | `type(datatypes)`                                | Returns `"array"`                                                              |
+| `intersects(a: array, b: array) -> bool` 	  | `true` if arguments contain any shared elements                               | `intersects(dataset.modalities, ["pet", "mri"])` | True if either PET or MRI data is found in dataset                             |
+| `length(arg: array) -> int`              	  | Number of elements in an array                                                | `length(columns.onset) > 0`                      | True if there is at least one value in the onset column                        |
+| `count(arg: array, val: any)`            	  | Number of elements in an array equal to `val`                                 | `count(columns.type, "EEG")`                     | The number of times "EEG" appears in the column "type" of the current TSV file |
+| `min(arg: array)`                        	  | The smallest non-`n/a` value in an array                                      | `min(sidecar.SliceTiming) == 0`                  | A check that the onset of the first slice is 0s                                |
+| `max(arg: array)`                        	  | The largest non-`n/a` value in an array                                       | `max(columns.onset)`                             | The time of the last onset in an events.tsv file                               |
 
 #### The special value `null`
 

--- a/src/schema/rules/checks/general.yaml
+++ b/src/schema/rules/checks/general.yaml
@@ -1,0 +1,12 @@
+---
+# BIDS Validator Original Issue Code #74
+# Was DUPLICATE_NIFTI_FILES, but applies generally
+DuplicateFiles:
+  code: DUPLICATE_FILES
+  message: |
+    File exists with and without `.gz` extension
+  level: error
+  selectors:
+    - match(extension, '\.gz$')
+  checks:
+    - "!exists(substr(path, 0, length(path) - 3))"

--- a/src/schema/rules/errors.yaml
+++ b/src/schema/rules/errors.yaml
@@ -118,16 +118,6 @@ WrongNewLine:
   selectors:
     - extension == ".tsv"
 
-# BIDS Validator Original Issue Code #74
-# Was DUPLICATE_NIFTI_FILES, but applies generally
-DuplicateFiles:
-  code: DUPLICATE_FILES
-  message: |
-    File exists with and without `.gz` extension
-  level: error
-  selectors:
-    - match(extension, '\.gz$')
-
 # BIDS Validator Original Issue Code #88
 MalformedBvec:
   code: MALFORMED_BVEC

--- a/src/schema/rules/errors.yaml
+++ b/src/schema/rules/errors.yaml
@@ -119,6 +119,16 @@ WrongNewLine:
     - extension == ".tsv"
 
 # BIDS Validator Original Issue Code #74
+# Was DUPLICATE_NIFTI_FILES, but applies generally
+DuplicateFiles:
+  code: DUPLICATE_FILES
+  message: |
+    File exists with and without `.gz` extension
+  level: error
+  selectors:
+    - match(extension, '\.gz$')
+
+# BIDS Validator Original Issue Code #88
 MalformedBvec:
   code: MALFORMED_BVEC
   message: |
@@ -127,7 +137,7 @@ MalformedBvec:
   selectors:
     - extension == ".bvec"
 
-# BIDS Validator Original Issue Code #88
+# BIDS Validator Original Issue Code #89
 MalformedBval:
   code: MALFORMED_BVAL
   message: |
@@ -136,7 +146,7 @@ MalformedBval:
   selectors:
     - extension == ".bval"
 
-# BIDS Validator Original Issue Code #89
+# BIDS Validator Original Issue Code #90
 SidecarWithoutDatafile:
   code: SIDECAR_WITHOUT_DATAFILE
   message: |
@@ -145,7 +155,7 @@ SidecarWithoutDatafile:
   selectors:
     - extension == ".json"
 
-# BIDS Validator Original Issue Code #90
+# BIDS Validator Original Issue Code #97
 MissingSession:
   code: MISSING_SESSION
   message: |


### PR DESCRIPTION
Converts issue 74 (`DUPLICATE_NIFTI_FILES`) to generic `DUPLICATE_FILES` error if the same file exists both compressed and uncompressed.

If we add a slicing operator (or substring function), we could write the check in schema:

```YAML
selectors:
  - match(extension, '\.gz$')
check:
  - path[:length(path) - 3] in dataset.files
```