### PR TITLE
SCHEMA: Define associated data with selectors, path components and inheritance

### DIFF
--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -1,0 +1,43 @@
+# These rules indicate whether an association (defined in meta.context.context.associations)
+# applies to a given file. These are hints to allow implementations to avoid unnecessary
+# directory and file reads.
+#
+# If the selectors match a given file, a conforming tool MUST attempt to load the association.
+# Tools MAY attempt to load associations when selectors do not match.
+---
+events:
+  selectors:
+    - 'task in entities'
+    - extension != '.json'
+aslcontext:
+  selectors:
+    - suffix == 'asl'
+    - matches(extension, '\.nii(\.gz)?$')
+m0scan:
+  selectors:
+    - suffix == 'asl'
+    - matches(extension, '\.nii(\.gz)?$')
+magnitude:
+  selectors:
+    - suffix == 'fieldmap'
+    - matches(extension, '\.nii(\.gz)?$')
+magnitude1:
+  selectors:
+    - matches(suffix, 'phase(diff|1)$')
+    - matches(extension, '\.nii(\.gz)?$')
+bval:
+  selectors:
+    - suffix == 'dwi'
+    - matches(extension, '\.nii(\.gz)?$')
+bvec:
+  selectors:
+    - suffix == 'dwi'
+    - matches(extension, '\.nii(\.gz)?$')
+channels:
+  selectors:
+    - intersects([suffix], ['eeg', 'ieeg', 'meg', 'nirs', 'motion', 'optodes'])
+    - extension != '.json'
+coordsystem:
+  selectors:
+    - intersects([suffix], ['eeg', 'ieeg', 'meg', 'nirs', 'motion', 'electrodes', 'optodes'])
+    - extension != '.json'

--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -2,42 +2,91 @@
 # applies to a given file. These are hints to allow implementations to avoid unnecessary
 # directory and file reads.
 #
-# If the selectors match a given file, a conforming tool MUST attempt to load the association.
-# Tools MAY attempt to load associations when selectors do not match.
+# Structure:
+#
+# - "selectors" is a sequence of expressions that apply to a file that may have an association.
+#   If matched, a tool MUST attempt to find the associated file.
+# - "target" contains a set of path components that may be used to search for the associated file.
+#   These override the path components of the original file and MUST match for the associated file.
+#   A list of values, such as extensions, indicates multiple possible matches.
+# - "inherit" is a boolean indicating whether the associated file may be found at a shallower level
+#   of the hierarchy.
 ---
 events:
   selectors:
     - 'task in entities'
     - extension != '.json'
+  target:
+    suffix: events
+    extension: .tsv
+  inherit: true
+
 aslcontext:
   selectors:
     - suffix == 'asl'
     - matches(extension, '\.nii(\.gz)?$')
+  target:
+    suffix: aslcontext
+    extension: .tsv
+  inherit: true
+
 m0scan:
   selectors:
     - suffix == 'asl'
     - matches(extension, '\.nii(\.gz)?$')
+  target:
+    suffix: m0scan
+    extension: [.nii, .nii.gz]
+  inherit: false
+
 magnitude:
   selectors:
     - suffix == 'fieldmap'
     - matches(extension, '\.nii(\.gz)?$')
+  target:
+    suffix: magnitude
+    extension: [.nii, .nii.gz]
+  inherit: false
+
 magnitude1:
   selectors:
     - matches(suffix, 'phase(diff|1)$')
     - matches(extension, '\.nii(\.gz)?$')
+  target:
+    suffix: magnitude1
+    extension: [.nii, .nii.gz]
+  inherit: false
+
 bval:
   selectors:
     - suffix == 'dwi'
     - matches(extension, '\.nii(\.gz)?$')
+  target:
+    extension: .bval
+  inherit: true
+
 bvec:
   selectors:
     - suffix == 'dwi'
     - matches(extension, '\.nii(\.gz)?$')
+  target:
+    extension: .bvec
+  inherit: true
+
 channels:
   selectors:
     - intersects([suffix], ['eeg', 'ieeg', 'meg', 'nirs', 'motion', 'optodes'])
     - extension != '.json'
+  target:
+    suffix: channels
+    extension: .tsv
+  inherit: true
+
 coordsystem:
   selectors:
     - intersects([suffix], ['eeg', 'ieeg', 'meg', 'nirs', 'motion', 'electrodes', 'optodes'])
     - extension != '.json'
+  target:
+    suffix: coordsystem
+    extension: .json
+  inherit: true


### PR DESCRIPTION
One difficulty with validation is knowing when it is worth making the effort to load an associated file. This meta-schema is intended to hint to validators and other implementations when associations may be relevant.

It could make sense to add filename rules here, as well as indicators of whether a file can be found through inheritance (making some path components optional) or not. For example `magnitude` images will never be found through inheritance, but must match all entities with their corresponding `fieldmap` images. `bval` and `bvec`, however, can be inherited.