### PR TITLE
[ENH] Add `descriptions.tsv` file relating to the `desc-<label>` entity

### DIFF
--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -252,10 +252,13 @@ A guide for using macros can be found at
 All REQUIRED metadata fields coming from a derivative file’s source file(s) MUST
 be propagated to the JSON description of the derivative unless the processing
 makes them invalid (for example, if a source 4D image is averaged to create a single
-static volume, a `RepetitionTime` property would no longer be relevant). This creates
-a trail of the computational steps performed. Because many steps can occur until clean
-data and because it is NOT mandatory to save every file or step, the simpler `desc-preproc`
-and `desc-proc` are available.
+static volume, a `RepetitionTime` property would no longer be relevant). As each file 
+includes what was computed by increment, a trail of the computational steps performed
+is created. Because many steps can occur until the fully clean data are obtained and 
+because it is NOT mandatory to save every file or step, the simpler `desc-preproc`
+and `desc-proc` are available. It becomes however important to document what such 
+pre-processing or processing are, and record the order of computational steps. This 
+can be in the json file or alternatively described in a descriptions.tsv file.
 
 ## descriptions.tsv
 
@@ -284,10 +287,10 @@ To keep a record of what has been done to the data, a `descriptions.tsv` file ca
          descriptions.tsv
         "sub-001": {
             "eeg": {
-                "sub-001_task-listening_desc-filt_eeg.edf": "",
-                "sub-001_task-listening_desc-filt_eeg.json": "",
-                "sub-001_task-listening_desc-filt+ds_eeg.edf": "",
-                "sub-001_task-listening_desc-filt+ds_eeg.json": "",
+                "sub-001_task-listening_desc-Filt_eeg.edf": "",
+                "sub-001_task-listening_desc-Filt_eeg.json": "",
+                "sub-001_task-listening_desc-FiltDs_eeg.edf": "",
+                "sub-001_task-listening_desc-FiltDs_eeg.json": "",
                 "sub-001_task-listening_desc-preproc_eeg.edf": "",
                 "sub-001_task-listening_desc-preproc_eeg.json": "",                },
             },
@@ -299,8 +302,8 @@ To keep a record of what has been done to the data, a `descriptions.tsv` file ca
 
 | desc_id          | description                                                                                               |
 |------------------|-----------------------------------------------------------------------------------------------------------|
