### PR TITLE
SCHEMA: Make expression tests more manageable

### DIFF
--- a/src/schema/meta/expression_tests.yaml
+++ b/src/schema/meta/expression_tests.yaml
@@ -61,9 +61,9 @@
 - expression: '"VolumeTiming" in null'
   result: false
 - expression: exists(null, "bids-uri")
-  result: false
+  result: 0
 - expression: exists([], null)
-  result: false
+  result: 0
 
 # General expressions
 - expression: 1 + 2

--- a/src/schema/meta/expression_tests.yaml
+++ b/src/schema/meta/expression_tests.yaml
@@ -1,13 +1,13 @@
 ---
 # null fall-through logic
-- expression: sidecar.MissingValue != true
-  result: true
-- expression: null.anything != true
-  result: true
+- expression: sidecar.MissingValue
+  result: null
+- expression: null.anything
+  result: null
 - expression: (null)
   result: null
-- expression: null[0] != true
-  result: true
+- expression: null[0]
+  result: null
 - expression: null && true
   result: null
 - expression: true && null
@@ -27,7 +27,7 @@
 - expression: intersects(null, [])
   result: false
 - expression: match(null, 'pattern')
-  result: false
+  result: null
 - expression: match('string', null)
   result: false
 - expression: substr(null, 1, 4)
@@ -59,11 +59,13 @@
 - expression: null == 1
   result: false
 - expression: '"VolumeTiming" in null'
-  result: false
+  result: null
 - expression: exists(null, "bids-uri")
   result: 0
 - expression: exists([], null)
   result: 0
+- expression: true || sidecar.MissingValue
+  result: true
 
 # General expressions
 - expression: 1 + 2

--- a/src/schema/meta/expression_tests.yaml
+++ b/src/schema/meta/expression_tests.yaml
@@ -1,16 +1,14 @@
 ---
 # null fall-through logic
-- expression: sidecar.MissingValue
-  result: null
-- expression: null.anything
-  result: null
+- expression: sidecar.MissingValue != true
+  result: true
+- expression: null.anything != true
+  result: true
 - expression: (null)
   result: null
-- expression: null[0]
-  result: null
+- expression: null[0] != true
+  result: true
 - expression: null && true
-  result: null
-- expression: null || true
   result: null
 - expression: true && null
   result: null
@@ -18,38 +16,20 @@
   result: false
 - expression: true || null
   result: true
+- expression: null || true
+  result: true
 - expression: false || null
   result: null
 - expression: '!null'
-  result: null
-- expression: null + 1
-  result: null
-- expression: null - 1
-  result: null
-- expression: null * 1
-  result: null
-- expression: null / 1
-  result: null
-- expression: 1 + null
-  result: null
-- expression: 1 - null
-  result: null
-- expression: 1 * null
-  result: null
-- expression: 1 / null
-  result: null
-- expression: "'str1' + null"
-  result: null
-- expression: "null + 'str1'"
-  result: null
+  result: true
 - expression: intersects([], null)
-  result: null
+  result: false
 - expression: intersects(null, [])
-  result: null
+  result: false
 - expression: match(null, 'pattern')
-  result: null
+  result: false
 - expression: match('string', null)
-  result: null
+  result: false
 - expression: substr(null, 1, 4)
   result: null
 - expression: substr('string', null, 4)
@@ -85,21 +65,11 @@
 - expression: exists([], null)
   result: false
 
-# Truth/falsity of final expressions
-- expression: evaluate(true)
-  result: true
-- expression: evaluate(false)
-  result: false
-- expression: evaluate(null)
-  result: false
-
 # General expressions
 - expression: 1 + 2
   result: 3
 - expression: '"cat" + "dog"'
   result: 'catdog'
-- expression: '1 + "cat"'
-  result: null
 - expression: match('string', '.*')
   result: true
 - expression: match('', '.')


### PR DESCRIPTION
We started with a pretty ambitious expression language, thinking it would not be hard to implement in any language. It turns out that it would require a proper parser, which would probably be an intolerable slowdown to the javascript implementation. Making `null` "falsey" is enough, and we don't use much of the fall-through behavior we originally designed.

A Python implementation will be able to do some type-checking on the expressions we actually have to make sure they stay in the bounds the JS implementation can handle.