### PR TITLE
[INFRA] Remove LGTM.com configuration file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,8 +1,0 @@
----
-# This file contains configuration for the LGTM tool: https://lgtm.com/
-# The bids-specification repository is continuously scanned by the LGTM tool
-# for any security and/or code vulnerabilities. You can find the alert here:
-# https://lgtm.com/projects/g/bids-standard/bids-specification/
-queries:
-  # https://lgtm.com/rules/6770079/
-  - exclude: py/unused-import


### PR DESCRIPTION
LGTM.com has been deprecated and replaced by GitHub code analysis:
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/