### PR TITLE
FIX: Do not require notch frequencies to be parsed as numbers, accommodating multiples

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -302,13 +302,11 @@ notch:
   display_name: Notch frequencies
   description: |
     Frequencies used for the notch filter applied to the channel, in Hz.
+    If the low and high frequencies are supplied in addition to the center
+    frequency, it is RECOMMENDED that they take the form `[low, center, high]`,
+    for example `[60, 120, 180]`.
     If no notch filter applied, use `n/a`.
-  anyOf:
-    - type: number
-      unit: Hz
-    - type: string
-      enum:
-        - n/a
+  type: string
 onset:
   name: onset
   display_name: Event onset

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -302,9 +302,8 @@ notch:
   display_name: Notch frequencies
   description: |
     Frequencies used for the notch filter applied to the channel, in Hz.
-    If the low and high frequencies are supplied in addition to the center
-    frequency, it is RECOMMENDED that they take the form `[low, center, high]`,
-    for example `[60, 120, 180]`.
+    If the low and high frequencies are supplied in addition to the center frequency,
+    they MAY take the form `[low, center, high]`, for example `[60, 120, 180]`.
     If no notch filter applied, use `n/a`.
   type: string
 onset:

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -302,9 +302,10 @@ notch:
   display_name: Notch frequencies
   description: |
     Frequencies used for the notch filter applied to the channel, in Hz.
-    If the low and high frequencies are supplied in addition to the center frequency,
-    they MAY take the form `[low, center, high]`, for example `[60, 120, 180]`.
-    If no notch filter applied, use `n/a`.
+    If notch filters are applied at multiple frequencies,
+    these frequencies MAY be specified as a list,
+    for example, `[60, 120, 180]`.
+    If no notch filter was applied, use `n/a`.
   type: string
 onset:
   name: onset


### PR DESCRIPTION
While schematizing, the `notch` column was defined as a number. In the case of iEEG at least, the BEP leads had submitted examples where `notch` took the form `[F1, F2, F3]`. This PR recognizes this as existing practice and suggests that curators and tools adopt `[F1, F2, ...]` for interoperability, but does not require it.

cc @bids-standard/raw-electrophys for comment.

Closes https://github.com/bids-standard/bids-examples/issues/395.