### PR TITLE
[ENH] Add explicit wording on DICOM terms correspondence

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -422,10 +422,11 @@ possible. Since the NIfTI standard offers limited support for the various image
 acquisition parameters available in DICOM files, we RECOMMEND that users provide
 additional meta information extracted from DICOM files in a sidecar JSON file
 (with the same filename as the `.nii[.gz]` file, but with a `.json` extension).
-Many of such metadata entries are explicitly formalized in BIDS and can be found listed in the [Glossary](./glossary.md).
-Whenever formalizing a new metadata entry within BIDS, the name SHOULD correspond to the original DICOM Tag whenever the value is taken *as is* without any further harmonization.
-The description of the term in the schema then SHOULD describe such correspondence as "Corresponds to DICOM Tag ID1, ID2 `DICOM Tag Name`.".
-If value is harmonized, the description SHOULD describe such correspondence as "Based on DICOM Tag ID1, ID2 `DICOM Tag Name`.".
+Currently defined metadata fields are listed in the [Glossary](./glossary.md).
+Where possible, DICOM Tags are adopted directly as BIDS metadata terms and
+indicated with "**Corresponds to** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
+When harmonization has been deemed necessary, this is indicated in the
+BIDS term description with "**Based on** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
 Extraction of BIDS compatible metadata can be performed using [dcm2niix](https://github.com/rordenlab/dcm2niix)
 and [dicm2nii](https://www.mathworks.com/matlabcentral/fileexchange/42997-xiangruili-dicm2nii)
 DICOM to NIfTI converters. The [BIDS-validator](https://github.com/bids-standard/bids-validator)

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -422,6 +422,9 @@ possible. Since the NIfTI standard offers limited support for the various image
 acquisition parameters available in DICOM files, we RECOMMEND that users provide
 additional meta information extracted from DICOM files in a sidecar JSON file
 (with the same filename as the `.nii[.gz]` file, but with a `.json` extension).
+Many of such metadata entries are explicitly formalized in BIDS and could be found listed in the [Glossary](./glossary.md).
+Whenever formalizing a new metadata entry within BIDS, the name SHOULD correspond to original DICOM Tag whenever the value is taken *as is* without any further harmonization.
+The description of the term in the schema SHOULD describe such correspondence as "Corresponds to DICOM Tag ID1, ID2 `DICOM Tag Name`.".
 Extraction of BIDS compatible metadata can be performed using [dcm2niix](https://github.com/rordenlab/dcm2niix)
 and [dicm2nii](https://www.mathworks.com/matlabcentral/fileexchange/42997-xiangruili-dicm2nii)
 DICOM to NIfTI converters. The [BIDS-validator](https://github.com/bids-standard/bids-validator)

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -422,7 +422,7 @@ possible. Since the NIfTI standard offers limited support for the various image
 acquisition parameters available in DICOM files, we RECOMMEND that users provide
 additional meta information extracted from DICOM files in a sidecar JSON file
 (with the same filename as the `.nii[.gz]` file, but with a `.json` extension).
-Many of such metadata entries are explicitly formalized in BIDS and could be found listed in the [Glossary](./glossary.md).
+Many of such metadata entries are explicitly formalized in BIDS and can be found listed in the [Glossary](./glossary.md).
 Whenever formalizing a new metadata entry within BIDS, the name SHOULD correspond to the original DICOM Tag whenever the value is taken *as is* without any further harmonization.
 The description of the term in the schema then SHOULD describe such correspondence as "Corresponds to DICOM Tag ID1, ID2 `DICOM Tag Name`.".
 If value is harmonized, the description SHOULD describe such correspondence as "Based on DICOM Tag ID1, ID2 `DICOM Tag Name`.".

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -423,8 +423,9 @@ acquisition parameters available in DICOM files, we RECOMMEND that users provide
 additional meta information extracted from DICOM files in a sidecar JSON file
 (with the same filename as the `.nii[.gz]` file, but with a `.json` extension).
 Many of such metadata entries are explicitly formalized in BIDS and could be found listed in the [Glossary](./glossary.md).
-Whenever formalizing a new metadata entry within BIDS, the name SHOULD correspond to original DICOM Tag whenever the value is taken *as is* without any further harmonization.
-The description of the term in the schema SHOULD describe such correspondence as "Corresponds to DICOM Tag ID1, ID2 `DICOM Tag Name`.".
+Whenever formalizing a new metadata entry within BIDS, the name SHOULD correspond to the original DICOM Tag whenever the value is taken *as is* without any further harmonization.
+The description of the term in the schema then SHOULD describe such correspondence as "Corresponds to DICOM Tag ID1, ID2 `DICOM Tag Name`.".
+If value is harmonized, the description SHOULD describe such correspondence as "Based on DICOM Tag ID1, ID2 `DICOM Tag Name`.".
 Extraction of BIDS compatible metadata can be performed using [dcm2niix](https://github.com/rordenlab/dcm2niix)
 and [dicm2nii](https://www.mathworks.com/matlabcentral/fileexchange/42997-xiangruili-dicm2nii)
 DICOM to NIfTI converters. The [BIDS-validator](https://github.com/bids-standard/bids-validator)


### PR DESCRIPTION
I was under impression that we had such wording somewhere but I failed to find. Such aspect came up during recent presentation by @rordenlab to SC,

<details>
<summary>and we already have lots of metadata fields formalized that way</summary> 

```shell
❯ git grep DICOM | grep -i -e based -e correspond
src/modality-specific-files/magnetic-resonance-imaging-data.md:Volume types are defined in the following table, based on DICOM Tag 0018, 9257 `ASL Context`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9073 `Acquisition Duration`.
src/schema/objects/metadata.yaml:    Based on DICOM Tag 0018, 925F `ASL Bolus Cut-off Delay Time`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 925C `ASL Bolus Cut-off Flag`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 925E `ASL Bolus Cut-off Technique`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 1048 `Contrast/Bolus Ingredient`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0054, 1322 `Dose Calibration Factor`.
src/schema/objects/metadata.yaml:    For Siemens, this corresponds to DICOM field 0019, 1018 (in ns).
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0081 `Echo Time`
src/schema/objects/metadata.yaml:    Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
src/schema/objects/metadata.yaml:    This corresponds to DICOM Tag 0018, 1242 `Actual Frame Duration` converted
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 101A `Hardcopy Device Software Version`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 1074 `Radionuclide Total Dose`.
src/schema/objects/metadata.yaml:    This corresponds to DICOM Tag 0018, 1072 `Contrast/Bolus Start Time`
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0082 `Inversion Time`
src/schema/objects/metadata.yaml:    Based on DICOM macro C.8.13.5.14.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9258 `ASL Pulse Train Duration`.
src/schema/objects/metadata.yaml:    Based on DICOM macro C.8.13.5.14.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9255 `ASL Slab Orientation`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9254 `ASL Slab Thickness`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0023 `MR Acquisition Type`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9049 `MR Transmit Coil Sequence`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9020 `Magnetization Transfer`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0087 `Magnetic Field Strength`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 1077 `Radiopharmaceutical Specific Activity`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9078 `Parallel Acquisition Technique`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9069 `Parallel Reduction Factor In-plane`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9155 `Parallel Reduction Factor out-of-plane`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9081 `Partial Fourier`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9036 `Partial Fourier Direction`.
src/schema/objects/metadata.yaml:    Based on DICOM Tags 0018, 9079 `Inversion Times` and 0018, 0082
src/schema/objects/metadata.yaml:    This does not correspond to a tag in the DICOM ontology.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 1250 `Receive Coil Name`,
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0022 `Scan Options`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0020 `Scanning Sequence`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0024 `Sequence Name`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 0021 `Sequence Variant`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 9259 `ASL Crusher Flag`.
src/schema/objects/metadata.yaml:    Corresponds to DICOM Tag 0018, 925A `ASL Crusher Flow Limit`.
src/schema/objects/suffixes.yaml:    Based on DICOM macro C.8.13.5.14.
src/schema/rules/checks/asl.yaml:      `*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
src/schema/rules/checks/asl.yaml:      Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
src/schema/rules/checks/asl.yaml:      Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
src/schema/rules/checks/asl.yaml:      Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
src/schema/rules/checks/asl.yaml:      Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
src/schema/rules/checks/asl.yaml:      Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
src/schema/rules/sidecars/asl.yaml:          bolus cut-off saturation pulses are provided. Based on DICOM Tag
src/schema/rules/sidecars/asl.yaml:          Corresponds to DICOM Tag 0018,925E `ASL Bolus Cut-off Technique`.
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0018, 1000 `DeviceSerialNumber`.
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 1010 `Station Name`.
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0018, 1020 `Software Versions`.
src/schema/rules/sidecars/mri.yaml:          for the acquisition, specified in seconds. Corresponds to DICOM Tag
src/schema/rules/sidecars/mri.yaml:          Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`. The data
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
src/schema/rules/sidecars/mri.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
src/schema/rules/sidecars/pet.yaml:        Corresponds to DICOM Tag 0054, 1001 `Units`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
src/schema/rules/sidecars/pet.yaml:        Corresponds to DICOM Tags (0008,0105) `Mapping Resource` and
src/schema/rules/sidecars/pet.yaml:        Corresponds to DICOM Tags (0008,0104) `CodeValue` and (0008,0104) `CodeMeaning`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag (0008,0034) `Intervention Drug Name`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag (0008,0028) `Intervention Drug Dose`.
src/schema/rules/sidecars/pet.yaml:        Corresponds to a combination of DICOM Tags (0008,0027) `Intervention Drug Stop Time`
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag (0018,1072) `Radiopharmaceutical Start Time`.
src/schema/rules/sidecars/pet.yaml:        Corresponds to DICOM Tag (0018,1073) `Radiopharmaceutical Stop Time`
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag (0008,0022) `Acquisition Date`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: This corresponds to DICOM Tag (0054,1101) `Attenuation Correction Method`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag (0054,1323) `Scatter Fraction Factor`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag (0054,1321) `Decay Factor`.
src/schema/rules/sidecars/pet.yaml:      description_addendum: Corresponds to DICOM Tag (0054,1322) `Dose Calibration Factor`.

```
</details>

but it seems lacking formalization of that.

Possible TODOs
- [x] extend for "Based on"
- find some other location than `Imaging files` since DICOMs could be the source of other data types (e.g., physio). What about RFing into a dedicated section `Data converted from DICOM files` or alike preceding specific `Imaging files`?
   - no feedback was received -- decided to not bother on this for now
- [x] ~~might be worth establishing correspondence at the level of the schema.~~ DONE File a dedicated issue for this. https://github.com/bids-standard/bids-specification/issues/1759
- Per @robertoostenveld correct note: later we might find similar correspondences to other formats/standards (e.g. NWB/Zarr) so wording might need to be adjusted later on, and aforementioned issue might want to mention that so relationship specification is not "assuming" DICOM only.
  - correct, that is why in #1759 suggested schema can allow for easy extension to other relation targets. Not a concern for this PR IMHO 