### PR TITLE
ENH: Add reference volumes to common imaging derivatives

### DIFF
--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -140,6 +140,31 @@ And the corresponding `sub-001_task-rest_run-1_space-fsLR_bold.json` file:
 }
 ```
 
+## Reference volumes
+
+Template:
+
+```Text
+<pipeline_name>/
+    sub-<label>/
+        func|dwi|perf/
+            <source_entities>[_space-<space>][_res-<label>][_desc-<label>]_<suffix>.nii.gz
+```
+
+A reference volume is a 3D image that is used to represent a 4D series.
+Reference volumes are often used for registration, as resampling targets,
+as well as for generating quality control reports.
+
+The suffix of a reference volume is derived by adding `ref` to the suffix
+of the series for which it is a reference.
+
+| Data type | Original suffix | Reference volume suffix |
+|-----------|-----------------|-------------------------|
+| `func`    | `bold`          | `boldref`               |
+| `func`    | `cbv`           | `cbvref`                |
+| `dwi`     | `dwi`           | `dwiref`                |
+| `perf`    | `asl`           | `aslref`                |
+
 ## Masks
 
 Template:

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -510,6 +510,11 @@ asllabeling:
     An anonymized screenshot of the planning of the labeling slab/plane
     with respect to the imaging slab or slices.
     This screenshot is based on DICOM macro C.8.13.5.14.
+aslref:
+  value: aslref
+  display_name: ASL reference image
+  description: |
+    Reference image for arterial spin labeling (ASL) series
 beh:
   value: beh
   display_name: Behavioral recording
@@ -529,11 +534,21 @@ bold:
   display_name: Blood-Oxygen-Level Dependent image
   description: |
     Blood-Oxygen-Level Dependent contrast (specialized T2\* weighting)
+boldref:
+  value: boldref
+  display_name: BOLD reference image
+  description: |
+    Reference image for blood-oxygen-level-dependent (BOLD) series
 cbv:
   value: cbv
   display_name: Cerebral blood volume image
   description: |
     Cerebral Blood Volume contrast (specialized T2\* weighting or difference between T1 weighted images)
+cbvref:
+  value: cbvref
+  display_name: CBV reference image
+  description: |
+    Reference image for cerebral blood volume (CBV) series
 channels:
   value: channels
   display_name: Channels File
@@ -563,6 +578,11 @@ dwi:
   display_name: Diffusion-weighted image
   description: |
     Diffusion-weighted imaging contrast (specialized T2 weighting).
+dwiref:
+  value: dwiref
+  display_name: DWI reference image
+  description: |
+    Reference image for diffusion-weighted imaging (DWI) series
 eeg:
   value: eeg
   display_name: Electroencephalography


### PR DESCRIPTION
It was discovered that fmriprep, aslprep and qsiprep all generate `<suffix>ref` volumes for their respective input modalities. Here is an initial proposal. I do not think we need any additional metadata over the universally RECOMMENDED `Description` and OPTIONAL `Sources`.

I kept `space-<label>` and `res-<label>` but not `den-<label>`, since these do make sense to resample into target spaces and possibly with resolutions differing from the input images, but there doesn't seem a clear analog for surface meshes. I suppose you could theoretically sample the `boldref` to a surface as a diagnostic, but I figure we should let the use case come up before specifying it.

Contradicting that, I threw `cbvref` in there, since it's functional data like `bold`. I have no clue how that's processed, but it seems reasonable to say "if you want a reference file, call it `cbvref`". In any case, there's nothing stopping modalities from adding another suffix that in practice they use as a reference volume. It is just useful to have a name for the thing that's not an actual average image but is some attempt to make a good registration target from what we are given.

Closes #1532.
