### PR TITLE
[FIX] Revert index (entity format) definition to be a non-negative number, permitting zero

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -709,7 +709,7 @@ for naming of participants, sessions, acquisition schemes.
 Note that they MUST consist only of allowed characters as described in
 [Definitions](common-principles.md#definitions) above.
 In `<index>`es we RECOMMEND using zero padding (for example, `01` instead of `1`
-if you have more than nine subjects) to make alphabetical sorting more intuitive.
+if you have more than ten subjects) to make alphabetical sorting more intuitive.
 Note that zero padding SHOULD NOT be used to merely maintain uniqueness
 of `<index>`es.
 

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -709,7 +709,7 @@ for naming of participants, sessions, acquisition schemes.
 Note that they MUST consist only of allowed characters as described in
 [Definitions](common-principles.md#definitions) above.
 In `<index>`es we RECOMMEND using zero padding (for example, `01` instead of `1`
-if you have more than ten subjects) to make alphabetical sorting more intuitive.
+if some participants have two-digit labels) to make alphabetical sorting more intuitive.
 Note that zero padding SHOULD NOT be used to merely maintain uniqueness
 of `<index>`es.
 

--- a/src/schema/objects/formats.yaml
+++ b/src/schema/objects/formats.yaml
@@ -5,7 +5,7 @@ index:
   display_name: Index
   description: |
     Non-negative, optionally prefixed with leading zeros for better visual homogeneity and sorting.
-  pattern: '[0-9]*'
+  pattern: '[0-9]+'
 label:
   display_name: Label
   description: |

--- a/src/schema/objects/formats.yaml
+++ b/src/schema/objects/formats.yaml
@@ -4,9 +4,8 @@
 index:
   display_name: Index
   description: |
-    Non-negative, non-zero integers, optionally prefixed with leading zeros for sortability.
-    An index may not be all zeros.
-  pattern: '[0-9]*[1-9]+[0-9]*'
+    Non-negative, optionally prefixed with leading zeros for better visual homogeneity and sorting.
+  pattern: '[0-9]*'
 label:
   display_name: Label
   description: |


### PR DESCRIPTION
In continuation of previous discussions, including https://github.com/bids-standard/bids-specification/pull/535/

A bit of theoretical background:
* An *index* simply labels elements of another set. There's no particular reason for zero to not be an index, in fact it might be the most used one :) 
* The confusion zero sometimes causes is when it is used as an *ordinal*, since it leads to an asymmetric break in the number line by virtue of being its own inverse additive. Notably there is no year 0AD (or BC). Mathematically this can be considered an atavism, 0th is a valid ordinal, the problem with having a year 0 is that it causes asymmetry since distances between years would need to be calculated based on their start/end regardless of their position, and not based on their start if BC and end if AD.

More practically, there are a few datasets which include `0` values of an index:

* https://openneuro.org/datasets/ds000017
* https://openneuro.org/datasets/ds003722
* https://openneuro.org/datasets/ds003810
* https://openneuro.org/datasets/ds003020
* https://openneuro.org/datasets/ds000244
* https://zenodo.org/record/3575149
* https://zenodo.org/record/3601531
* https://zenodo.org/record/3598424

and supporting this doesn't break or encumber anything (if anything it makes the regex matching marginally shorter).


If we were to explicitly exclude zero, I think ordinal would be a better notion, since zero is clearly what people think of as a valid index when reading the word index — though as explained above, even that is a bit arbitrary. The zeroth (nought) week is a thing at some colleges.

@effigies @yarikoptic 