### PR TITLE
SCHEMA Make multipartid optional.

### DIFF
--- a/src/schema/rules/sidecars/dwi.yaml
+++ b/src/schema/rules/sidecars/dwi.yaml
@@ -1,9 +1,3 @@
-#
-# Groups of related metadata fields
-#
-# Assumptions: never need disjunction of selectors
-# Assumptions: top-to-bottom overrides is sufficient logic
-
 ---
 # Multipart (split) DWI schemes
 # NOTE: I don't think this can be schemafied, since it depends on owner intent.
@@ -12,7 +6,7 @@ MRIDiffusionMultipart:
     - modality == "mri"
     - datatype == "dwi"
   fields:
-    MultipartID: required
+    MultipartID: optional
 
 # Other recommended metadata
 MRIDiffusionOtherMetadata:


### PR DESCRIPTION
We lack sufficient selectors to tell when it should really be required:
https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#multipart-split-dwi-schemes