### PR TITLE
[FIX] Demote `sample` and `value` columns in `events.tsv` from OPTIONAL to arbitrary

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -396,16 +396,6 @@ response_time:
     - type: string
       enum:
         - n/a
-sample:
-  name: sample
-  display_name: Sample index
-  description: |
-    Onset of the event according to the sampling scheme of the recorded modality
-    (that is, referring to the raw data file that the `events.tsv` file accompanies).
-    When there are several sampling schemes present in the raw data file (as can be
-    the case for example for `.edf` files), this column is ambiguous and
-    SHOULD NOT be used.
-  type: integer
 sample_id:
   name: sample_id
   display_name: Sample ID
@@ -818,15 +808,6 @@ units__motion:
     and [Common Principles](SPEC_ROOT/common-principles.md#units) pages.
   type: string
   format: unit
-value:
-  name: value
-  display_name: Marker value
-  description: |
-    Marker value associated with the event (for example, the value of a TTL
-    trigger that was recorded at the onset of the event).
-  anyOf:
-    - type: number
-    - type: string
 volume_type:
   name: volume_type
   display_name: ASL volume type

--- a/src/schema/rules/tabular_data/task.yaml
+++ b/src/schema/rules/tabular_data/task.yaml
@@ -6,10 +6,8 @@ TaskEvents:
   columns:
     onset: required
     duration: required
-    sample: optional
     trial_type: optional
     response_time: optional
-    value: optional
     HED: optional
     stim_file: optional
   additional_columns: allowed


### PR DESCRIPTION
closes #1441 

As discussed in this comment:

- https://github.com/bids-standard/bids-specification/pull/1441#issuecomment-1482554152

Cc @Andesha @christinerogers