### PR TITLE
SCHEMA: Add data array accessor to context

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -231,6 +231,19 @@ context:
         comment:
           description: 'Comment'
           type: string
+    data:
+      # This is currently only used for checking bval/bvec shape
+      # This may need to be reconsidered if we start checking data contents
+      # or >2D shapes
+      description: 'Metadata about the data array held in a file'
+      type: object
+      properties:
+        n_rows:
+          description: 'Number of rows in aslcontext.tsv'
+          type: integer
+        n_cols:
+          description: 'Number of rows in aslcontext.tsv'
+          type: integer
     nifti_header:
       name: 'NIfTI Header'
       description: 'Parsed contents of NIfTI header referenced elsewhere in schema.'


### PR DESCRIPTION
This is a formality, as nobody is actually dynamically building a context from `schema.meta.context`, but we have a couple rules that require access to the data array shape:

https://github.com/bids-standard/bids-specification/blob/fc98780caf366fbcef3b390ba61edc04da7ff2aa/src/schema/rules/checks/dwi.yaml#L20-L42

I have implemented this in the JS validator as part of https://github.com/bids-standard/bids-validator/pull/1797.

It is not future-proof, but we reserve the option to make breaking changes to the schema.