### PR TITLE
[FIX] Close backtick in `TaskName` description

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -3240,7 +3240,7 @@ TaskName:
     No two tasks should have the same name.
     The task label included in the file name is derived from this `"TaskName"` field
     by removing all non-alphanumeric characters (that is, all except those matching `[0-9a-zA-Z]`).
-    For example `"TaskName"` `"faces n-back"` or `"head nodding" will correspond to task labels
+    For example `"TaskName"` `"faces n-back"` or `"head nodding"` will correspond to task labels
     `facesnback` and `headnodding`, respectively.
   type: string
 TermURL:


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/83442/221943985-aabe66c5-57b4-47a7-b219-d960103481db.png)
