### PR TITLE
FIX/SCHEMA: Remove TracerName requirement for trc entity

### DIFF
--- a/src/schema/rules/sidecars/entity_rules.yaml
+++ b/src/schema/rules/sidecars/entity_rules.yaml
@@ -19,12 +19,6 @@ EntitiesCeMetadata:
   fields:
     ContrastBolusIngredient: optional
 
-EntitiesTrcMetadata:
-  selectors:
-    - '"trc" in entities'
-  fields:
-    TracerName: required
-
 EntitiesStainMetadata:
   selectors:
     - '"stain" in entities'


### PR DESCRIPTION
Already covered by rules.sidecars.pet.PETRadioChemistry, and avoids hitting this rule for blood files.

Fixes https://github.com/bids-standard/bids-examples/issues/416