### PR TITLE
[SCHEMATOOLS] Implement inheritance for all TSV/JSON files

### DIFF
--- a/tools/schemacode/bidsschematools/rules.py
+++ b/tools/schemacode/bidsschematools/rules.py
@@ -130,7 +130,7 @@ def _entity_rule(rule: Mapping, schema: bst.types.Namespace):
     }
 
 
-def _split_inheritance_rules(rule: Mapping) -> ty.List[Mapping]:
+def _split_inheritance_rules(rule: dict) -> ty.List[dict]:
     """Break composite rules into main and sidecar rules
 
     Implements the inheritance principle for file naming.
@@ -139,32 +139,28 @@ def _split_inheritance_rules(rule: Mapping) -> ty.List[Mapping]:
     rule_exts = set(rule["extensions"])
 
     main_exts = rule_exts - heritable_exts
-    # If a rule only has TSV or JSON files, entities can be
-    # made required
-    if not main_exts:
-        if ".tsv" in rule_exts:
-            main_exts = {".tsv"}
-        elif ".json" in rule_exts:
-            main_exts = {".json"}
-
     sidecar_exts = rule_exts - main_exts
     if not sidecar_exts:
         return [rule]
 
-    sidecar_dtypes = [""] + rule.get("datatypes", [])
-    sidecar_entities = {ent: "optional" for ent in rule["entities"]}
+    rules = []
 
-    main_rule = {**rule, **{"extensions": list(main_exts)}}
-    sidecar_rule = {
-        **rule,
-        **{
-            "extensions": list(sidecar_exts),
-            "datatypes": sidecar_dtypes,
-            "entities": sidecar_entities,
-        },
-    }
+    # Some rules only address metadata, such as events.tsv or coordsystem.json
+    if main_exts:
+        rules.append({**rule, **{"extensions": list(main_exts)}})
 
-    return [main_rule, sidecar_rule]
+    rules.append(
+        {
+            **rule,
+            **{
+                "extensions": list(sidecar_exts),
+                "datatypes": [""] + rule.get("datatypes", []),
+                "entities": {ent: "optional" for ent in rule["entities"]},
+            },
+        }
+    )
+
+    return rules
 
 
 def _sanitize_extension(ext: str) -> str:


### PR DESCRIPTION
The previous implementation assumed that, if a file rule only contained TSV or JSON files, then at least one of these was not inheritable. This seems to contradict the inheritance principle, unless the files cease to be "metadata" files, as well as fails to validate actual files in examples, such as `channels.tsv` and `events.tsv`.

If the rule needs to become more complex, the schema will need a way to indicate whether a rule addresses data or metadata files.