### PR TITLE
[FIX] Rename `channels.tsv` column: `orientation_component` to `component`

### DIFF
--- a/src/modality-specific-files/near-infrared-spectroscopy.md
+++ b/src/modality-specific-files/near-infrared-spectroscopy.md
@@ -206,18 +206,18 @@ Any of the channel types defined in other BIDS specification MAY be used here as
 As several of these data types are commonly acquired using NIRS devices they are included as an example at the base of the table.
 Note that upper-case is REQUIRED.
 
-| **Keyword**                 | **Description**                                                                                                                                                              |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| NIRSCWAMPLITUDE             | Continuous wave amplitude measurements. Equivalent to dataType 001 in SNIRF.                                                                                                 |
-| NIRSCWFLUORESCENSEAMPLITUDE | Continuous wave fluorescence amplitude measurements. Equivalent to dataType 051 in SNIRF.                                                                                    |
-| NIRSCWOPTICALDENSITY        | Continuous wave change in optical density measurements. Equivalent to dataTypeLabel dOD in SNIRF.                                                                            |
-| NIRSCWHBO                   | Continuous wave oxygenated hemoglobin (oxyhemoglobin) concentration measurements. Equivalent to dataTypeLabel HbO in SNIRF.                                                  |
-| NIRSCWHBR                   | Continuous wave deoxygenated hemoglobin (deoxyhemoglobin) concentration measurements. Equivalent to dataTypeLabel HbR in SNIRF.                                              |
-| NIRSCWMUA                   | Continuous wave optical absorption  measurements. Equivalent to dataTypeLabel mua in SNIRF.                                                                                  |
-| ACCEL                       | Accelerometer channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z).                   |
-| GYRO                        | Gyrometer channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z).                       |
-| MAGN                        | Magnetomenter channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z).                   |
-| MISC                        | Miscellaneous                                                                                                                                                                |
+| **Keyword**                 | **Description**                                                                                                                                            |
+| --------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| NIRSCWAMPLITUDE             | Continuous wave amplitude measurements. Equivalent to dataType 001 in SNIRF.                                                                               |
+| NIRSCWFLUORESCENSEAMPLITUDE | Continuous wave fluorescence amplitude measurements. Equivalent to dataType 051 in SNIRF.                                                                  |
+| NIRSCWOPTICALDENSITY        | Continuous wave change in optical density measurements. Equivalent to dataTypeLabel dOD in SNIRF.                                                          |
+| NIRSCWHBO                   | Continuous wave oxygenated hemoglobin (oxyhemoglobin) concentration measurements. Equivalent to dataTypeLabel HbO in SNIRF.                                |
+| NIRSCWHBR                   | Continuous wave deoxygenated hemoglobin (deoxyhemoglobin) concentration measurements. Equivalent to dataTypeLabel HbR in SNIRF.                            |
+| NIRSCWMUA                   | Continuous wave optical absorption  measurements. Equivalent to dataTypeLabel mua in SNIRF.                                                                |
+| ACCEL                       | Accelerometer channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z). |
+| GYRO                        | Gyrometer channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z).     |
+| MAGN                        | Magnetomenter channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z). |
+| MISC                        | Miscellaneous                                                                                                                                              |
 
 ### Example `*_channels.tsv`
 

--- a/src/modality-specific-files/near-infrared-spectroscopy.md
+++ b/src/modality-specific-files/near-infrared-spectroscopy.md
@@ -214,9 +214,9 @@ Note that upper-case is REQUIRED.
 | NIRSCWHBO                   | Continuous wave oxygenated hemoglobin (oxyhemoglobin) concentration measurements. Equivalent to dataTypeLabel HbO in SNIRF.                                                  |
 | NIRSCWHBR                   | Continuous wave deoxygenated hemoglobin (deoxyhemoglobin) concentration measurements. Equivalent to dataTypeLabel HbR in SNIRF.                                              |
 | NIRSCWMUA                   | Continuous wave optical absorption  measurements. Equivalent to dataTypeLabel mua in SNIRF.                                                                                  |
