### PR TITLE
[SCHEMA] Add remaining enum definitions

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -300,9 +300,9 @@ context:
               name: 'XYZ Units'
               description: 'String representing the unit of voxel spacing.'
               type: string
-              # TODO: Add definitions for these values. (perhaps don't specify)
               enum:
                 - $ref: objects.enums.unknown.value
+                # TODO: Add definitions for these values. (perhaps don't specify)
                 - 'meter'
                 - 'mm'
                 - 'um'
@@ -310,9 +310,9 @@ context:
               name: 'Time Unit'
               description: 'String representing the unit of inter-volume intervals.'
               type: string
-              # TODO: Add definitions for these values. (perhaps don't specify)
               enum:
                 - $ref: objects.enums.unknown.value
+                # TODO: Add definitions for these values. (perhaps don't specify)
                 - 'sec'
                 - 'msec'
                 - 'usec'

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -300,9 +300,9 @@ context:
               name: 'XYZ Units'
               description: 'String representing the unit of voxel spacing.'
               type: string
-              # TODO: Add definitions for these values.
+              # TODO: Add definitions for these values. (perhaps don't specify)
               enum:
-                - 'unknown'
+                - $ref: objects.enums.unknown.value
                 - 'meter'
                 - 'mm'
                 - 'um'
@@ -310,9 +310,9 @@ context:
               name: 'Time Unit'
               description: 'String representing the unit of inter-volume intervals.'
               type: string
-              # TODO: Add definitions for these values.
+              # TODO: Add definitions for these values. (perhaps don't specify)
               enum:
-                - 'unknown'
+                - $ref: objects.enums.unknown.value
                 - 'sec'
                 - 'msec'
                 - 'usec'

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -300,6 +300,7 @@ context:
               name: 'XYZ Units'
               description: 'String representing the unit of voxel spacing.'
               type: string
+              # TODO: Add definitions for these values.
               enum:
                 - 'unknown'
                 - 'meter'
@@ -309,6 +310,7 @@ context:
               name: 'Time Unit'
               description: 'String representing the unit of inter-volume intervals.'
               type: string
+              # TODO: Add definitions for these values.
               enum:
                 - 'unknown'
                 - 'sec'

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -63,6 +63,7 @@ component:
     For example, `x`,`y`,`z` for position channels,
     or `quat_x`, `quat_y`, `quat_z`, `quat_w` for quaternion orientation channels.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - x
     - y
@@ -162,6 +163,7 @@ handedness:
     For "ambidextrous", use one of these values: `ambidextrous`, `a`, `A`, `AMBIDEXTROUS`,
     `Ambidextrous`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - left
     - l