-| filt             |  low-pass filtered at 30Hz                                                                                |
-| filt+ds          | low-pass filtered at 30Hz,downsampled to 250Hz                                                            |
+| Filt             |  low-pass filtered at 30Hz                                                                                |
+| FiltDs           | low-pass filtered at 30Hz,downsampled to 250Hz                                                            |
 | preproc          | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference            |
 
 

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -264,36 +264,53 @@ This can be done in the JSON sidecar files or alternatively described in a `desc
 
 ## descriptions.tsv
 
-To keep a record of what has been done to the data, a `descriptions.tsv` file can be used,
-containing at least two columns: `desc_id` and `description`.
+To keep a record of processing steps applied to the data, a `descriptions.tsv` file can be used.
+The `descriptions.tsv` file MUST contain at least the following two columns:
+
+-  `desc_id`
+-  `description`
+
 This file MAY be located at the root of the derivative dataset,
 or at the subject or session level
-([Inheritance Principle](../common-principles.md#the-inheritance-principle))).
+([Inheritance Principle](../common-principles.md#the-inheritance-principle)).
 
-`desc_id` contains all labels used in the [`desc entity`](../appendices/entities.md#desc),
-while `description` is a human-readable description of what was computed.
-Note that while it is helpful to document how files are generated, we see this as *light provenance*,
-that is, it is not aimed at providing full computational reproducibility.
+The `desc_id` column contains the labels used with the [`desc entity`](../appendices/entities.md#desc),
+within the particular nesting that the `description.tsv` file is placed.
+For example, if the `descriptions.tsv` file is placed at the root of the derivative dataset,
+its `desc_id` column SHOULD contain all labels of the [`desc entity`](../appendices/entities.md#desc)
+used across the entire derivative dataset.
 
+The `description` column contains human-readable descriptions of the processing steps.
+
+The use of `description.tsv` files together with the [`desc entity`](../appendices/entities.md#desc)
+are helpful to document how files are generated, even if their use may not be sufficient
+to provide full computational reproducibility.
+
+### Example use of a `descriptions.tsv` file
+
+<!-- This block generates a file tree.
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
 {{ MACROS___make_filetree_example(
-   {
+    {
     "raw/": {
-         CHANGES
-         README
-         channels.tsv
-         dataset_description.tsv
-         participants.tsv
-          "sub-001": {
-            "eeg": {
-                "sub-001_task-listening_events.tsv": "",
-                "sub-001_task-listening_events.json": "",
-                "sub-001_task-listening_eeg.edf": "",
-                "sub-001_task-listening_eeg.json": "",
+        "CHANGES": "",
+        "README": "",
+        "channels.tsv": "",
+        "dataset_description.tsv": "",
+        "participants.tsv": "",
+            "sub-001": {
+                "eeg": {
+                    "sub-001_task-listening_events.tsv": "",
+                    "sub-001_task-listening_events.json": "",
+                    "sub-001_task-listening_eeg.edf": "",
+                    "sub-001_task-listening_eeg.json": "",
+                    },
                 },
             },
-          },
-  "derivatives/": {
-         descriptions.tsv
+    "derivatives/": {
+        "descriptions.tsv": "",
         "sub-001": {
             "eeg": {
                 "sub-001_task-listening_desc-Filt_eeg.edf": "",
@@ -301,19 +318,20 @@ that is, it is not aimed at providing full computational reproducibility.
                 "sub-001_task-listening_desc-FiltDs_eeg.edf": "",
                 "sub-001_task-listening_desc-FiltDs_eeg.json": "",
                 "sub-001_task-listening_desc-preproc_eeg.edf": "",
-                "sub-001_task-listening_desc-preproc_eeg.json": "",                },
+                "sub-001_task-listening_desc-preproc_eeg.json": "",
+                },
             },
         }
-   }
+    }
 ) }}
 
-`descriptions.tsv`
+Contents of the `descriptions.tsv` file:
 
-| desc_id | description                                                                                    |
-|---------|------------------------------------------------------------------------------------------------|
-| Filt    | low-pass filtered at 30Hz                                                                      |
-| FiltDs  | low-pass filtered at 30Hz,downsampled to 250Hz                                                 |
-| preproc | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference |
+| desc_id | description                                                                                     |
+|---------|-------------------------------------------------------------------------------------------------|
+| Filt    | low-pass filtered at 30Hz                                                                       |
+| FiltDs  | low-pass filtered at 30Hz, downsampled to 250Hz                                                 |
+| preproc | low-pass filtered at 30Hz, downsampled to 250Hz, and rereferenced to a common average reference |
 
 <!-- Link Definitions -->
 

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -252,12 +252,12 @@ A guide for using macros can be found at
 All REQUIRED metadata fields coming from a derivative file’s source file(s) MUST
 be propagated to the JSON description of the derivative unless the processing
 makes them invalid (for example, if a source 4D image is averaged to create a single
-static volume, a `RepetitionTime` property would no longer be relevant). As each file 
+static volume, a `RepetitionTime` property would no longer be relevant). As each file
 includes what was computed by increment, a trail of the computational steps performed
-is created. Because many steps can occur until the fully clean data are obtained and 
+is created. Because many steps can occur until the fully clean data are obtained and
 because it is NOT mandatory to save every file or step, the simpler `desc-preproc`
-and `desc-proc` are available. It becomes however important to document what such 
-pre-processing or processing are, and record the order of computational steps. This 
+and `desc-proc` are available. It becomes however important to document what such
+pre-processing or processing are, and record the order of computational steps. This
 can be in the json file or alternatively described in a descriptions.tsv file.
 
 ## descriptions.tsv

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -253,22 +253,14 @@ All REQUIRED metadata fields coming from a derivative file’s source file(s) MU
 be propagated to the JSON description of the derivative unless the processing
 makes them invalid (for example, if a source 4D image is averaged to create a single
 static volume, a `RepetitionTime` property would no longer be relevant).
-As each file includes what was computed by increment,
-a trail of the computational steps performed is created.
-Because many steps can occur until the fully clean data are obtained,
-and because it is OPTIONAL to save every file or step,
-the simpler `desc-preproc` and `desc-proc` are available.
-It becomes however important to document what such pre-processing or processing are,
-and record the order of computational steps.
-This can be done in the JSON sidecar files or alternatively described in a `descriptions.tsv` file.
 
 ## descriptions.tsv
 
-To keep a record of processing steps applied to the data, a `descriptions.tsv` file can be used.
+To keep a record of processing steps applied to the data, a `descriptions.tsv` file MAY be used.
 The `descriptions.tsv` file MUST contain at least the following two columns:
 
--  `desc_id`
--  `description`
+-   `desc_id`
+-   `description`
 
 This file MAY be located at the root of the derivative dataset,
 or at the subject or session level

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -301,10 +301,10 @@ To keep a record of what has been done to the data, a `descriptions.tsv` file ca
 `descriptions.tsv`
 
 | desc_id          | description                                                                                               |
-|------------------|-----------------------------------------------------------------------------------------------------------|
-| Filt             |  low-pass filtered at 30Hz                                                                                |
+|------------------|-----------------------------------------------------------------------------------------------|
+| Filt             | low-pass filtered at 30Hz                                                                                |
 | FiltDs           | low-pass filtered at 30Hz,downsampled to 250Hz                                                            |
-| preproc          | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference            |
+| preproc          | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference |
 
 
 <!-- Link Definitions -->

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -259,17 +259,17 @@ static volume, a `RepetitionTime` property would no longer be relevant).
 To keep a record of processing steps applied to the data, a `descriptions.tsv` file MAY be used.
 The `descriptions.tsv` file MUST contain at least the following two columns:
 
--   `desc_id`
+-   `label`
 -   `description`
 
 This file MAY be located at the root of the derivative dataset,
 or at the subject or session level
 ([Inheritance Principle](../common-principles.md#the-inheritance-principle)).
 
-The `desc_id` column contains the labels used with the [`desc entity`](../appendices/entities.md#desc),
+The `label` column contains the labels used with the [`desc entity`](../appendices/entities.md#desc),
 within the particular nesting that the `description.tsv` file is placed.
 For example, if the `descriptions.tsv` file is placed at the root of the derivative dataset,
-its `desc_id` column SHOULD contain all labels of the [`desc entity`](../appendices/entities.md#desc)
+its `label` column SHOULD contain all labels of the [`desc entity`](../appendices/entities.md#desc)
 used across the entire derivative dataset.
 
 The `description` column contains human-readable descriptions of the processing steps.
@@ -319,7 +319,7 @@ A guide for using macros can be found at
 
 Contents of the `descriptions.tsv` file:
 
-| desc_id | description                                                                                     |
+| label   | description                                                                                     |
 |---------|-------------------------------------------------------------------------------------------------|
 | Filt    | low-pass filtered at 30Hz                                                                       |
 | FiltDs  | low-pass filtered at 30Hz, downsampled to 250Hz                                                 |

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -252,16 +252,16 @@ A guide for using macros can be found at
 All REQUIRED metadata fields coming from a derivative file’s source file(s) MUST
 be propagated to the JSON description of the derivative unless the processing
 makes them invalid (for example, if a source 4D image is averaged to create a single
-static volume, a `RepetitionTime` property would no longer be relevant). This creates 
-a trail of the computational steps performed. Because many steps can occur until clean 
-data and because it is NOT mandatory to save every file or step, the simpler `desc-preproc` 
+static volume, a `RepetitionTime` property would no longer be relevant). This creates
+a trail of the computational steps performed. Because many steps can occur until clean
+data and because it is NOT mandatory to save every file or step, the simpler `desc-preproc`
 and `desc-proc` are available.
 
 ## descriptions.tsv
 
-To keep a record of what has been done to the data, a `descriptions.tsv` file can be used, containing at least two columns: `desc_id` and `description`. This file can be located at the root derivatives level or at the subject level (inheritance principle).  
+To keep a record of what has been done to the data, a `descriptions.tsv` file can be used, containing at least two columns: `desc_id` and `description`. This file can be located at the root derivatives level or at the subject level (inheritance principle).
 
-`desc_id` contains all labels used in the [`desc entity`](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance' (see [provenance BEP28](https://github.com/bids-standard/BEP028_BIDSprov) for full computational reproducibility).  
+`desc_id` contains all labels used in the [`desc entity`](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance' (see [provenance BEP28](https://github.com/bids-standard/BEP028_BIDSprov) for full computational reproducibility).
 
 {{ MACROS___make_filetree_example(
    {
@@ -280,7 +280,7 @@ To keep a record of what has been done to the data, a `descriptions.tsv` file ca
                 },
             },
           },
-  "derivatives/": {      
+  "derivatives/": {
          descriptions.tsv
         "sub-001": {
             "eeg": {

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -267,14 +267,14 @@ or at the subject or session level
 ([Inheritance Principle](../common-principles.md#the-inheritance-principle)).
 
 The `label` column contains the labels used with the [`desc entity`](../appendices/entities.md#desc),
-within the particular nesting that the `description.tsv` file is placed.
+within the particular nesting that the `descriptions.tsv` file is placed.
 For example, if the `descriptions.tsv` file is placed at the root of the derivative dataset,
 its `label` column SHOULD contain all labels of the [`desc entity`](../appendices/entities.md#desc)
 used across the entire derivative dataset.
 
 The `description` column contains human-readable descriptions of the processing steps.
 
-The use of `description.tsv` files together with the [`desc entity`](../appendices/entities.md#desc)
+The use of `descriptions.tsv` files together with the [`desc entity`](../appendices/entities.md#desc)
 are helpful to document how files are generated, even if their use may not be sufficient
 to provide full computational reproducibility.
 
@@ -290,7 +290,7 @@ A guide for using macros can be found at
         "CHANGES": "",
         "README": "",
         "channels.tsv": "",
-        "dataset_description.tsv": "",
+        "dataset_description.json": "",
         "participants.tsv": "",
             "sub-001": {
                 "eeg": {

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -300,12 +300,11 @@ To keep a record of what has been done to the data, a `descriptions.tsv` file ca
 
 `descriptions.tsv`
 
-| desc_id          | description                                                                                               |
-|------------------|-----------------------------------------------------------------------------------------------|
-| Filt             | low-pass filtered at 30Hz                                                                                |
-| FiltDs           | low-pass filtered at 30Hz,downsampled to 250Hz                                                            |
+| desc_id          | description                                                                                    |
+|------------------|------------------------------------------------------------------------------------------------|
+| Filt             | low-pass filtered at 30Hz                                                                      |
+| FiltDs           | low-pass filtered at 30Hz,downsampled to 250Hz                                                 |
 | preproc          | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference |
-
 
 <!-- Link Definitions -->
 

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -264,7 +264,7 @@ can be in the json file or alternatively described in a descriptions.tsv file.
 
 To keep a record of what has been done to the data, a `descriptions.tsv` file can be used, containing at least two columns: `desc_id` and `description`. This file can be located at the root derivatives level or at the subject level (inheritance principle).
 
-`desc_id` contains all labels used in the [`desc entity`](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance' (see [provenance BEP28](https://github.com/bids-standard/BEP028_BIDSprov) for full computational reproducibility).
+`desc_id` contains all labels used in the [`desc entity`](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance', i.e. it is not aimed at providing full computational reproducibility.
 
 {{ MACROS___make_filetree_example(
    {

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -259,17 +259,17 @@ static volume, a `RepetitionTime` property would no longer be relevant).
 To keep a record of processing steps applied to the data, a `descriptions.tsv` file MAY be used.
 The `descriptions.tsv` file MUST contain at least the following two columns:
 
--   `label`
+-   `desc_id`
 -   `description`
 
 This file MAY be located at the root of the derivative dataset,
 or at the subject or session level
 ([Inheritance Principle](../common-principles.md#the-inheritance-principle)).
 
-The `label` column contains the labels used with the [`desc entity`](../appendices/entities.md#desc),
+The `desc_id` column contains the labels used with the [`desc entity`](../appendices/entities.md#desc),
 within the particular nesting that the `descriptions.tsv` file is placed.
 For example, if the `descriptions.tsv` file is placed at the root of the derivative dataset,
-its `label` column SHOULD contain all labels of the [`desc entity`](../appendices/entities.md#desc)
+its `desc_id` column SHOULD contain all labels of the [`desc entity`](../appendices/entities.md#desc)
 used across the entire derivative dataset.
 
 The `description` column contains human-readable descriptions of the processing steps.
@@ -319,7 +319,7 @@ A guide for using macros can be found at
 
 Contents of the `descriptions.tsv` file:
 
-| label   | description                                                                                     |
+| desc_id | description                                                                                     |
 |---------|-------------------------------------------------------------------------------------------------|
 | Filt    | low-pass filtered at 30Hz                                                                       |
 | FiltDs  | low-pass filtered at 30Hz, downsampled to 250Hz                                                 |

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -252,19 +252,28 @@ A guide for using macros can be found at
 All REQUIRED metadata fields coming from a derivative file’s source file(s) MUST
 be propagated to the JSON description of the derivative unless the processing
 makes them invalid (for example, if a source 4D image is averaged to create a single
-static volume, a `RepetitionTime` property would no longer be relevant). As each file
-includes what was computed by increment, a trail of the computational steps performed
-is created. Because many steps can occur until the fully clean data are obtained and
-because it is OPTIONAL to save every file or step, the simpler `desc-preproc`
-and `desc-proc` are available. It becomes however important to document what such
-pre-processing or processing are, and record the order of computational steps. This
-can be done in the JSON sidecar files or alternatively described in a `descriptions.tsv` file.
+static volume, a `RepetitionTime` property would no longer be relevant).
+As each file includes what was computed by increment,
+a trail of the computational steps performed is created.
+Because many steps can occur until the fully clean data are obtained,
+and because it is OPTIONAL to save every file or step,
+the simpler `desc-preproc` and `desc-proc` are available.
+It becomes however important to document what such pre-processing or processing are,
+and record the order of computational steps.
+This can be done in the JSON sidecar files or alternatively described in a `descriptions.tsv` file.
 
 ## descriptions.tsv
 
-To keep a record of what has been done to the data, a `descriptions.tsv` file can be used, containing at least two columns: `desc_id` and `description`. This file MAY be located at the root of the derivative dataset, or at the subject or session level ([Inheritance Principle](../common-principles.md#the-inheritance-principle))).
+To keep a record of what has been done to the data, a `descriptions.tsv` file can be used,
+containing at least two columns: `desc_id` and `description`.
+This file MAY be located at the root of the derivative dataset,
+or at the subject or session level
+([Inheritance Principle](../common-principles.md#the-inheritance-principle))).
 
-`desc_id` contains all labels used in the [`desc entity`](../appendices/entities.md#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance', i.e. it is not aimed at providing full computational reproducibility.
+`desc_id` contains all labels used in the [`desc entity`](../appendices/entities.md#desc),
+while `description` is a human-readable description of what was computed.
+Note that while it is helpful to document how files are generated, we see this as *light provenance*,
+that is, it is not aimed at providing full computational reproducibility.
 
 {{ MACROS___make_filetree_example(
    {
@@ -300,11 +309,11 @@ To keep a record of what has been done to the data, a `descriptions.tsv` file ca
 
 `descriptions.tsv`
 
-| desc_id          | description                                                                                    |
-|------------------|------------------------------------------------------------------------------------------------|
-| Filt             | low-pass filtered at 30Hz                                                                      |
-| FiltDs           | low-pass filtered at 30Hz,downsampled to 250Hz                                                 |
-| preproc          | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference |
+| desc_id | description                                                                                    |
+|---------|------------------------------------------------------------------------------------------------|
+| Filt    | low-pass filtered at 30Hz                                                                      |
+| FiltDs  | low-pass filtered at 30Hz,downsampled to 250Hz                                                 |
+| preproc | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference |
 
 <!-- Link Definitions -->
 

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -255,16 +255,16 @@ makes them invalid (for example, if a source 4D image is averaged to create a si
 static volume, a `RepetitionTime` property would no longer be relevant). As each file
 includes what was computed by increment, a trail of the computational steps performed
 is created. Because many steps can occur until the fully clean data are obtained and
-because it is NOT mandatory to save every file or step, the simpler `desc-preproc`
+because it is OPTIONAL to save every file or step, the simpler `desc-preproc`
 and `desc-proc` are available. It becomes however important to document what such
 pre-processing or processing are, and record the order of computational steps. This
-can be in the json file or alternatively described in a descriptions.tsv file.
+can be done in the JSON sidecar files or alternatively described in a `descriptions.tsv` file.
 
 ## descriptions.tsv
 
-To keep a record of what has been done to the data, a `descriptions.tsv` file can be used, containing at least two columns: `desc_id` and `description`. This file can be located at the root derivatives level or at the subject level (inheritance principle).
+To keep a record of what has been done to the data, a `descriptions.tsv` file can be used, containing at least two columns: `desc_id` and `description`. This file MAY be located at the root of the derivative dataset, or at the subject or session level ([Inheritance Principle](../common-principles.md#the-inheritance-principle))).
 
-`desc_id` contains all labels used in the [`desc entity`](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance', i.e. it is not aimed at providing full computational reproducibility.
+`desc_id` contains all labels used in the [`desc entity`](../appendices/entities.md#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance', i.e. it is not aimed at providing full computational reproducibility.
 
 {{ MACROS___make_filetree_example(
    {

--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -252,7 +252,57 @@ A guide for using macros can be found at
 All REQUIRED metadata fields coming from a derivative file’s source file(s) MUST
 be propagated to the JSON description of the derivative unless the processing
 makes them invalid (for example, if a source 4D image is averaged to create a single
-static volume, a `RepetitionTime` property would no longer be relevant).
+static volume, a `RepetitionTime` property would no longer be relevant). This creates 
+a trail of the computational steps performed. Because many steps can occur until clean 
+data and because it is NOT mandatory to save every file or step, the simpler `desc-preproc` 
+and `desc-proc` are available.
+
+## descriptions.tsv
+
+To keep a record of what has been done to the data, a `descriptions.tsv` file can be used, containing at least two columns: `desc_id` and `description`. This file can be located at the root derivatives level or at the subject level (inheritance principle).  
+
+`desc_id` contains all labels used in the [`desc entity`](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#desc), while `description` is a human-readable description of what was computed. Note that while it is helpful to document how files are generated, we see this as 'light provenance' (see [provenance BEP28](https://github.com/bids-standard/BEP028_BIDSprov) for full computational reproducibility).  
+
+{{ MACROS___make_filetree_example(
+   {
+    "raw/": {
+         CHANGES
+         README
+         channels.tsv
+         dataset_description.tsv
+         participants.tsv
+          "sub-001": {
+            "eeg": {
+                "sub-001_task-listening_events.tsv": "",
+                "sub-001_task-listening_events.json": "",
+                "sub-001_task-listening_eeg.edf": "",
+                "sub-001_task-listening_eeg.json": "",
+                },
+            },
+          },
+  "derivatives/": {      
+         descriptions.tsv
+        "sub-001": {
+            "eeg": {
+                "sub-001_task-listening_desc-filt_eeg.edf": "",
+                "sub-001_task-listening_desc-filt_eeg.json": "",
+                "sub-001_task-listening_desc-filt+ds_eeg.edf": "",
+                "sub-001_task-listening_desc-filt+ds_eeg.json": "",
+                "sub-001_task-listening_desc-preproc_eeg.edf": "",
+                "sub-001_task-listening_desc-preproc_eeg.json": "",                },
+            },
+        }
+   }
+) }}
+
+`descriptions.tsv`
+
+| desc_id          | description                                                                                               |
+|------------------|-----------------------------------------------------------------------------------------------------------|
+| filt             |  low-pass filtered at 30Hz                                                                                |
+| filt+ds          | low-pass filtered at 30Hz,downsampled to 250Hz                                                            |
+| preproc          | low-pass filtered at 30Hz, downsampled to 250Hz and rereferenced to a common average reference            |
+
 
 <!-- Link Definitions -->
 


### PR DESCRIPTION
add descriptions.tsv file as optional based on the derivatives guidelines https://docs.google.com/document/d/1JtTu5u7XTkWxxnCIH6sxGajGn1qG_syJ-p14aejpk3E/edit?usp=sharing