### PR TITLE
SCHEMA: Minor fixes

### DIFF
--- a/src/schema/rules/checks/dwi.yaml
+++ b/src/schema/rules/checks/dwi.yaml
@@ -24,7 +24,7 @@ DWIBvalRows:
       '.bval' files should contain exactly one row of volumes.
     level: error
   selectors:
-    - extension == "bval"
+    - extension == ".bval"
   checks:
     - data.n_rows == 1
 
@@ -36,7 +36,7 @@ DWIBvecRows:
       '.bvec' files should contain exactly three rows of volumes.
     level: error
   selectors:
-    - extension == "bvec"
+    - extension == ".bvec"
   checks:
     - data.n_rows == 3
 
@@ -49,7 +49,7 @@ DWIMissingBvec:
     level: error
   selectors:
     - suffix == "dwi"
-    - extension != "json"
+    - extension != ".json"
   checks:
     - '"bvec" in associations'
 
@@ -62,6 +62,6 @@ DWIMissingBval:
     level: error
   selectors:
     - suffix == "dwi"
-    - extension != "json"
+    - extension != ".json"
   checks:
     - '"bval" in associations'

--- a/src/schema/rules/checks/func.yaml
+++ b/src/schema/rules/checks/func.yaml
@@ -24,7 +24,7 @@ RepetitionTimeGreaterThan:
     level: warning
   selectors:
     - suffix == "bold"
-    - sidecar.RepetitionTime != "null"
+    - type(sidecar.RepetitionTime) != "null"
   checks:
     - sidecar.RepetitionTime <= 100
 
@@ -37,8 +37,8 @@ RepetitionTimeMismatch:
     level: error
   selectors:
     - suffix == "bold"
-    - sidecar.RepetitionTime != "null"
-    - nifti_header != "null"
+    - type(sidecar.RepetitionTime) != "null"
+    - type(nifti_header) != "null"
   checks:
     - sidecar.RepetitionTime == nifti_header.pixdim[4]
 
@@ -51,7 +51,7 @@ BoldNot4d:
     level: error
   selectors:
     - suffix == "bold"
-    - nifti_header != "null"
+    - type(nifti_header) != "null"
   checks:
     - nifti_header.dim[0] == 4
 


### PR DESCRIPTION
TODO: Purge ` in ` infix operator. Didn't have time. Can do it here or in another PR.

Did not replace all `obj != null` with `type(obj) != "null"` (or `==`). While we did decide on dropping `in`, it sounds like just directly checking null might be less problematic than we thought at first.