### PR TITLE
[MISC] consistently list filename templates; `ext` --> `extension`; `_photo.jpg` --> `_photo.<extension>`

### DIFF
--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -181,7 +181,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         <datatype>/
-            <source_entities>[_space-<space>][_desc-<label>]_<suffix>.<ext>
+            <source_entities>[_space-<space>][_desc-<label>]_<suffix>.<extension>
 ```
 
 Data is considered to be *preprocessed* or *cleaned* if the data type of the input,

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -11,7 +11,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         <datatype>/
-            <source_entities>[_space-<space>][_res-<label>][_den-<label>][_desc-<label>]_<suffix>.<ext>
+            <source_entities>[_space-<space>][_res-<label>][_den-<label>][_desc-<label>]_<suffix>.<extension>
 ```
 
 Volumetric preprocessing does not modify the number of dimensions, and so

--- a/src/derivatives/introduction.md
+++ b/src/derivatives/introduction.md
@@ -39,7 +39,7 @@ in [Derived dataset and pipeline description][derived-dataset-description].
     copy of that raw file.
 
 -   Each Derivatives filename MUST be of the form:
-    `<source_entities>[_keyword-<value>]_<suffix>.<ext>`
+    `<source_entities>[_keyword-<value>]_<suffix>.<extension>`
     (where `<value>` could either be an `<index>` or a `<label>` depending on
     the keyword; see [Definitions][definitions])
 

--- a/src/modality-specific-files/electroencephalography.md
+++ b/src/modality-specific-files/electroencephalography.md
@@ -22,7 +22,7 @@ and a guide for using macros can be found at
 {{ MACROS___make_filename_template(
    "raw",
    datatypes=["eeg"],
-   suffixes=["eeg", "events", "physio", "stim"])
+   suffixes=["eeg", "channels", "electrodes", "coordsystem", "photo", "events", "physio", "stim"])
 }}
 
 The EEG community uses a variety of formats for storing raw data, and there is

--- a/src/modality-specific-files/electroencephalography.md
+++ b/src/modality-specific-files/electroencephalography.md
@@ -421,7 +421,7 @@ voxels (starting from `[0, 0, 0]`).
 }
 ```
 
-## Landmark photos (`*_photo.jpg`)
+## Landmark photos (`*_photo.<extension>`)
 
 Photos of the anatomical landmarks and/or fiducials.
 
@@ -444,7 +444,7 @@ indicate acquisition of different photos of
 the same face (or other body part in different angles to show, for example, the
 location of the nasion (NAS) as opposed to the right periauricular point (RPA).
 
-### Example `*_photo.jpg`
+### Example `*_photo.<extension>`
 
 Picture of a NAS fiducial placed between the eyebrows, rather than at the
 actual anatomical nasion: `sub-0001_ses-001_acq-NAS_photo.jpg`

--- a/src/modality-specific-files/electroencephalography.md
+++ b/src/modality-specific-files/electroencephalography.md
@@ -22,7 +22,7 @@ and a guide for using macros can be found at
 {{ MACROS___make_filename_template(
    "raw",
    datatypes=["eeg"],
-   suffixes=["eeg", "channels", "electrodes", "coordsystem", "photo", "events", "physio", "stim"])
+   suffixes=["eeg", "events", "physio", "stim"])
 }}
 
 The EEG community uses a variety of formats for storing raw data, and there is

--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -430,7 +430,7 @@ data.
 }
 ```
 
-## Photos of the electrode positions (`*_photo.jpg`)
+## Photos of the electrode positions (`*_photo.<extension>`)
 
 <!--
 This block generates a filename templates.
