### PR TITLE
[FIX] Re-align the text and the schema for filenames in derivatives

### DIFF
--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -180,8 +180,9 @@ Template:
 ```Text
 <pipeline_name>/
     sub-<label>/
-        <datatype>/
-            <source_entities>[_space-<space>][_desc-<label>]_<suffix>.<extension>
+        [ses-<label>/]
+            <datatype>/
+                <source_entities>[_space-<space>][_desc-<label>]_<suffix>.<extension>
 ```
 
 Data is considered to be *preprocessed* or *cleaned* if the data type of the input,

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -268,7 +268,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         anat|func|dwi/
-            <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>]_dseg.nii.gz
+            <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_desc-<label>]_dseg.nii.gz
 ```
 
 Example:
@@ -333,7 +333,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         func|anat|dwi/
-            <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_label-<label>]_probseg.nii.gz
+            <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_label-<label>][_desc-<label>]_probseg.nii.gz
 ```
 
 Example:
@@ -407,7 +407,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         anat/
-            <source_entities>[_hemi-{L|R}][_space-<space>][_atlas-<label>][_res-<label>][_den-<label>]_dseg.{label.gii|dlabel.nii}
+            <source_entities>[_hemi-{L|R}][_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_desc-<label>]_dseg.{label.gii|dlabel.nii}
 ```
 
 The [`hemi-<label>`](../appendices/entities.md#hemi) entity is REQUIRED for GIFTI files storing information about

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -10,8 +10,9 @@ Template:
 ```Text
 <pipeline_name>/
     sub-<label>/
-        <datatype>/
-            <source_entities>[_space-<space>][_res-<label>][_den-<label>][_desc-<label>]_<suffix>.<extension>
+        [ses-<label>/]
+            <datatype>/
+                <source_entities>[_space-<space>][_res-<label>][_den-<label>][_desc-<label>]_<suffix>.<extension>
 ```
 
 Volumetric preprocessing does not modify the number of dimensions, and so
@@ -147,8 +148,9 @@ Template:
 ```Text
 <pipeline_name>/
     sub-<label>/
-        anat|func|dwi/
-            <source_entities>[_space-<space>][_res-<label>][_den-<label>][_label-<label>][_desc-<label>]_mask.nii.gz
+        [ses-<label>/]
+            anat|func|dwi/
+                <source_entities>[_space-<space>][_res-<label>][_den-<label>][_label-<label>][_desc-<label>]_mask.nii.gz
 ```
 
 A binary (1 - inside, 0 - outside) mask in the space defined by the [`space` entity](../appendices/entities.md#space).
@@ -267,8 +269,9 @@ Template:
 ```Text
 <pipeline_name>/
     sub-<label>/
-        anat|func|dwi/
-            <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_desc-<label>]_dseg.nii.gz
+        [ses-<label>/]
+            anat|func|dwi/
+                <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_desc-<label>]_dseg.nii.gz
 ```
 
 Example:
@@ -332,8 +335,9 @@ Template:
 ```Text
 <pipeline_name>/
     sub-<label>/
-        func|anat|dwi/
-            <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_label-<label>][_desc-<label>]_probseg.nii.gz
+        [ses-<label>/]
+            func|anat|dwi/
+                <source_entities>[_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_label-<label>][_desc-<label>]_probseg.nii.gz
 ```
 
 Example:
@@ -406,8 +410,9 @@ Template:
 ```Text
 <pipeline_name>/
     sub-<label>/
-        anat/
-            <source_entities>[_hemi-{L|R}][_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_desc-<label>]_dseg.{label.gii|dlabel.nii}
+        [ses-<label>/]
+            anat/
+                <source_entities>[_hemi-{L|R}][_space-<space>][_atlas-<label>][_res-<label>][_den-<label>][_desc-<label>]_dseg.{label.gii|dlabel.nii}
 ```
 
 The [`hemi-<label>`](../appendices/entities.md#hemi) entity is REQUIRED for GIFTI files storing information about

--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -90,6 +90,7 @@ anat_parametric_discrete_segmentation:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     description: optional
@@ -106,6 +107,7 @@ anat_nonparametric_discrete_segmentation:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     description: optional
@@ -122,6 +124,7 @@ func_discrete_segmentation:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     description: optional
@@ -133,6 +136,7 @@ dwi_discrete_segmentation:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     description: optional
@@ -144,6 +148,7 @@ anat_parametric_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     label: optional
@@ -156,6 +161,7 @@ anat_nonparametric_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     label: optional
@@ -168,6 +174,7 @@ func_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     label: optional
@@ -180,6 +187,7 @@ dwi_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     label: optional
@@ -198,6 +206,7 @@ anat_parametic_discrete_surface:
     $ref: rules.files.raw.anat.parametric.entities
     hemisphere: optional
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     description: optional
@@ -215,6 +224,7 @@ anat_nonparametic_discrete_surface:
     $ref: rules.files.raw.anat.nonparametric.entities
     hemisphere: optional
     space: optional
+    atlas: optional
     resolution: optional
     density: optional
     description: optional


### PR DESCRIPTION
I initially set out to add the `desc` entity to the filename templates for segmentations (in [the 'Segmentations' subsection](https://bids-specification.readthedocs.io/en/stable/05-derivatives/03-imaging.html#segmentations)), since the BIDS spec says [here](https://bids-specification.readthedocs.io/en/stable/05-derivatives/01-introduction.html) that:

> When necessary to distinguish two files that do not otherwise have a distinguishing entity, the [_desc-<label>](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#desc) entity SHOULD be used.

But then I noticed that this repository also contains a YAML version of the spec, and the `desc` entity already appears there. What's more, I noticed that the `atlas` filename entity has the opposite problem: it appears in the text (added in #997), but not in the YAML.

I also noticed that the `[ses-<label>/]` folder layer was missing from the filename templates in the text about Derivatives (probably because they can't use the nifty `MACROS___make_filename_template` construct), so I fixed that too.

This pull request fixes all three problems.

I'm not sure if this pull request counts as a [FIX] or a [SCHEMA]: it feels to me like a bugfix, but technically it does touch the YAML files.

(This is my first contribution, but I'll wait until it's accepted before adding myself to [the Recent Contributors page on the wiki](https://github.com/bids-standard/bids-specification/wiki/Recent-Contributors).)