### PR TITLE
[FIX] Clean up qMRI RB1COR notes

### DIFF
--- a/src/appendices/qmri.md
+++ b/src/appendices/qmri.md
@@ -706,9 +706,12 @@ The example above applies to the `TB1RFM` suffix as well.
 
 #### `RB1COR` specific notes
 
-This method generates a sensitivity map by combining two low resolution images
-collected by two transmit coils (the body and the head coil) upon subsequent scans
-with identical acquisition parameters.
+This method generates a receive sensitivity map by combining two low resolution images
+collected by two different RF coils in receive mode (the body and the head coil)
+with otherwise identical acquisition parameters.
+To correct for dynamic changes in the receive sensitivity over time due to, for example,
+subject motion, separate receive sensitivity maps may be acquired for each anatomical
+acquisition in a file collection.
 
 To properly identify constituents of this particular method, values of the `acq`
 entity SHOULD begin with either `body` or `head` and MAY be followed by freeform

--- a/src/appendices/qmri.md
+++ b/src/appendices/qmri.md
@@ -707,7 +707,7 @@ The example above applies to the `TB1RFM` suffix as well.
 #### `RB1COR` specific notes
 
 This method generates a receive sensitivity map by combining two low resolution images
-collected by two different RF coils in receive mode (the body and the head coil)
+collected sequentially by two different RF coils in receive mode (the body and the head coil)
 with otherwise identical acquisition parameters.
 To correct for dynamic changes in the receive sensitivity over time due to, for example,
 subject motion, separate receive sensitivity maps may be acquired for each anatomical


### PR DESCRIPTION
- The documentation of the RB1COR receive sensitivity mapping file collection referred to different "transmit" coils, rather than different "receive" coils. This is fixed by this pull request. Note that because the body coil can typically be used as a receive coil and a transmit coil, I have used the phrasing "coil in receive mode" rather than "receive coil".
-  It was unclear to me whether "upon subsequent scans" referred to the two RB1COR images being acquired sequentially, or to the possibility of acquiring a separate receive sensitivity map for each element of an MPM file collection. I have attempted to clarify this.