### PR TITLE
Add to schemacode_ci.yml a workflow to publish master version of schema

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -125,6 +125,43 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+  publish-schema:
+    runs-on: ${{ matrix.os }}
+    name: Publish to dandi-schema (on master)
+    needs: [ publish ]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: "Checkout dandi-schema"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          repository: bids-standard/bids-schema
+
+      - name: Set Up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install the schemacode package for bst tool used by inject-schema
+        run: |
+          python -m pip install --progress-bar off --upgrade pip setuptools wheel
+          python -m pip install -e ./tools/schemacode[all]
+
+      - name: "Add copy of 'master' to bids-schema"
+        run:
+          sha=$(git describe --match 'v*' --always master)
+          cd bids-schema
+          tools/inject-schema master ..
+          if ! git diff --exit-code; then
+            git config credential.helper 'cache --timeout=120'
+            git config user.email "bids.maintenance@gmail.com"
+            git config user.name "bids-maintenance"
+
+            git add versions/
+            git commit -m "Added master version of schema from $sha"
+            git push https://${{ secrets.CHANGE_TOKEN }}@github.com/bids-standard/bids-schema.git main
+          fi
+
   validate_schema:
     runs-on: ubuntu-latest
     name: Validate schema


### PR DESCRIPTION
The idea is to automate population/updates to  https://github.com/bids-standard/bids-schema/tree/main/versions/master . original issue is https://github.com/bids-standard/bids-schema/issues/7 but likely we want to make workflow here to react immediately on pushes to master and releases (only when typing this thought : "why? couldn't we just make workflow triggered from pushes to master here or releases?")

Unfortunately we cannot use this workflow for publishing on releases since it reacts to schema- tags and not v* tags and anyways not taking care about actual releases of the bids-specification itself.  So we would either need to move this into release workflow (is it the circleci one?) or just duplicate this directly in  bids-schema  making it to run there on cron and checking version tags.

Also probably I need some custom to that repo CHANGE_TOKEN to be able to push to it.

But before anything else, may be @effigies @sappelhoff or @tsalo have better ideas on how to wrap it all up?  May be indeed just keeping it in `bids-schema` but having it  triggered from here within `bids-schema` repo?