### PR TITLE
CI: Add pyparsing to build requirements

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install build dependencies"
         run: pip install --upgrade build twine
       - name: "Install test dependencies on tag"
-        run: pip install --upgrade pytest pyyaml pandas tabulate markdown-it-py
+        run: pip install --upgrade pytest pyyaml pandas tabulate markdown-it-py pyparsing
         if: ${{ startsWith(github.ref, 'refs/tags/schema-') }}
       - name: "Build archive on tag"
         run: pytest tools/schemacode/bidsschematools -k make_archive


### PR DESCRIPTION
Schema 0.7.0 failed to upload because our build process requires being able to import the entire module. We should come up with a better solution, but this is needed for now.

Mostly just want to test PR builds for the bidsschematools RTD.