### PR TITLE
SCHEMA: Relax SkullStripped metadata requirement for masks and segmentations

### DIFF
--- a/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
@@ -71,6 +71,7 @@ ImageDerivatives:
     - dataset.dataset_description.DatasetType == "derivative"
     - 'intersects([modality], ["mri", "pet"])'
     - 'match(extension, "^\.nii(\.gz)?$")'
+    - '!intersects([suffix], ["dseg", "probseg", "mask"])'
   fields:
     SkullStripped: required
 


### PR DESCRIPTION
The specification says `SkullStripped` is required for [Preprocessed, coregistered and/or resampled volumes](https://bids-specification.readthedocs.io/en/stable/05-derivatives/03-imaging.html#preprocessed-coregistered-andor-resampled-volumes), but is not listed for masks or segmentations. It's not clear that it's useful for these derviatives, so I propose removing this rule.

Appears when attempting to validate fMRIPrep derivatives:

```console
  ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ds000001-fmriprep                                                                                                                 │
  └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
    NOT_INCLUDED                               .SKIP_VALIDATION                                                                        
                                                                                                                                       
    TSV_COLUMN_MISSING                         desc-aparcaseg_dseg.tsv                    Columns cited as index columns not in        
                                                                                          file: index.                                 
                                                                                          schema.rules.tabular_data.derivatives.co     
                                                                                          mmon_derivatives.SegmentationLookup          
                                                                                                                                       
    JSON_KEY_REQUIRED                          sub-10_desc-aparcaseg_dseg.nii.gz          missing SkullStripped as per                 
                                                                                          schema.rules.sidecars.derivatives.common     
                                                                                          _derivatives.ImageDerivatives                
```