### PR TITLE
[ENH] Add optional low_cutoff and high_cutoff columns for fnirs channels.tsv

### DIFF
--- a/src/schema/rules/tabular_data/nirs.yaml
+++ b/src/schema/rules/tabular_data/nirs.yaml
@@ -25,6 +25,8 @@ nirsChannels:
       level: optional
       level_addendum: required if `type` is `ACCEL`, `GYRO` or `MAGN`
     wavelength_actual: optional
+    low_cutoff: optional
+    high_cutoff: optional
     description: optional
     wavelength_emission_actual: optional
     short_channel: optional


### PR DESCRIPTION
- relates to https://github.com/bids-standard/bids-examples/issues/396

makes it consistent with what is done in EEG, iEEG, MEG

See the HTML table [here](https://bids-specification--1597.org.readthedocs.build/en/1597/modality-specific-files/near-infrared-spectroscopy.html#channels-description-_channelstsv)

@rob-luke @lpollonini does this make sense to you

Closes bids-standard/bids-examples#396.