### PR TITLE
CI: Hard-code codecov token so PRs can submit coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,5 @@
 ignore:
-    - "*/*/tests/*"
-    - "**/tests/*"
+  - "*/*/tests/*"
+  - "**/tests/*"
+codecov:
+  token: 7e84a7fb-8f7e-45f5-8dcc-9f5219fa3855


### PR DESCRIPTION
Based on the recommendations in [[0]], a hard-coded token is the only way to reliably get PRs from forks to submit coverage until rate-limiting on Codecov's use of the GitHub API are resolved. The scope of this token only permits an attacker to upload bad coverage reports, so the threat seems acceptably small.

[0]: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954