### PR TITLE
Allow for .nwb standard/file format  to be used for "micr"

### DIFF
--- a/src/schema/rules/files/raw/micr.yaml
+++ b/src/schema/rules/files/raw/micr.yaml
@@ -25,6 +25,7 @@ microscopy:
     - .png
     - .tif
     - .json
+    - .nwb
   datatypes:
     - micr
   entities:


### PR DESCRIPTION
See https://pynwb.readthedocs.io/en/stable/tutorials/domain/ophys.html for support of various microscopy modalities within NWB.  As NWB is already supported for other modalities, there is some support for microscopy in NWB in various tools, and as there are datasets with .nwb -- it makes sense to allow for .nwb to be used for microscopy data as well where appropriate.
