### PR TITLE
Fix years and degrees Units and unit to be singular to match the rest

### DIFF
--- a/src/modality-agnostic-files.md
+++ b/src/modality-agnostic-files.md
@@ -269,7 +269,7 @@ to date of birth.
 {
     "age": {
         "Description": "age of the participant",
-        "Units": "years"
+        "Units": "year"
     },
     "sex": {
         "Description": "sex of the participant as reported by the participant",

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -3263,7 +3263,7 @@ SpoilingRFPhaseIncrement:
     which is applied to the phase of the excitation pulse at each TR period for
     achieving RF spoiling.
   type: number
-  unit: degrees
+  unit: degree
 SpoilingState:
   name: SpoilingState
   display_name: Spoiling State


### PR DESCRIPTION
What we have

	❯ git grep '"Units":'
	src/appendices/hed.md:    "Units": "s",
	src/appendices/hed.md:       "Units": "ms",
	src/appendices/qmri.md:      "Units": "RECOMMENDED",
	src/appendices/qmri.md:"Units": "second",
	src/common-principles.md:        "Units": "RECOMMENDED",
	src/common-principles.md:    "Units": "kg/m^2",
	src/modality-agnostic-files.md:        "Units": "years"
	src/modality-specific-files/magnetic-resonance-imaging-data.md:   "Units": "rad"
	src/modality-specific-files/magnetic-resonance-imaging-data.md:   "Units": "rad/s",
	src/modality-specific-files/physiological-and-other-continuous-recordings.md:        "Units": "mV"
	src/modality-specific-files/physiological-and-other-continuous-recordings.md:        "Units": "mV"
	src/modality-specific-files/positron-emission-tomography.md:  "Units": "Bq/mL",
	src/modality-specific-files/positron-emission-tomography.md:        "Units": "s"
	src/modality-specific-files/positron-emission-tomography.md:        "Units": "kBq/mL"
	src/modality-specific-files/positron-emission-tomography.md:        "Units": "kBq/mL"
	src/modality-specific-files/positron-emission-tomography.md:        "Units": "arbitrary"
	src/modality-specific-files/positron-emission-tomography.md:        "Units": "arbitrary"
	src/modality-specific-files/positron-emission-tomography.md:        "Units": "arbitrary"

which are singular and then in the schema "unit"

    ❯ git grep -h unit: | sed -e 's,^[- ]*,,g' | sort | uniq -c | sort -n
          1 unit:
          1 unit: cm
          1 unit: degrees
          1 unit: g/mL
          1 unit: hexadecimal
          1 unit: kOhm
          1 unit: mL
          1 unit: mL/s
          1 unit: 'mm^2'
          1 unit: mT.s/m
          1 unit: ppm
          1 unit: rad
          1 unit: um
          1 unit: uT
          1 unit: year
          2 unit: cm/s
          2 unit: ms
          2 unit: mT/m
          3 unit: 1/s
          3 unit: degree
          4 unit: m
          6 unit: mm
         12 unit: Hz
         20 unit: arbitrary
         49 unit: s

also singular.