-| ACCEL                       | Accelerometer channel, one channel for each spatial axis. An extra column `component` for the axis of the orientation MUST be added to the `*_channels.tsv` file (x, y or z). |
-| GYRO                        | Gyrometer channel, one channel for each spatial axis. An extra column `component` for the axis of the orientation MUST be added to the `*_channels.tsv` file (x, y or z).     |
-| MAGN                        | Magnetomenter channel, one channel for each spatial axis. An extra column `component` for the axis of the orientation MUST be added to the `*_channels.tsv` file (x, y or z). |
+| ACCEL                       | Accelerometer channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z).                   |
+| GYRO                        | Gyrometer channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z).                       |
+| MAGN                        | Magnetomenter channel, one channel for each spatial axis. An extra column `component` for the axis MUST be added to the `*_channels.tsv` file (x, y or z).                   |
 | MISC                        | Miscellaneous                                                                                                                                                                |
 
 ### Example `*_channels.tsv`

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -312,7 +312,9 @@ component:
   name: component
   display_name: Component
   description: |
-    Description of the spatial axis or component associated with the channel.
+    Description of the spatial axis or label of quaternion component associated with the channel. 
+    For example, `x`,`y`,`z` for position channels, 
+    or `quat_x`, `quat_y`, `quat_z`, `quat_w` for quaternion orientation channels.
   type: string
   enum:
     - x

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -312,8 +312,8 @@ component:
   name: component
   display_name: Component
   description: |
-    Description of the spatial axis or label of quaternion component associated with the channel. 
-    For example, `x`,`y`,`z` for position channels, 
+    Description of the spatial axis or label of quaternion component associated with the channel.
+    For example, `x`,`y`,`z` for position channels,
     or `quat_x`, `quat_y`, `quat_z`, `quat_w` for quaternion orientation channels.
   type: string
   enum:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -308,16 +308,21 @@ onset:
     acquired data point.
   type: number
   unit: s
-orientation_component:
-  name: orientation_component
-  display_name: Orientation Component
+component:
+  name: component
+  display_name: Component
   description: |
-    Description of the orientation of the channel.
+    Description of the spatial axis or component associated with the channel.
   type: string
   enum:
     - x
     - y
     - z
+    - quat_x
+    - quat_y
+    - quat_z
+    - quat_w
+    - n/a
 pathology:
   name: pathology
   display_name: Pathology

--- a/src/schema/rules/checks/nirs.yaml
+++ b/src/schema/rules/checks/nirs.yaml
@@ -44,14 +44,14 @@ ShortChannelCountReq:
   checks:
     - sidecar.ShortChannelCount == count(associations.channels.short_channel, true)
 
-OrientationComponent:
+Component:
   selectors:
     - datatype == "nirs"
     - suffix == "channels"
     - extension == ".tsv"
     - intersect(columns.type, ["ACCEL", "GYRO", "MAGN"])
   checks:
-    - columns.orientation_component != null
+    - columns.component != null
 
 RequiredChannels:
   selectors:

--- a/src/schema/rules/tabular_data/nirs.yaml
+++ b/src/schema/rules/tabular_data/nirs.yaml
@@ -21,7 +21,7 @@ nirsChannels:
     sampling_frequency:
       level: optional
       level_addendum: required if `SamplingFrequency` is `n/a` in `_nirs.json`
-    orientation_component:
+    component:
       level: optional
       level_addendum: required if `type` is `ACCEL`, `GYRO` or `MAGN`
     wavelength_actual: optional


### PR DESCRIPTION
Following the discussion on issue:

- #1393

(closes #1393)

- [x] update `orientation_component` column in `*_channels.tsv` to `component` to cover non-orientation spatial channels and 
- [x] wording change in motion channel description in NIRS spec. 

accompanying validator PR:

- https://github.com/bids-standard/bids-validator/pull/1629