### PR TITLE
SCHEMA: Update DWI rules to check bval/bvec size in associations

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -180,6 +180,9 @@ context:
             n_cols:
               description: 'Number of columns in bval file'
               type: integer
+            n_rows:
+              description: 'Number of rows in bval file'
+              type: integer
         bvec:
           description: 'B vector file'
           type: object
@@ -189,6 +192,9 @@ context:
               type: string
             n_cols:
               description: 'Number of columns in bvec file'
+              type: integer
+            n_rows:
+              description: 'Number of rows in bvec file'
               type: integer
         channels:
           description: 'Channels file'

--- a/src/schema/rules/checks/dwi.yaml
+++ b/src/schema/rules/checks/dwi.yaml
@@ -25,9 +25,10 @@ DWIBvalRows:
       '.bval' files should contain exactly one row of values.
     level: error
   selectors:
-    - extension == ".bval"
+    - suffix == "dwi"
+    - '"bval" in associations'
   checks:
-    - data.n_rows == 1
+    - associations.bval.n_rows == 1
 
 # 31
 DWIBvecRows:
@@ -37,9 +38,10 @@ DWIBvecRows:
       '.bvec' files should contain exactly three rows of values.
     level: error
   selectors:
-    - extension == ".bvec"
+    - suffix == "dwi"
+    - '"bvec" in associations'
   checks:
-    - data.n_rows == 3
+    - associations.bvec.n_rows == 1
 
 # 32
 DWIMissingBvec:

--- a/src/schema/rules/errors.yaml
+++ b/src/schema/rules/errors.yaml
@@ -45,24 +45,6 @@ GzNotGzipped:
   selectors:
     - match(extension, '\.gz$')
 
-# BIDS Validator Original Issue Code #30
-BvalMultipleRows:
-  code: BVAL_MULTIPLE_ROWS
-  message: |
-    .bval files should contain exactly one row of volumes.
-  level: error
-  selectors:
-    - extension == ".bval"
-
-# BIDS Validator Original Issue Code #31
-BvecNumberRows:
-  code: BVEC_NUMBER_ROWS
-  message: |
-    .bvec files should contain exactly three rows of volumes.
-  level: error
-  selectors:
-    - extension == ".bvec"
-
 # BIDS Validator Original Issue Code #36
 NiftiTooSmall:
   code: NIFTI_TOO_SMALL


### PR DESCRIPTION
This is an alternative to #1609. Instead of directly referencing bval/bvec shape on these files, we can operate on the associations. Constructing the association should take more time than parsing the file, so this should be a net optimization, even though we will end up processing the rule more times.