### PR TITLE
Recommend SliceTiming if MRAcquisitionType is "2D"

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -98,7 +98,7 @@ The definitions of the fields specified in these tables may be found in
 A guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
-{{ MACROS___make_sidecar_table("mri.MRITimingParameters") }}
+{{ MACROS___make_sidecar_table(["mri.MRITimingParameters", "mri.SliceTimingMRI"]) }}
 
 ### RF & Contrast
 

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -187,13 +187,19 @@ MRITimingParameters:
           should only be used when the volume timing is critical for interpretation
           of the data, such as in ASL or variable echo time fMRI sequences.
     InversionTime: recommended
+    SliceEncodingDirection: recommended
+    DwellTime: recommended
+
+SliceTimingMRI:
+  selectors:
+    - modality == "mri"
+    - sidecar.MRAcquisitionType == "2D"
+  fields:
     SliceTiming:
       level: recommended
       level_addendum: |
         required for sparse sequences that do not have the `DelayTime` field set,
         and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.
-    SliceEncodingDirection: recommended
-    DwellTime: recommended
 
 SliceTimingASL:
   selectors:
@@ -208,7 +214,7 @@ SliceTimingASL:
       issue:
         code: SLICE_TIMING_NOT_DEFINED_2D_ASL
         message: |
-          You should define `SliceTiming` for this file, because `SequenceType` is sets
+          You should define `SliceTiming` for this file, because `SequenceType` is set
           to a 2D sequence. `SliceTiming` is the time at which each slice was
           acquired within each volume (frame) of the acquisition. Slice timing
           is not slice order -- rather, it is a list of times containing the

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -187,7 +187,6 @@ MRITimingParameters:
           should only be used when the volume timing is critical for interpretation
           of the data, such as in ASL or variable echo time fMRI sequences.
     InversionTime: recommended
-    SliceEncodingDirection: recommended
     DwellTime: recommended
 
 SliceTimingMRI:
@@ -200,6 +199,7 @@ SliceTimingMRI:
       level_addendum: |
         required for sparse sequences that do not have the `DelayTime` field set,
         and Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.
+    SliceEncodingDirection: recommended
 
 SliceTimingASL:
   selectors:


### PR DESCRIPTION
Closes #1585.

Changes proposed:

- Create new rule, `SliceTimingMRI`, making `SliceTiming` a recommended field for MRI scans with `MRAcquisitionType` set to `2D`. This way, `SliceTiming` is no longer recommended for 3D acquisitions.