@@ -424,6 +426,7 @@ sample_type:
     Biosample type defined by
     [ENCODE Biosample Type](https://www.encodeproject.org/profiles/biosample_type).
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - cell line
     - in vitro differentiated cells
@@ -461,6 +464,7 @@ sex:
 
     For "other", use one of these values: `other`, `o`, `O`, `OTHER`, `Other`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - male
     - m
@@ -543,6 +547,7 @@ status:
     If quality is unknown, then a value of `n/a` may be used.
     Description of noise type SHOULD be provided in `[status_description]`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - good
     - bad
@@ -685,6 +690,7 @@ type__optodes:
   description: |
     The type of the optode.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - source
     - detector
@@ -730,6 +736,7 @@ volume_type:
     The `*_aslcontext.tsv` table consists of a single column of labels identifying
     the `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - control
     - label

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -688,8 +688,8 @@ type__optodes:
     The type of the optode.
   type: string
   enum:
-    - $ref: objects.enums.source
-    - $ref: objects.enums.detector
+    - $ref: objects.enums.source.value
+    - $ref: objects.enums.detector.value
     - n/a
 units:
   name: units

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -425,17 +425,16 @@ sample_type:
     Biosample type defined by
     [ENCODE Biosample Type](https://www.encodeproject.org/profiles/biosample_type).
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - cell line
-    - in vitro differentiated cells
-    - primary cell
-    - cell-free sample
-    - cloning host
-    - tissue
-    - whole organisms
-    - organoid
-    - technical sample
+    - $ref: objects.enums.cell_line.value
+    - $ref: objects.enums.in_vitro_differentiated_cells.value
+    - $ref: objects.enums.primary_cell.value
+    - $ref: objects.enums.cell_free_sample.value
+    - $ref: objects.enums.cloning_host.value
+    - $ref: objects.enums.tissue.value
+    - $ref: objects.enums.whole_organisms.value
+    - $ref: objects.enums.organoid.value
+    - $ref: objects.enums.technical_sample.value
 sampling_frequency:
   name: sampling_frequency
   display_name: Channel sampling frequency
@@ -546,10 +545,9 @@ status:
     If quality is unknown, then a value of `n/a` may be used.
     Description of noise type SHOULD be provided in `[status_description]`.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - good
-    - bad
+    - $ref: objects.enums.good.value
+    - $ref: objects.enums.bad.value
     - n/a
 status_description:
   name: status_description
@@ -734,13 +732,12 @@ volume_type:
     The `*_aslcontext.tsv` table consists of a single column of labels identifying
     the `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - control
-    - label
-    - m0scan
-    - deltam
-    - cbf
+    - $ref: objects.enums.control.value
+    - $ref: objects.enums.label.value
+    - $ref: objects.enums.m0scan.value
+    - $ref: objects.enums.deltam.value
+    - $ref: objects.enums.cbf.value
 wavelength_nominal:
   name: wavelength_nominal
   display_name: Wavelength nominal

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -63,15 +63,14 @@ component:
     For example, `x`,`y`,`z` for position channels,
     or `quat_x`, `quat_y`, `quat_z`, `quat_w` for quaternion orientation channels.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - x
-    - y
-    - z
-    - quat_x
-    - quat_y
-    - quat_z
-    - quat_w
+    - $ref: objects.enums.x.value
+    - $ref: objects.enums.y.value
+    - $ref: objects.enums.z.value
+    - $ref: objects.enums.quat_x.value
+    - $ref: objects.enums.quat_y.value
+    - $ref: objects.enums.quat_z.value
+    - $ref: objects.enums.quat_w.value
     - n/a
 detector__channels:
   name: detector

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -690,10 +690,9 @@ type__optodes:
   description: |
     The type of the optode.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - source
-    - detector
+    - $ref: objects.enums.source
+    - $ref: objects.enums.detector
     - n/a
 units:
   name: units

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -162,7 +162,7 @@ handedness:
     For "ambidextrous", use one of these values: `ambidextrous`, `a`, `A`, `AMBIDEXTROUS`,
     `Ambidextrous`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - left
     - l
@@ -463,7 +463,7 @@ sex:
 
     For "other", use one of these values: `other`, `o`, `O`, `OTHER`, `Other`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - male
     - m

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1344,7 +1344,7 @@ csf:
   value: csf
   display_name: CSF
   description: |
-    The origin of a sample: cerebrospinal fluid
+    Cerebrospinal fluid (for example, the origin of a sample or tissue)
 breast_milk:
   value: breast milk
   display_name: breast milk

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1342,9 +1342,9 @@ brain:
     The origin of a sample: brain
 csf:
   value: csf
-  display_name: csf
+  display_name: CSF
   description: |
-    cerebrospinal fluid (e.g., the origin of a sample or tissue)
+    The origin of a sample: cerebrospinal fluid
 breast_milk:
   value: breast milk
   display_name: breast milk

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -322,6 +322,22 @@ ChietiItab:
   display_name: Chieti ITAB
   description: |
     RAS orientation and the origin between the ears.
+calibration:
+  value: calibration
+  display_name: calibration
+  description: |
+    The fine-calibration file, is produced by the MaxFilter software and the work of
+    Neuromag/Elekta/MEGIN engineers during maintenance of the MEG acquisition system.
+    It is specific to the site of recording and may change in the process of regular system maintenance.
+    it is usually shared with a crosstalk file.
+crosstalk:
+  value: crosstalk
+  display_name: crosstalk
+  description: |
+    The crosstalk file, is produced by the MaxFilter software and the work of
+    Neuromag/Elekta/MEGIN engineers during maintenance of the MEG acquisition system.
+    It is specific to the site of recording and may change in the process of regular system maintenance.
+    it is usually shared with a fine-calibration file.
 individual:
   value: individual
   display_name: individual

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1153,3 +1153,13 @@ quat_w:
   display_name: quat_w
   description: |
     The quaternion w dimension of the coordinate system.
+unknown:
+  value: 'unknown'
+  display_name: 'unknown'
+  description: |
+    An unknown unit.
+pixels:
+  value: pixels
+  display_name: pixels
+  description: |
+    A dimension specified in pixels.

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1103,3 +1103,13 @@ NIRSCWMUA:
     - fnirs
   description: |
     Continuous wave optical absorption measurements. Equivalent to dataTypeLabel mua in SNIRF.
+source:
+  value: source
+  display_name: source
+  description: |
+    A light emitting device, sometimes called a transmitter.
+detector:
+  value: detector
+  display_name: detector
+  description: |
+    A photoelectric transducer, sometimes called a receiver.

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1163,3 +1163,240 @@ pixels:
   display_name: pixels
   description: |
     A dimension specified in pixels.
+cell_line:
+  value: cell line
+  display_name: cell line
+  description: |
+    A biosample type (`sample_type`): cell line
+in_vitro_differentiated_cells:
+  value: in vitro differentiated cells
+  display_name: in vitro differentiated cells
+  description: |
+    A biosample type (`sample_type`): in vitro differentiated cells
+primary_cell:
+  value: primary cell
+  display_name: primary cell
+  description: |
+    A biosample type (`sample_type`): primary cell
+cell_free_sample:
+  value: cell-free sample
+  display_name: cell-free sample
+  description: |
+    A biosample type (`sample_type`): cell-free sample
+cloning_host:
+  value: cloning host
+  display_name: cloning host
+  description: |
+    A biosample type (`sample_type`): cloning host
+tissue:
+  value: tissue
+  display_name: tissue
+  description: |
+    A biosample type (`sample_type`): tissue
+whole_organisms:
+  value: whole organisms
+  display_name: whole organisms
+  description: |
+    A biosample type (`sample_type`):  whole organisms
+organoid:
+  value: organoid
+  display_name: organoid
+  description: |
+    A biosample type (`sample_type`): organoid
+technical_sample:
+  value: technical sample
+  display_name: technical sample
+  description: |
+    A biosample type (`sample_type`): technical sample
+good:
+  value: good
+  display_name: good
+  description: |
+    A good status (for example the status of a recording channel).
+bad:
+  value: bad
+  display_name: bad
+  description: |
+    A bad status (for example the status of a recording channel).
+control:
+  value: control
+  display_name: control
+  description: |
+    An ASL volume type: control
+label:
+  value: label
+  display_name: label
+  description: |
+    An ASL volume type: label
+m0scan:
+  value: m0scan
+  display_name: m0scan
+  description: |
+    An ASL volume type: m0scan
+deltam:
+  value: deltam
+  display_name: deltam
+  description: |
+    An ASL volume type: deltam
+cbf:
+  value: cbf
+  display_name: cbf
+  description: |
+    An ASL volume type: cbf
+single_coil:
+  value: single-coil
+  display_name: single-coil
+  description: |
+    CASL Type: when a single coil is used for labeling.
+double_coil:
+  value: double-coil
+  display_name: double-coil
+  description: |
+    CASL Type: when a double coil is used for labeling.
+IODINE:
+  value: IODINE
+  display_name: IODINE
+  description: |
+    A Contrast Bolus Ingredient: Iodine
+GADOLINIUM:
+  value: GADOLINIUM
+  display_name: GADOLINIUM
+  description: |
+    A Contrast Bolus Ingredient: Gadolinium
+CARBON_DIOXIDE:
+  value: CARBON DIOXIDE
+  display_name: CARBON DIOXIDE
+  description: |
+    A Contrast Bolus Ingredient: Carbon Dioxide
+BARIUM:
+  value: BARIUM
+  display_name: BARIUM
+  description: |
+    A Contrast Bolus Ingredient: Barium
+XENON:
+  value: XENON
+  display_name: XENON
+  description: |
+    A Contrast Bolus Ingredient: Xenon
+raw:
+  value: raw
+  display_name: raw
+  description: |
+    A raw BIDS dataset.
+derivative:
+  value: derivative
+  display_name: derivative
+  description: |
+    A derived BIDS dataset.
+balanced:
+  value: balanced
+  display_name: balanced
+  description: |
+    PCASL Type: when balanced gradient pulses are used.
+unbalanced:
+  value: unbalanced
+  display_name: unbalanced
+  description: |
+    PCASL Type: when unbalanced gradient pulses are used.
+left_hand:
+  value: left-hand
+  display_name: left-hand
+  description: |
+    A rotation rule: rotations are applied clockwise around
+    an axis when seen from the positive direction
+right_hand:
+  value: right-hand
+  display_name: right-hand
+  description: |
+    A rotation rule: rotations are applied counter-clockwise around
+    an axis when seen from the positive direction
+in_vivo:
+  value: in vivo
+  display_name: in vivo
+  description: |
+    The environment of a sample: in vivo
+ex_vivo:
+  value: ex vivo
+  display_name: ex vivo
+  description: |
+    The environment of a sample: ex vivo
+in_vitro:
+  value: in vitro
+  display_name: in vitro
+  description: |
+    The environment of a sample: in vitro
+blood:
+  value: blood
+  display_name: blood
+  description: |
+    The origin of a sample: blood
+saliva:
+  value: saliva
+  display_name: saliva
+  description: |
+    The origin of a sample: saliva
+brain:
+  value: brain
+  display_name: brain
+  description: |
+    The origin of a sample: brain
+csf:
+  value: csf
+  display_name: csf
+  description: |
+    cerebrospinal fluid (e.g., the origin of a sample or tissue)
+breast_milk:
+  value: breast milk
+  display_name: breast milk
+  description: |
+    The origin of a sample: breast milk
+amniotic_fluid:
+  value: amniotic fluid
+  display_name: amniotic fluid
+  description: |
+    The origin of a sample: amniotic fluid
+other_biospecimen:
+  value: other biospecimen
+  display_name: other biospecimen
+  description: |
+    The origin of a sample: other biospecimen
+RF:
+  value: RF
+  display_name: RF
+  description: |
+    A spoiling type: RF
+GRADIENT:
+  value: GRADIENT
+  display_name: GRADIENT
+  description: |
+    A spoiling type: GRADIENT
+COMBINED:
+  value: COMBINED
+  display_name: COMBINED
+  description: |
+    A spoiling type: COMBINED
+gray_matter:
+  value: gray matter
+  display_name: gray matter
+  description: |
+    The origin of a tissue: gray matter
+white_matter:
+  value: white matter
+  display_name: white matter
+  description: |
+    The origin of a tissue: white matter
+meninges:
+  value: meninges
+  display_name: meninges
+  description: |
+    The origin of a tissue: meninges
+macrovascular:
+  value: macrovascular
+  display_name: macrovascular
+  description: |
+    The origin of a tissue: macrovascular
+microvascular:
+  value: microvascular
+  display_name: microvascular
+  description: |
+    The origin of a tissue: microvascular

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1350,6 +1350,11 @@ breast_milk:
   display_name: breast milk
   description: |
     The origin of a sample: breast milk
+bile:
+  value: bile
+  display_name: Bile
+  description: |
+    The origin of a sample: bile
 amniotic_fluid:
   value: amniotic fluid
   display_name: amniotic fluid

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1155,7 +1155,7 @@ quat_w:
     The quaternion w dimension of the coordinate system.
 unknown:
   value: 'unknown'
-  display_name: 'unknown'
+  display_name: unknown
   description: |
     An unknown unit.
 pixels:

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1113,3 +1113,43 @@ detector:
   display_name: detector
   description: |
     A photoelectric transducer, sometimes called a receiver.
+mixed:
+  value: mixed
+  display_name: mixed
+  description: |
+    Mixed detector types were used for this NIRS recording, specify in `optodes.tsv`.
+x:
+  value: x
+  display_name: x
+  description: |
+    The x dimension of the coordinate system.
+y:
+  value: y
+  display_name: y
+  description: |
+    The y dimension of the coordinate system.
+z:
+  value: z
+  display_name: z
+  description: |
+    The z dimension of the coordinate system.
+quat_x:
+  value: quat_x
+  display_name: quat_x
+  description: |
+    The quaternion x dimension of the coordinate system.
+quat_y:
+  value: quat_y
+  display_name: quat_y
+  description: |
+    The quaternion y dimension of the coordinate system.
+quat_z:
+  value: quat_z
+  display_name: quat_z
+  description: |
+    The quaternion z dimension of the coordinate system.
+quat_w:
+  value: quat_w
+  display_name: quat_w
+  description: |
+    The quaternion w dimension of the coordinate system.

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -364,10 +364,9 @@ CASLType:
   description: |
     Describes if a separate coil is used for labeling.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - single-coil
-    - double-coil
+    - $ref: objects.enums.single_coil.value
+    - $ref: objects.enums.double_coil.value
 CapManufacturer:
   name: CapManufacturer
   display_name: Cap Manufacturer
@@ -490,13 +489,13 @@ ContrastBolusIngredient:
     Active ingredient of agent.
     Corresponds to DICOM Tag 0018, 1048 `Contrast/Bolus Ingredient`.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - IODINE
-    - GADOLINIUM
-    - CARBON DIOXIDE
-    - BARIUM
-    - XENON
+    - $ref: objects.enums.IODINE.value
+    - $ref: objects.enums.GADOLINIUM.value
+    - $ref: objects.enums.CARBON_DIOXIDE.value
+    - $ref: objects.enums.BARIUM.value
+    - $ref: objects.enums.XENON.value
+    # TODO: Add definitions for these values. (perhaps don't specify)
     - UNKNOWN
     - NONE
 DCOffsetCorrection:
@@ -537,10 +536,9 @@ DatasetType:
     The interpretation of the dataset.
     For backwards compatibility, the default value is `"raw"`.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - raw
-    - derivative
+    - $ref: objects.enums.raw.value
+    - $ref: objects.enums.derivative.value
 DecayCorrectionFactor:
   name: DecayCorrectionFactor
   display_name: Decay Correction Factor
@@ -2261,10 +2259,9 @@ PCASLType:
   description: |
     The type of gradient pulses used in the `control` condition.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - balanced
-    - unbalanced
+    - $ref: objects.enums.balanced.value
+    - $ref: objects.enums.unbalanced.value
 ParallelAcquisitionTechnique:
   name: ParallelAcquisitionTechnique
   display_name: Parallel Acquisition Technique
@@ -2725,7 +2722,7 @@ RotationOrder:
   description: |
     Specify the sequence in which the elemental 3D extrinsic rotations are applied around the three distinct axes.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - XYZ
     - XZY
@@ -2742,10 +2739,9 @@ RotationRule:
     clockwise around an axis when seen from the positive direction (left-hand rule) or
     counter-clockwise (right-hand rule). Must be one of: "left-hand", "right-hand".
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - left-hand
-    - right-hand
+    - $ref: objects.enums.left_hand.value
+    - $ref: objects.enums.right_hand.value
     - n/a
 SEEGChannelCount:
   name: SEEGChannelCount
@@ -2767,11 +2763,10 @@ SampleEnvironment:
     Environment in which the sample was imaged. MUST be one of: `"in vivo"`, `"ex vivo"`
     or `"in vitro"`.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - in vivo
-    - ex vivo
-    - in vitro
+    - $ref: objects.enums.in_vivo.value
+    - $ref: objects.enums.ex_vivo.value
+    - $ref: objects.enums.in_vitro.value
 SampleExtractionInstitution:
   name: SampleExtractionInstitution
   display_name: Sample Extraction Institution
@@ -2800,16 +2795,15 @@ SampleOrigin:
   description: |
     Describes from which tissue the genetic information was extracted.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - blood
-    - saliva
-    - brain
-    - csf
-    - breast milk
-    - bile
-    - amniotic fluid
-    - other biospecimen
+    - $ref: objects.enums.blood.value
+    - $ref: objects.enums.saliva.value
+    - $ref: objects.enums.brain.value
+    - $ref: objects.enums.csf.value
+    - $ref: objects.enums.breast_milk.value
+    - $ref: objects.enums.bile.value
+    - $ref: objects.enums.amniotic_fluid.value
+    - $ref: objects.enums.other_biospecimen.value
 SamplePrimaryAntibody:
   name: SamplePrimaryAntibody
   display_name: Sample Primary Antibody
@@ -3291,11 +3285,10 @@ SpoilingType:
   description: |
     Specifies which spoiling method(s) are used by a spoiled sequence.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - RF
-    - GRADIENT
-    - COMBINED
+    - $ref: objects.enums.RF.value
+    - $ref: objects.enums.GRADIENT.value
+    - $ref: objects.enums.COMBINED.value
 StartTime:
   name: StartTime
   display_name: Start Time
@@ -3407,14 +3400,13 @@ TissueOrigin:
   description: |
     Describes the type of tissue analyzed for `"SampleOrigin"` `brain`.
   type: string
-  # TODO: Add definitions for these values.
   enum:
-    - gray matter
-    - white matter
-    - csf
-    - meninges
-    - macrovascular
-    - microvascular
+    - $ref: objects.enums.gray_matter.value
+    - $ref: objects.enums.white_matter.value
+    - $ref: objects.enums.csf.value
+    - $ref: objects.enums.meninges.value
+    - $ref: objects.enums.macrovascular.value
+    - $ref: objects.enums.microvascular.value
 TotalAcquiredPairs:
   name: TotalAcquiredPairs
   display_name: Total Acquired Pairs
@@ -3652,12 +3644,12 @@ iEEGCoordinateUnits:
     Units of the `*_electrodes.tsv`.
     MUST be `"pixels"` if `iEEGCoordinateSystem` is `Pixels`.
   type: string
-  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
+    - $ref: objects.enums.pixels.value
+    # TODO: Add definitions for these values. (perhaps don't specify)
     - m
     - mm
     - cm
-    - $ref: objects.enums.pixels.value
     - n/a
 iEEGElectrodeGroups:
   name: iEEGElectrodeGroups

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -98,6 +98,7 @@ AnatomicalLandmarkCoordinateUnits:
   description: |
     Units of the coordinates of `"AnatomicalLandmarkCoordinateSystem"`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm
@@ -363,6 +364,7 @@ CASLType:
   description: |
     Describes if a separate coil is used for labeling.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - single-coil
     - double-coil
@@ -488,6 +490,7 @@ ContrastBolusIngredient:
     Active ingredient of agent.
     Corresponds to DICOM Tag 0018, 1048 `Contrast/Bolus Ingredient`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - IODINE
     - GADOLINIUM
@@ -534,6 +537,7 @@ DatasetType:
     The interpretation of the dataset.
     For backwards compatibility, the default value is `"raw"`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - raw
     - derivative
@@ -609,6 +613,7 @@ DetectorType:
     - type: string
       format: unit
     - type: string
+      # TODO: Add definitions for these values.
       enum:
         - mixed
 DeviceSerialNumber:
@@ -673,6 +678,7 @@ DigitizedHeadPointsCoordinateUnits:
   description: |
     Units of the coordinates of `"DigitizedHeadPointsCoordinateSystem"`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm
@@ -774,6 +780,7 @@ EEGCoordinateUnits:
   description: |
     Units of the coordinates of `EEGCoordinateSystem`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm
@@ -982,6 +989,7 @@ FiducialsCoordinateUnits:
     Units in which the coordinates that are  listed in the field
     `"FiducialsCoordinateSystem"` are represented.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm
@@ -1280,6 +1288,7 @@ HeadCoilCoordinateUnits:
   description: |
     Units of the coordinates of `HeadCoilCoordinateSystem`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm
@@ -1803,6 +1812,7 @@ MEGCoordinateUnits:
   description: |
     Units of the coordinates of `"MEGCoordinateSystem"`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm
@@ -2143,6 +2153,7 @@ NIRSCoordinateUnits:
   description: |
     Units of the coordinates of `NIRSCoordinateSystem`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm
@@ -2398,6 +2409,7 @@ PixelSizeUnits:
     Unit format of the specified `"PixelSize"`. MUST be one of: `"mm"` (millimeter), `"um"`
     (micrometer) or `"nm"` (nanometer).
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - mm
     - um
@@ -2714,6 +2726,7 @@ RotationOrder:
   description: |
     Specify the sequence in which the elemental 3D extrinsic rotations are applied around the three distinct axes.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - XYZ
     - XZY
@@ -2730,6 +2743,7 @@ RotationRule:
     clockwise around an axis when seen from the positive direction (left-hand rule) or
     counter-clockwise (right-hand rule). Must be one of: "left-hand", "right-hand".
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - left-hand
     - right-hand
@@ -2754,6 +2768,7 @@ SampleEnvironment:
     Environment in which the sample was imaged. MUST be one of: `"in vivo"`, `"ex vivo"`
     or `"in vitro"`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - in vivo
     - ex vivo
@@ -3638,6 +3653,7 @@ iEEGCoordinateUnits:
     Units of the `*_electrodes.tsv`.
     MUST be `"pixels"` if `iEEGCoordinateSystem` is `Pixels`.
   type: string
+  # TODO: Add definitions for these values.
   enum:
     - m
     - mm

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -613,9 +613,8 @@ DetectorType:
     - type: string
       format: unit
     - type: string
-      # TODO: Add definitions for these values.
       enum:
-        - mixed
+        - $ref: objects.enums.mixed.value
 DeviceSerialNumber:
   name: DeviceSerialNumber
   display_name: Device Serial Number

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -98,7 +98,7 @@ AnatomicalLandmarkCoordinateUnits:
   description: |
     Units of the coordinates of `"AnatomicalLandmarkCoordinateSystem"`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
@@ -677,7 +677,7 @@ DigitizedHeadPointsCoordinateUnits:
   description: |
     Units of the coordinates of `"DigitizedHeadPointsCoordinateSystem"`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
@@ -779,7 +779,7 @@ EEGCoordinateUnits:
   description: |
     Units of the coordinates of `EEGCoordinateSystem`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
@@ -988,7 +988,7 @@ FiducialsCoordinateUnits:
     Units in which the coordinates that are  listed in the field
     `"FiducialsCoordinateSystem"` are represented.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
@@ -1287,7 +1287,7 @@ HeadCoilCoordinateUnits:
   description: |
     Units of the coordinates of `HeadCoilCoordinateSystem`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
@@ -1811,7 +1811,7 @@ MEGCoordinateUnits:
   description: |
     Units of the coordinates of `"MEGCoordinateSystem"`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
@@ -2152,7 +2152,7 @@ NIRSCoordinateUnits:
   description: |
     Units of the coordinates of `NIRSCoordinateSystem`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
@@ -2408,7 +2408,7 @@ PixelSizeUnits:
     Unit format of the specified `"PixelSize"`. MUST be one of: `"mm"` (millimeter), `"um"`
     (micrometer) or `"nm"` (nanometer).
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - mm
     - um
@@ -3652,12 +3652,12 @@ iEEGCoordinateUnits:
     Units of the `*_electrodes.tsv`.
     MUST be `"pixels"` if `iEEGCoordinateSystem` is `Pixels`.
   type: string
-  # TODO: Add definitions for these values.
+  # TODO: Add definitions for these values. (perhaps don't specify)
   enum:
     - m
     - mm
     - cm
-    - pixels
+    - $ref: objects.enums.pixels.value
     - n/a
 iEEGElectrodeGroups:
   name: iEEGElectrodeGroups

--- a/src/schema/rules/files/raw/meg.yaml
+++ b/src/schema/rules/files/raw/meg.yaml
@@ -39,9 +39,8 @@ calibration:
     session: optional
     acquisition:
       level: required
-      # TODO: Add definitions for these values.
       enum:
-        - calibration
+        - $ref: objects.enums.calibration.value
 
 crosstalk:
   suffixes:
@@ -55,9 +54,8 @@ crosstalk:
     session: optional
     acquisition:
       level: required
-      # TODO: Add definitions for these values.
       enum:
-        - crosstalk
+        - $ref: objects.enums.crosstalk.value
 
 headshape:
   suffixes:


### PR DESCRIPTION
- Addresses part of #1529 

specifically, I intend to add definitions for those "enums" that don't have one yet.

See @tsalo and my discussion here: https://github.com/bids-standard/bids-specification/pull/919#issuecomment-1602963705


- [x] add todo comments to enums that have not yet been worked on
- [x] address all todo comments that are deemed relevant
    - [x] answer this questions: should we add definitions for something like this?
    
```
  type: string
  # TODO: Add definitions for these values.
  enum:
    - left
    - l
    - L
    - LEFT
    - Left
```