### PR TITLE
SCHEMA: Fix overeager BOLD rules

### DIFF
--- a/src/schema/rules/sidecars/func.yaml
+++ b/src/schema/rules/sidecars/func.yaml
@@ -10,8 +10,8 @@
 # Required fields
 MRIFuncRequired:
   selectors:
-    - modality == "mri"
     - datatype == "func"
+    - suffix == "bold"
     - match(extension, "^\.nii(\.gz)?$")
   fields:
     TaskName:
@@ -22,8 +22,8 @@ MRIFuncRequired:
 
 MRIFuncRepetitionTime:
   selectors:
-    - modality == "mri"
     - datatype == "func"
+    - suffix == "bold"
     - '!("VolumeTiming" in sidecar)'
     - match(extension, "^\.nii(\.gz)?$")
   fields:
@@ -33,8 +33,8 @@ MRIFuncRepetitionTime:
 
 MRIFuncVolumeTiming:
   selectors:
-    - modality == "mri"
     - datatype == "func"
+    - suffix == "bold"
     - '!("RepetitionTime" in sidecar)'
     - match(extension, "^\.nii(\.gz)?$")
   fields:
@@ -45,8 +45,8 @@ MRIFuncVolumeTiming:
 # Timing Parameters
 MRIFuncTimingParameters:
   selectors:
-    - modality == "mri"
     - datatype == "func"
+    - suffix == "bold"
   fields:
     NumberOfVolumesDiscardedByScanner: recommended
     NumberOfVolumesDiscardedByUser: recommended
@@ -66,8 +66,8 @@ MRIFuncTimingParameters:
 # fMRI task information
 MRIFuncTaskInformation:
   selectors:
-    - modality == "mri"
     - datatype == "func"
+    - suffix == "bold"
   fields:
     Instructions:
       level: recommended


### PR DESCRIPTION
Validation is failing on derivatives datasets because things like `func/*_dseg.nii.gz` are both MRI and in `func/` but they no longer have timing information.

Will add more fixes like this in the next 30 minutes, but after that, merge at will.