### PR TITLE
SCHEMA bvals bvecs should only be listed missing for datafiles

### DIFF
--- a/src/schema/rules/checks/dwi.yaml
+++ b/src/schema/rules/checks/dwi.yaml
@@ -49,6 +49,7 @@ DWIMissingBvec:
     level: error
   selectors:
     - suffix == "dwi"
+    - extension != "json"
   checks:
     - '"bvec" in associations'
 
@@ -61,5 +62,6 @@ DWIMissingBval:
     level: error
   selectors:
     - suffix == "dwi"
+    - extension != "json"
   checks:
     - '"bval" in associations'


### PR DESCRIPTION
schema based valdiator was throwing errors for *_dwi.json sidecars in root of bids-examples/eeg_rest_fmri.