### PR TITLE
Allow for "echo" entity to be used with T1w (and other "anat" nonparametric) sequences

### DIFF
--- a/src/schema/rules/files/raw/anat.yaml
+++ b/src/schema/rules/files/raw/anat.yaml
@@ -27,6 +27,7 @@ nonparametric:
     ceagent: optional
     reconstruction: optional
     run: optional
+    echo: optional
     part: optional
 
 parametric:


### PR DESCRIPTION
Closes #654

https://github.com/bids-standard/bids-specification/issues/654 provides more of discussion with a number of people bringing up the  use cases which keep coming about.

As EchoTime is a recommended sidecar file metadata field for any file of 'mri' modality, I decided that it would only be logical for at least existing use cases (T1w) and possibly other cases (to not overspecify T1w) to simply allow for "echo" entity to be used if so necessary to distignuish two files while they do remain of that weighting (e.g. T1w) given the EchoTime values.
