### PR TITLE
SCHEMA: Fix match() expression function

### DIFF
--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -957,7 +957,7 @@ EventsMissing:
     level: warning # could be an error with the proper selectors, I think
   selectors:
     - '"task" in entities'
-    - '!matches(entities.task, "rest")'
+    - '!match(entities.task, "rest")'
     - suffix != "events"
   checks:
     - '"events" in associations'

--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -24,7 +24,7 @@ events:
 aslcontext:
   selectors:
     - suffix == 'asl'
-    - matches(extension, '\.nii(\.gz)?$')
+    - match(extension, '\.nii(\.gz)?$')
   target:
     suffix: aslcontext
     extension: .tsv
@@ -33,7 +33,7 @@ aslcontext:
 m0scan:
   selectors:
     - suffix == 'asl'
-    - matches(extension, '\.nii(\.gz)?$')
+    - match(extension, '\.nii(\.gz)?$')
   target:
     suffix: m0scan
     extension: [.nii, .nii.gz]
@@ -42,7 +42,7 @@ m0scan:
 magnitude:
   selectors:
     - suffix == 'fieldmap'
-    - matches(extension, '\.nii(\.gz)?$')
+    - match(extension, '\.nii(\.gz)?$')
   target:
     suffix: magnitude
     extension: [.nii, .nii.gz]
@@ -50,8 +50,8 @@ magnitude:
 
 magnitude1:
   selectors:
-    - matches(suffix, 'phase(diff|1)$')
-    - matches(extension, '\.nii(\.gz)?$')
+    - match(suffix, 'phase(diff|1)$')
+    - match(extension, '\.nii(\.gz)?$')
   target:
     suffix: magnitude1
     extension: [.nii, .nii.gz]
@@ -60,7 +60,7 @@ magnitude1:
 bval:
   selectors:
     - suffix == 'dwi'
-    - matches(extension, '\.nii(\.gz)?$')
+    - match(extension, '\.nii(\.gz)?$')
   target:
     extension: .bval
   inherit: true
@@ -68,7 +68,7 @@ bval:
 bvec:
   selectors:
     - suffix == 'dwi'
-    - matches(extension, '\.nii(\.gz)?$')
+    - match(extension, '\.nii(\.gz)?$')
   target:
     extension: .bvec
   inherit: true


### PR DESCRIPTION
Had some `matches()` which isn't valid.

Validator output:

```
DEBUG TypeError: matches is not a function
    at eval (eval at evalConstructor (file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:36:32), <anonymous>:3:25)
    at evalCheck (file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:74:12)
    at file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:128:34
    at Array.every (<anonymous>)
    at mapEvalCheck (file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:128:21)
    at evalRule (file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:116:26)
    at applyRules (file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:44:7)
    at applyRules (file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:51:7)
    at applyRules (file:///home/chris/Projects/bids/validator/bids-validator/src/schema/applyRules.ts:51:7)
    at validate (file:///home/chris/Projects/bids/validator/bids-validator/src/validators/bids.ts:84:13)
```