### PR TITLE
[SCHEMA] Update nirs.yaml ShortChannelCountReq check.

### DIFF
--- a/src/schema/rules/checks/nirs.yaml
+++ b/src/schema/rules/checks/nirs.yaml
@@ -42,7 +42,7 @@ ShortChannelCountReq:
   selectors:
     - suffix == "nirs"
   checks:
-    - sidecar.ShortChannelCount == count(associations.channels.short_channel, true)
+    - sidecar.ShortChannelCount == count(associations.channels.short_channel, "true")
 
 Component:
   selectors:


### PR DESCRIPTION
Ensures that the check is happening against a value that matches booleans format regex.