### PR TITLE
[SCHEMA] Update pet.yaml PlasmaAvail check.

### DIFF
--- a/src/schema/rules/tabular_data/pet.yaml
+++ b/src/schema/rules/tabular_data/pet.yaml
@@ -28,6 +28,7 @@ BloodPlasma:
     - suffix == "blood"
     - extension == ".tsv"
     - '"PlasmaAvail" in sidecar'
+    - sidecar.PlasmaAvail == true
   columns:
     plasma_radioactivity: required
 


### PR DESCRIPTION
BloodPlasma requirement in tabular data didn't check if the corresponding json was true. All jsons are required to have the PlasmaAvail field, so any dataset with PlasmaAvail false would fail this check.

