### PR TITLE
[SCHEMA][ENH] Remove atlas entity and replace it with seg in prep of BEP038

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: flake8
         args: [--config=tools/schemacode/setup.cfg]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
+    rev: v3.0.1
     hooks:
       - id: prettier
         files: src/schema/.*/.*\.yaml

--- a/DECISION-MAKING.md
+++ b/DECISION-MAKING.md
@@ -30,6 +30,7 @@ Current and past members of the steering group can be found
 | Eric Earl ([@ericearl](https://github.com/ericearl))                      | 2h/week         |                                       | Dec 2021 |
 | Christine Rogers ([@christinerogers](https://github.com/christinerogers)) | 2h/mo           | Interoperability, EEG and multi-modal | Apr 2023 |
 | Nell Hardcastle ([@nellh](https://github.com/nellh))                      | 2h/week         |                                       | Jul 2023 |
+| Kimberly Ray ([@KimberlyLRay](https://github.com/KimberlyLRay))                      | 1h/week         |                                       | Nov 2022 |
 
 In addition to the [BIDS Governance](https://bids.neuroimaging.io/governance.html#bids-maintainers-group)
 classification of a maintainer, maintainers may declare a limited scope of responsibility.

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -154,7 +154,7 @@ Template:
 A binary (1 - inside, 0 - outside) mask in the space defined by the [`space` entity](../appendices/entities.md#space).
 If no transformation has taken place, the value of `space` SHOULD be set to `orig`.
 If the mask is an ROI mask derived from an atlas segmentation,
-then the [`label` entity](../appendices/entities.md#label)) SHOULD be used to specify the masked structure
+then the [`label` entity](../appendices/entities.md#label) SHOULD be used to specify the masked structure
 (see [Common image-derived labels](#common-image-derived-labels)).
 
 JSON metadata fields:

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -229,7 +229,7 @@ vertices) or a combined volume/surface space.
 
 If the segmentation can be generated in different ways,
 for example, following an atlas segmentation,
-the [`seg` entity](../appendices/entities.md#atlas) MAY be used to
+the [`seg` entity](../appendices/entities.md#segmentation) MAY be used to
 distinguish the name of the segmentation used.
 
 The following section describes discrete and probabilistic segmentations of
@@ -293,7 +293,7 @@ In this case, the mask suffix MUST be used,
 the [`label` entity](../appendices/entities.md#label)) SHOULD be used
 to specify the masked structure
 (see [Common image-derived labels](#common-image-derived-labels)),
-and the [`seg` entity](../appendices/entities.md#atlas) SHOULD be defined.
+and the [`seg` entity](../appendices/entities.md#segmentation) SHOULD be defined.
 
 For example:
 

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -170,7 +170,6 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_sidecar_table([
        "derivatives.common_derivatives.MaskDerivatives",
-       "derivatives.common_derivatives.MaskDerivativesAtlas",
        "derivatives.common_derivatives.ImageDerivativeResEntity",
        "derivatives.common_derivatives.ImageDerivativeDenEntity",
    ]) }}

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -155,8 +155,7 @@ A binary (1 - inside, 0 - outside) mask in the space defined by the [`space` ent
 If no transformation has taken place, the value of `space` SHOULD be set to `orig`.
 If the mask is an ROI mask derived from an atlas segmentation,
 then the [`label` entity](../appendices/entities.md#label)) SHOULD be used to specify the masked structure
-(see [Common image-derived labels](#common-image-derived-labels)),
-and the `Atlas` metadata SHOULD be defined.
+(see [Common image-derived labels](#common-image-derived-labels)).
 
 JSON metadata fields:
 

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -249,7 +249,6 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_sidecar_table([
        "derivatives.common_derivatives.SegmentationCommon",
-       "derivatives.common_derivatives.SegmentationCommonAtlas",
        "derivatives.common_derivatives.ImageDerivativeResEntity",
        "derivatives.common_derivatives.ImageDerivativeDenEntity",
    ]) }}

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -25,16 +25,6 @@ acquisition:
     remains at the discretion of the researcher.
   type: string
   format: label
-atlas:
-  name: atlas
-  display_name: Atlas
-  description: |
-    The `atlas-<label>` key/value pair corresponds to a custom label the user
-    MAY use to distinguish a different atlas used for similar type of data.
-
-    This entity is only applicable to derivative data.
-  type: string
-  format: label
 ceagent:
   name: ce
   display_name: Contrast Enhancing Agent
@@ -284,6 +274,15 @@ sample:
     A sample pertaining to a subject such as tissue, primary cell or cell-free sample.
     The `sample-<label>` entity is used to distinguish between different samples from the same subject.
     The label MUST be unique per subject and is RECOMMENDED to be unique throughout the dataset.
+  type: string
+  format: label
+seg:
+  name: seg
+  display_name: segmentation
+  description: |
+    The `seg-<label>` key/value pair corresponds to a custom label the user
+    MAY use to distinguish different segmentations.
+    This entity is only applicable to derivative data.
   type: string
   format: label
 session:

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -282,6 +282,7 @@ segmentation:
   description: |
     The `seg-<label>` key/value pair corresponds to a custom label the user
     MAY use to distinguish different segmentations.
+
     This entity is only applicable to derivative data.
   type: string
   format: label

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -276,9 +276,9 @@ sample:
     The label MUST be unique per subject and is RECOMMENDED to be unique throughout the dataset.
   type: string
   format: label
-seg:
+segmentation:
   name: seg
-  display_name: segmentation
+  display_name: Segmentation
   description: |
     The `seg-<label>` key/value pair corresponds to a custom label the user
     MAY use to distinguish different segmentations.

--- a/src/schema/rules/entities.yaml
+++ b/src/schema/rules/entities.yaml
@@ -25,7 +25,7 @@
 - split
 - recording
 - chunk
-- atlas
+- segmentation
 - resolution
 - density
 - label

--- a/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
@@ -38,16 +38,6 @@ MaskDerivatives:
     Sources: recommended
     RawSources: deprecated
 
-MaskDerivativesAtlas:
-  selectors:
-    - dataset.dataset_description.DatasetType == "derivative"
-    - suffix == "mask"
-    - '"label" in entities'
-  fields:
-    Atlas:
-      level: recommended
-      level_addendum: if `label` entity is defined
-
 SegmentationCommon:
   selectors:
     - dataset.dataset_description.DatasetType == "derivative"


### PR DESCRIPTION
During the [BIDS derivative meeting](https://openneuropet.github.io/bidsderivativemeeting/) in June, the [atlas BEP0038](https://bids.neuroimaging.io/bep038) was thoroughly discussed. You can see a summary of the discussions [here](https://docs.google.com/document/d/1JtTu5u7XTkWxxnCIH6sxGajGn1qG_syJ-p14aejpk3E/edit).

The outcome of this discussion was that the concept of an atlas is broader than what the [current atlas entity](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#atlas) defines it to be, so we would like to replace the current atlas entity which was basically representing a segmentation of a derived dataset with the entity "seg" instead. Currently, we define what [segmentation](https://bids-specification.readthedocs.io/en/stable/05-derivatives/03-imaging.html#segmentations) is in the spec but do not use segmentation as an entity.

This opens up the possibility for the [atlas BEP038](https://bids.neuroimaging.io/bep038) to re-define the atlas entity in a broader sense and to allow it to e.g. be used like a subject in itself.

Examples of the use of the seg entity in a derivative would then be:

```
<dataset>/derivatives/<pipeline_name>/
sub-01/
	anat/		
             sub-01_space-<label>_seg-<label>_[dseg|probseg|mask].[nii.gz|dscalar.nii|dlabel.nii|label.gii|tsv]
```

The label would then identify which segmentation was used, e.g. DKT, HarvardOxford, etc.

Note also two things of relevance to this discussion:

1) "atlas" is defined twice in the specification, once as an [entity](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#atlas) and once as a [metadata concept](https://bids-specification.readthedocs.io/en/stable/glossary.html#objects.metadata.Atlas). This will also be necessarily updated by BEP038 in a separate issue.

2) In the derivatives spec we define [parcellations explicitly as discrete surface segmentations](https://bids-specification.readthedocs.io/en/stable/05-derivatives/03-imaging.html#discrete-surface-segmentations), so while originally the use of "parc" as an entity was discussed as well "seg" seems more appropriate and broader.

---

The following screenshots summarize the changes to the specification, as compared with the current latest:

| Before | After |
|---|---|
| ![Screenshot from 2023-08-17 16-58-08](https://github.com/bids-standard/bids-specification/assets/83442/6b5cffae-e27f-4603-9c6b-1040c5a33465) | ![Screenshot from 2023-08-17 16-58-16](https://github.com/bids-standard/bids-specification/assets/83442/2a5b7c54-ffac-4a3f-a8d6-1c56e4dd2652) |
| ![Screenshot from 2023-08-17 17-01-00](https://github.com/bids-standard/bids-specification/assets/83442/65ece2e3-3de1-4d82-9f59-7a3144554342) | ![Screenshot from 2023-08-17 17-01-06](https://github.com/bids-standard/bids-specification/assets/83442/0cde84df-0d79-452d-b91c-a9cc2e5f3868) |
| ![image](https://github.com/bids-standard/bids-specification/assets/83442/4e6302ae-541a-4935-a5aa-04e846f06e1d) | ![image](https://github.com/bids-standard/bids-specification/assets/83442/0b27266e-eaae-45ab-af30-6ebf6c2b6625) |
| ![Screenshot from 2023-08-17 17-03-37](https://github.com/bids-standard/bids-specification/assets/83442/36832372-2a6b-4631-8107-773d1849e494) | ![Screenshot from 2023-08-17 17-03-44](https://github.com/bids-standard/bids-specification/assets/83442/646c0360-7bc3-4b3d-a910-8f4a62ebc3fa) |
| ![Screenshot from 2023-08-17 17-04-38](https://github.com/bids-standard/bids-specification/assets/83442/630614e9-4c96-4f97-92e2-4d640afef362) | ![Screenshot from 2023-08-17 17-04-45](https://github.com/bids-standard/bids-specification/assets/83442/2fa3f647-4644-4fbb-9b41-adccfdc1071b) |
| ![Screenshot from 2023-08-17 17-05-33](https://github.com/bids-standard/bids-specification/assets/83442/27ceac77-3a96-4e52-893e-260632c333d7) | ![Screenshot from 2023-08-17 17-05-36](https://github.com/bids-standard/bids-specification/assets/83442/40857661-a7ea-4abd-aa22-827739fa709a) |
| ![Screenshot from 2023-08-17 17-07-42](https://github.com/bids-standard/bids-specification/assets/83442/af7286f6-6a6a-4ad2-bb96-915aa8facd83) | ![Screenshot from 2023-08-17 17-07-48](https://github.com/bids-standard/bids-specification/assets/83442/c833bc10-190b-4d3b-a15c-b995c54c18aa) |
| ![Screenshot from 2023-08-17 17-09-41](https://github.com/bids-standard/bids-specification/assets/83442/665c4d78-b341-46a1-aead-4924c036e179) | ![Screenshot from 2023-08-17 17-09-46](https://github.com/bids-standard/bids-specification/assets/83442/e55e3dbd-033a-4a3c-bc66-262ae1734a27) |

