### PR TITLE
Logging info on error-less validation, better warning/error separation

### DIFF
--- a/tools/schemacode/bidsschematools/validator.py
+++ b/tools/schemacode/bidsschematools/validator.py
@@ -270,16 +270,24 @@ def log_errors(validation_result):
     """
     total_file_count = len(validation_result["path_listing"])
     validated_files_count = total_file_count - len(validation_result["path_tracking"])
-    if validated_files_count == 0:
-        lgr.error("No valid BIDS files were found.")
-    for entry in validation_result["schema_tracking"]:
-        if entry["mandatory"]:
-            lgr.error(
-                "The `%s` regex pattern file required by BIDS was not found.",
-                entry["regex"],
-            )
+    errorless = True
     for i in validation_result["path_tracking"]:
         lgr.warning("The `%s` file was not matched by any regex schema entry.", i)
+        errorless = False
+    if validated_files_count == 0:
+        lgr.error("No valid BIDS files were found.")
+        errorless = False
+    else:
+        # No use reporting this separately if no BIDS files were found
+        for entry in validation_result["schema_tracking"]:
+            if entry["mandatory"]:
+                lgr.error(
+                    "The `%s` regex pattern file required by BIDS was not found.",
+                    entry["regex"],
+                )
+                errorless = False
+    if errorless:
+        lgr.info("All files are BIDS valid and not BIDS-required files are missing.")
 
 
 def select_schema_path(

--- a/tools/schemacode/bidsschematools/validator.py
+++ b/tools/schemacode/bidsschematools/validator.py
@@ -287,7 +287,7 @@ def log_errors(validation_result):
                 )
                 errorless = False
     if errorless:
-        lgr.info("All files are BIDS valid and not BIDS-required files are missing.")
+        lgr.info("SUCCESS: All files are BIDS valid and no BIDS-required files are missing.")
 
 
 def select_schema_path(


### PR DESCRIPTION
Ideally we would inform the user that validation was successful. Could also do it with a print call... but logging seems like it would prevent stdout from getting cluttered when this is used as a lib.

Let me know :)