### PR TITLE
ENH: Add sample metadata to MRI and PET

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -162,6 +162,18 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_sidecar_table("mri.MRIEchoPlanarImagingAndB0Mapping") }}
 
+#### Tissue description
+
+<!-- This block generates a metadata table.
+These tables are defined in
+  src/schema/rules/sidecars
+The definitions of the fields specified in these tables may be found in
+  src/schema/objects/metadata.yaml
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_sidecar_table("mri.MRISample") }}
+
 ## Anatomy imaging data
 
 Anatomy MRI sequences measure static, structural features of the brain.

--- a/src/modality-specific-files/positron-emission-tomography.md
+++ b/src/modality-specific-files/positron-emission-tomography.md
@@ -216,6 +216,18 @@ A guide for using macros can be found at
 
 {{ MACROS___make_sidecar_table("pet.PETInstitutionInformation") }}
 
+#### Tissue description
+
+<!-- This block generates a metadata table.
+These tables are defined in
+  src/schema/rules/sidecars
+The definitions of the fields specified in these tables may be found in
+  src/schema/objects/metadata.yaml
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_sidecar_table("pet.PETSample") }}
+
 #### Task
 
 If the OPTIONAL [`task-<label>`](../appendices/entities.md#task) is used,

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -35,6 +35,16 @@ MRIHardware:
     MatrixCoilMode: recommended
     CoilCombinationMethod: recommended
 
+MRISample:
+  selectors:
+    - modality == "mri"
+  fields:
+    BodyPart:
+      level: optional
+      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
+    BodyPartDetails: optional
+    BodyPartDetailsOntology: optional
+
 MRIScannerHardwareASL:
   selectors:
     - datatype == "perf"

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -35,6 +35,17 @@ PETInstitutionInformation:
       level: recommended
       description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
 
+PETSample:
+  selectors:
+    - modality == "pet"
+    - suffix == "pet"
+  fields:
+    BodyPart:
+      level: optional
+      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
+    BodyPartDetails: optional
+    BodyPartDetailsOntology: optional
+
 PETRadioChemistry:
   selectors:
     - datatype == "pet"


### PR DESCRIPTION
Adds `BodyPart`, `BodyPartDetails` and `BodyPartDetailsOntology` to MRI and PET imaging, taken from additions in BEP 031 - Microscopy. `BodyPart` corresponds to a DICOM tag (0018, 0015 `Body Part Examined`), while the others are for additional annotation when this is insufficient detail.

The more straightforward part of #1396. This complements #1586, which proposes to use the `chunk-<index>` entity to identify different fields of view in MRI, which we expect will most commonly be used for spinal cord imaging.

This also lays some groundwork for BEP22 (MRS), which is waiting on a release with motion before starting their final review process.