### PR TITLE
[ENH] Add "chunk" entity to MRI datatype

### DIFF
--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -51,9 +51,12 @@ chunk:
   name: chunk
   display_name: Chunk
   description: |
-    The `chunk-<index>` key/value pair is used to distinguish between different regions,
-    2D images or 3D volumes files,
-    of the same physical sample with different fields of view acquired in the same imaging experiment.
+    The `chunk-<index>` entity is used to distinguish between different regions, 2D images (for example Microscopy),
+    3D volumes files, or 4D volumes files (for example DWI) of the same physical sample with different fields of
+    view acquired in the same imaging experiment.
+
+    In case of MRI data, this entity is used to distinguish between different anatomical regions, for example brain
+    and spinal cord.
   type: string
   format: index
 density:

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -404,6 +404,8 @@ ChunkTransformationMatrix:
     scaling along the second and third axis respectively).
     Note that non-spatial dimensions like time and channel are not included in the
     transformation matrix.
+    In case of MRI data, the ChunkTransformationMatrix corresponds to the NIFTI [qform matrix]
+    (https://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields/nifti1fields_pages/qsform.html)
   anyOf:
     - type: array
       minItems: 3

--- a/src/schema/rules/files/raw/anat.yaml
+++ b/src/schema/rules/files/raw/anat.yaml
@@ -28,6 +28,7 @@ nonparametric:
     reconstruction: optional
     run: optional
     part: optional
+    chunk: optional
 
 parametric:
   suffixes:
@@ -61,6 +62,7 @@ parametric:
     ceagent: optional
     reconstruction: optional
     run: optional
+    chunk: optional
 
 defacemask:
   suffixes:
@@ -80,6 +82,7 @@ defacemask:
     reconstruction: optional
     run: optional
     modality: optional
+    chunk: optional
 
 multiecho:
   suffixes:
@@ -122,6 +125,7 @@ multiflip:
     echo: optional
     flip: required
     part: optional
+    chunk: optional
 
 multiinversion:
   suffixes:
@@ -142,6 +146,7 @@ multiinversion:
     run: optional
     inversion: required
     part: optional
+    chunk: optional
 
 mp2rage:
   suffixes:
@@ -164,6 +169,7 @@ mp2rage:
     flip: optional
     inversion: required
     part: optional
+    chunk: optional
 
 vfamt:
   suffixes:
@@ -187,6 +193,7 @@ vfamt:
     flip: required
     mtransfer: required
     part: optional
+    chunk: optional
 
 mtr:
   suffixes:
@@ -207,3 +214,4 @@ mtr:
     run: optional
     mtransfer: required
     part: optional
+    chunk: optional

--- a/src/schema/rules/files/raw/dwi.yaml
+++ b/src/schema/rules/files/raw/dwi.yaml
@@ -18,6 +18,7 @@ dwi:
     direction: optional
     run: optional
     part: optional
+    chunk: optional
 
 sbref:
   suffixes:
@@ -36,3 +37,4 @@ sbref:
     direction: optional
     run: optional
     part: optional
+    chunk: optional

--- a/src/schema/rules/files/raw/func.yaml
+++ b/src/schema/rules/files/raw/func.yaml
@@ -21,6 +21,7 @@ func:
     run: optional
     echo: optional
     part: optional
+    chunk: optional
 
 phase:
   suffixes:
@@ -41,3 +42,4 @@ phase:
     direction: optional
     run: optional
     echo: optional
+    chunk: optional


### PR DESCRIPTION
The `chunk` entity was originally added for the 'Microscopy' datatype in BEP031 https://github.com/bids-standard/bids-specification/pull/881. This PR adds the `chunk` entity also to the MRI datatype. In the context of MRI, `chunks` refer to individual field-of-views (FOVs), for example, one FOV for the brain and the second FOV for the spinal cord.
Since two different FOVs might be acquired not only for anatomical MRI, I added the `chunk` entity also for DWI and fMRI.

Resolves: #1382