@@ -451,18 +451,18 @@ or entirely omitted prior to sharing, depending on obtained consent.
 If there are photos of the electrodes, the [`acq-<label>`](../appendices/entities.md#acq) entity should be specified
 with:
 
--   `*_photo.jpg` in case of an operative photo
+-   `*_photo.<extension>` in case of an operative photo
 
--   `*_acq-xray#_photo.jpg` in case of an x-ray picture
+-   `*_acq-xray#_photo.<extension>` in case of an x-ray picture
 
--   `*_acq-drawing#_photo.jpg` in case of a drawing or sketch of electrode
+-   `*_acq-drawing#_photo.<extension>` in case of a drawing or sketch of electrode
     placements
 
--   `*_acq-render#_photo.jpg` in case of a rendering
+-   `*_acq-render#_photo.<extension>` in case of a rendering
 
 The [`ses-<label>`](../appendices/entities.md#ses) entity may be used to specify when the photo was taken.
 
-### Example `*_photo.jpg`
+### Example `*_photo.<extension>`
 
 Example of the operative photo of ECoG electrodes (here is an annotated example in
 which electrodes and vasculature are marked, taken from Hermes et al.,

--- a/src/modality-specific-files/magnetoencephalography.md
+++ b/src/modality-specific-files/magnetoencephalography.md
@@ -66,6 +66,12 @@ remember to list all files separately in `scans.tsv` and that the entries for th
 `acq_time` column in `scans.tsv` MUST all be identical, as described in
 [Scans file](../modality-agnostic-files.md#scans-file).
 
+The Neuromag/Elekta/Megin system may also produce datasets that require a set of
+`crosstalk` and `calibration` files to be used properly (see also filename templates above).
+Please refer to
+[Cross-talk and fine-calibration files](../appendices/meg-file-formats.md#cross-talk-and-fine-calibration-files)
+for more information on this detail.
+
 Another manufacturer-specific detail pertains to the KIT/Yokogawa/Ricoh system,
 which saves the MEG sensor coil positions in a separate file with two possible filename extensions  (`.sqd`, `.mrk`).
 For these files, the `markers` suffix MUST be used.

--- a/src/modality-specific-files/magnetoencephalography.md
+++ b/src/modality-specific-files/magnetoencephalography.md
@@ -391,10 +391,10 @@ For more information on typical coordinate systems for MEG-MRI coregistration:
 or:
 [http://neuroimage.usc.edu/brainstorm/CoordinateSystems](http://neuroimage.usc.edu/brainstorm/CoordinateSystems)
 
-## Landmark photos (`*_photo.jpg`)
+## Landmark photos (`*_photo.<extension>`)
 
 Photos of the anatomical landmarks and/or head localization coils
-(`*_photo.jpg`)
+(`*_photo.<extension>`)
 
 <!--
 This block generates a filename templates.
@@ -416,14 +416,14 @@ The [`acq-<label>`](../appendices/entities.md#acq) entity can be used to indicat
 the same face (or other body part in different angles to show, for example, the
 location of the nasion (NAS) as opposed to the right periauricular point (RPA)).
 
-### Example `*_photo.jpg`
+### Example `*_photo.<extension>`
 
 Example of the NAS fiducial placed between the eyebrows, rather than at the
 actual anatomical nasion: `sub-0001_ses-001_acq-NAS_photo.jpg`
 
 ![placement of NAS fiducial](images/sub-0001_ses-001_acq-NAS_photo.jpg "placement of NAS fiducial")
 
-## Head shape and electrode description (`*_headshape.<ext>`)
+## Head shape and electrode description (`*_headshape.<extension>`)
 
 <!--
 This block generates a filename templates.

--- a/src/modality-specific-files/motion.md
+++ b/src/modality-specific-files/motion.md
@@ -63,7 +63,8 @@ these time information MAY be stored in form of latencies to recording onset (fi
 If a system has uneven sampling rate behavior, the `LATENCY` channel can be used to share these information.
 
 To store events alongside motion data when there are multiple tracking systems simulatenously in use, it is RECOMMENDED to designate a tracking system to the events file.
-Such an events file name SHOULD include the `tracksys` key and looks like `sub-<label>[_ses-<label>]_task-<label>[_acq-<label>]_tracksys-<label>[_run-<index>]_events.tsv`.
+Such an events file name SHOULD include the `tracksys` key and looks like
+`sub-<label>[_ses-<label>]_task-<label>[_tracksys-<label>][_acq-<label>][_run-<index>]_events.tsv`
 Event latencies can then be related to motion samples of multiple tracking systems also by using `acq_time` column entries in the `*_scans.tsv`.
 The same principle applies when the events file is saved alongside a simultaneously recorded non-motion data (for example EEG).
 

--- a/src/modality-specific-files/motion.md
+++ b/src/modality-specific-files/motion.md
@@ -11,7 +11,7 @@ and can be used as helpful guidance when curating new datasets.
 {{ MACROS___make_filename_template(
 "raw",
 datatypes=["motion"],
-suffixes=["motion", "channels", "events", "physio", "stim"])
+suffixes=["motion", "events", "physio", "stim"])
 }}
 
 A wide variety of motion capture systems are used in human research, resulting in different proprietary data formats.

--- a/src/modality-specific-files/motion.md
+++ b/src/modality-specific-files/motion.md
@@ -11,7 +11,7 @@ and can be used as helpful guidance when curating new datasets.
 {{ MACROS___make_filename_template(
 "raw",
 datatypes=["motion"],
-suffixes=["motion", "channels", "events"])
+suffixes=["motion", "channels", "events", "physio", "stim"])
 }}
 
 A wide variety of motion capture systems are used in human research, resulting in different proprietary data formats.

--- a/src/modality-specific-files/near-infrared-spectroscopy.md
+++ b/src/modality-specific-files/near-infrared-spectroscopy.md
@@ -14,7 +14,7 @@ have been formatted using this specification and can be used for practical guida
 {{ MACROS___make_filename_template(
    "raw",
    datatypes=["nirs"],
-   suffixes=["nirs", "events", "channels", "optodes", "coordsystem", "physio", "stim"])
+   suffixes=["nirs", "events", "physio", "stim"])
 }}
 
 Only the *Shared Near Infrared Spectroscopy Format* ([SNIRF](https://github.com/fNIRS/snirf))

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -30,7 +30,6 @@ timeseries:
     - eeg
     - ieeg
     - nirs
-    - motion
   entities:
     subject: required
     session: optional
@@ -98,6 +97,14 @@ timeseries__meg:
   entities:
     $ref: rules.files.raw.task.timeseries.entities
     processing: optional
+
+timeseries__motion:
+  $ref: rules.files.raw.task.timeseries
+  datatypes:
+    - motion
+  entities:
+    $ref: rules.files.raw.task.timeseries.entities
+    tracksys: required
 
 timeseries__pet:
   $ref: rules.files.raw.task.timeseries

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -30,6 +30,7 @@ timeseries:
     - eeg
     - ieeg
     - nirs
+    - motion
   entities:
     subject: required
     session: optional

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -57,7 +57,7 @@ events__motion:
     - motion
   entities:
     $ref: rules.files.raw.task.events.entities
-    tracksys: required
+    tracksys: optional
 
 events__pet:
   $ref: rules.files.raw.task.events
@@ -104,7 +104,7 @@ timeseries__motion:
     - motion
   entities:
     $ref: rules.files.raw.task.timeseries.entities
-    tracksys: required
+    tracksys: optional
 
 timeseries__pet:
   $ref: rules.files.raw.task.timeseries


### PR DESCRIPTION
closes #1456 

**NOTE: see update below this post**

Looking at this more closely, I was a bit surprised to see "channels" as a potential suffix in the filename templates for MOTION ... but not for EEG.

This first commit is to try out what works and what doesn't: adding `photo` and `coordsystem` as well (see EEG spec: https://bids-specification.readthedocs.io/en/latest/modality-specific-files/electroencephalography.html)

Maybe we need to discuss this in more depth.

This is how it would look with the present changes: https://bids-specification--1458.org.readthedocs.build/en/1458/modality-specific-files/electroencephalography.html 

... it looks good to me, it picks up all the correct extensions.

cc @Remi-Gau 