### PR TITLE
SCHEMA Update BloodMetabolite tabular data rule to match surrounding rules.

### DIFF
--- a/src/schema/rules/tabular_data/pet.yaml
+++ b/src/schema/rules/tabular_data/pet.yaml
@@ -37,6 +37,7 @@ BloodMetabolite:
     - suffix == "blood"
     - extension == ".tsv"
     - '"MetaboliteAvail" in sidecar'
+    - sidecar.MetaboliteAvail == true
   columns:
     metabolite_parent_fraction: required
     metabolite_polar_fraction: recommended


### PR DESCRIPTION
Sidecar entry `MetaboliteAvail` must be true for this rule to apply, not just present.

https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/09-positron-emission-tomography.html#blood-recording-data