### PR TITLE
SCHEMA: Add convenience objects to nifti_header context

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -266,6 +266,22 @@ context:
           maxItems: 8
           items:
             type: number
+        shape:
+          name: 'Data shape'
+          description: 'Data array shape, equal to dim[1:dim[0] + 1]'
+          type: array
+          minItems: 0
+          maxItems: 7
+          items:
+            type: integer
+        voxel_sizes:
+          name: 'Voxel sizes'
+          description: 'Voxel sizes, equal to pixdim[1:dim[0] + 1]'
+          type: array
+          minItems: 0
+          maxItems: 7
+          items:
+            type: number
         xyzt_units:
           name: 'XYZT Units'
           description: 'Units of pixdim[1..4]'

--- a/src/schema/rules/checks/nifti.yaml
+++ b/src/schema/rules/checks/nifti.yaml
@@ -1,0 +1,38 @@
+---
+# 40
+NiftiDimension:
+  issue:
+    code: NIFTI_DIMENSION
+    message: |
+      NIfTI file's header field for dimension information blank or too short.
+    level: warning
+  selectors:
+    - type(nifti_header) != "null"
+  checks:
+    - length(nifti_header.shape) > 0
+    - min(nifti_header.shape) > 0
+
+# 41
+NiftiUnit:
+  issue:
+    code: NIFTI_UNIT
+    message: |
+      NIfTI file's header field for unit information for x, y, z, and t dimensions empty or too short
+    level: warning
+  selectors:
+    - type(nifti_header) != "null"
+  checks:
+    - nifti_header.xyzt_units.xyz != 'unknown'
+    - nifti_header.dim[0] < 4 || nifti_header.xyzt_units.t != 'unknown'
+
+# 42
+NiftiPixdim:
+  issue:
+    code: NIFTI_PIXDIM
+    message: |
+      NIfTI file's header field for pixel dimension information empty or too short.
+    level: warning
+  selectors:
+    - type(nifti_header) != "null"
+  checks:
+    - min(nifti_header.voxel_sizes) > 0


### PR DESCRIPTION
Some existing checks assumed that the NIfTI header had been interpreted, and not simply exposed as fields. This adds `shape == dim[1:dim[0] + 1]` and `voxel_sizes == pixdim[1:dim[0] + 1]`, which can range in length from 0 to 7.

This permits us to do things like check `min(shape) > 0`, which would be more inconvenient to do directly on `dim`.