### PR TITLE
[FIX] Clarify that dataset_description.Genetics object is required for genetics data

### DIFF
--- a/src/modality-specific-files/genetic-descriptor.md
+++ b/src/modality-specific-files/genetic-descriptor.md
@@ -20,7 +20,7 @@ and can be used for practical guidance when curating a new dataset.
 ## Dataset Description
 
 If information on associated genetic data is supplied as part of a BIDS dataset,
-genetic descriptors are encoded as an additional, REQUIRED entry in the
+these "genetic descriptors" are encoded as an additional, REQUIRED entry in the
 [`dataset_description.json`](../modality-agnostic-files.md#dataset_descriptionjson)
 file.
 

--- a/src/modality-specific-files/genetic-descriptor.md
+++ b/src/modality-specific-files/genetic-descriptor.md
@@ -19,7 +19,7 @@ and can be used for practical guidance when curating a new dataset.
 
 ## Dataset Description
 
-If genetic data is supplied as part of a BIDS dataset,
+If information on associated genetic data is supplied as part of a BIDS dataset,
 genetic descriptors are encoded as an additional, REQUIRED entry in the
 [`dataset_description.json`](../modality-agnostic-files.md#dataset_descriptionjson)
 file.

--- a/src/modality-specific-files/genetic-descriptor.md
+++ b/src/modality-specific-files/genetic-descriptor.md
@@ -19,11 +19,12 @@ and can be used for practical guidance when curating a new dataset.
 
 ## Dataset Description
 
-Genetic descriptors are encoded as an additional, OPTIONAL entry in the
+If genetic data is supplied as part of a BIDS dataset,
+genetic descriptors are encoded as an additional, REQUIRED entry in the
 [`dataset_description.json`](../modality-agnostic-files.md#dataset_descriptionjson)
 file.
 
-Datasets linked to a genetic database entry include the following REQUIRED or OPTIONAL
+Datasets linked to a genetic database entry include the following REQUIRED and OPTIONAL
 keys in the `Genetics` sub-[object][] of `dataset_description.json`:
 
 <!-- This block generates a table describing subfields within a metadata field.

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1139,18 +1139,18 @@ Genetics:
   type: object
   required_fields: [Dataset]
   properties:
-    Database:
-      name: Database
-      description: |
-        [URI](SPEC_ROOT/common-principles.md#uniform-resource-indicator)
-        of database where the dataset is hosted.
-      type: string
-      format: uri
     Dataset:
       name: Dataset
       description: |
         [URI](SPEC_ROOT/common-principles.md#uniform-resource-indicator)
         where data can be retrieved.
+      type: string
+      format: uri
+    Database:
+      name: Database
+      description: |
+        [URI](SPEC_ROOT/common-principles.md#uniform-resource-indicator)
+        of database where the dataset is hosted.
       type: string
       format: uri
     Descriptors:

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1137,6 +1137,7 @@ Genetics:
   description: |
     An object containing information about the genetics descriptor.
   type: object
+  required_fields: [Dataset]
   properties:
     Database:
       name: Database


### PR DESCRIPTION
also clarify that Genetics.Dataset is required if Genetics is supplied.

closes #1395


- old: https://bids-specification.readthedocs.io/en/latest/modality-specific-files/genetic-descriptor.html
- new: https://bids-specification--1442.org.readthedocs.build/en/1442/modality-specific-files/genetic-descriptor.html
