### PR TITLE
ENH: Clarify sample column values to be 0-based and possibly non-integer

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -394,10 +394,13 @@ sample:
   description: |
     Onset of the event according to the sampling scheme of the recorded modality
     (that is, referring to the raw data file that the `events.tsv` file accompanies).
+    A sample MAY contain a fractional part when the precision of the event recording
+    is higher than the sampling rate of the corresponding data file.
+    Sample indices start at 0.
     When there are several sampling schemes present in the raw data file (as can be
     the case for example for `.edf` files), this column is ambiguous and
     SHOULD NOT be used.
-  type: integer
+  type: number
 sample_id:
   name: sample_id
   display_name: Sample ID


### PR DESCRIPTION
Based on discussion in https://github.com/bids-standard/bids-examples/pull/356, it seems that defining the `sample` column of `events.tsv` as containing integer values may have been mistaken. This column was introduced in 1.2.0, when EEG and iEEG were added to the specification, and there does not appear to be consensus among contributors to those BEPs that this was intended to be an integer, with @arnodelorme stating:

> Sample latencies can sometimes be fractional because they come from a different machine that has more resolution than the EEG sampling frequency. This is important for reaction time, for example. Even with EEG sampled at 250 Hz, you need to be able to determine reaction time with 1ms (1000 Hz equivalent sampling rate) precision.

If sample is not purely an index, then it is a value where the time unit is not seconds. Therefore it should be possible to say "0 samples from the start of the run", resolving issue #499 in favor of 0-based "indexing".

This PR is necessary in order to correctly validate events.tsv files that contain non-integer sample indices.