### PR TITLE
SCHEMA: Add file rule for phenotype tables

### DIFF
--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -751,6 +751,10 @@
       "type": "object",
       "properties": {
         "level": { "enum": ["optional", "recommended", "required"] },
+        "datatypes": {
+          "type": "array",
+          "items": { "pattern": "^[a-z]+$" }
+        },
         "stem": { "type": "string" },
         "extensions": { "type": "array", "items": { "type": "string" } }
       },

--- a/src/schema/rules/files/common/tables.yaml
+++ b/src/schema/rules/files/common/tables.yaml
@@ -30,3 +30,16 @@ sessions: # This file may only exist if session is present in the dataset.
     - .json
   entities:
     subject: required
+
+# Phenotype is a special case where there are no applicable entities, but a
+# parent directory is specified. This most closely matches datatype in the current
+# structure. We also require a stem that can match any value, as there are no
+# constraints on the filename except extension.
+phenotype:
+  level: optional
+  datatypes:
+    - phenotype
+  stem: '*'
+  extensions:
+    - .tsv
+    - .json

--- a/tools/schemacode/bidsschematools/conftest.py
+++ b/tools/schemacode/bidsschematools/conftest.py
@@ -25,6 +25,7 @@ BIDS_SELECTION = [
     "qmri_tb1tfl",  # fmap, _TB1TFL
     "qmri_vfa",  # derivatives
     "ds000248",  # .bidsignore
+    "fnirs_automaticity",  # phenotypic
 ]
 # Errors are described in the README of the respective datasets:
 # https://github.com/bids-standard/bids-error-examples

--- a/tools/schemacode/bidsschematools/data/tests/test_rules.py
+++ b/tools/schemacode/bidsschematools/data/tests/test_rules.py
@@ -87,6 +87,11 @@ def test_rule_objects(schema_obj):
 
                 # Build a list of items mentioned in rules, but not found in objects.
                 if use not in object_values:
+                    if (use, object_type) == ("phenotype", "datatypes"):
+                        # Special case: phenotype is a top-level directory
+                        # that acts like a datatype, but we don't want to
+                        # define it that way in the glossary, currently.
+                        continue
                     temp_path = path[:]
                     if is_list:
                         temp_path[-1] += f"[{i_use}]"

--- a/tools/schemacode/bidsschematools/rules.py
+++ b/tools/schemacode/bidsschematools/rules.py
@@ -4,6 +4,7 @@ This module is currently limited to constructing filename rules from
 ``schema.rules.files``.
 """
 
+import fnmatch
 import re
 import typing as ty
 from collections.abc import Mapping
@@ -170,11 +171,16 @@ def _sanitize_extension(ext: str) -> str:
 
 
 def _stem_rule(rule: bst.types.Namespace):
-    stem_regex = re.escape(rule.stem)
-    ext_match = "|".join(_sanitize_extension(ext) for ext in rule.extensions)
-    ext_regex = f"(?P<extension>{ext_match})"
+    # translate includes a trailing \Z (end of string) but we expect extensions
+    stem_regex = fnmatch.translate(rule.stem)[:-2]
 
-    return {"regex": stem_regex + ext_regex, "mandatory": rule.level == "required"}
+    dtypes = set(rule.get("datatypes", ()))
+    dir_regex = f"(?P<datatype>{'|'.join(dtypes)})/" if dtypes else ""
+
+    ext_match = "|".join(_sanitize_extension(ext) for ext in rule.extensions)
+    ext_regex = rf"(?P<extension>{ext_match})\Z"
+
+    return {"regex": dir_regex + stem_regex + ext_regex, "mandatory": rule.level == "required"}
 
 
 def _path_rule(rule: bst.types.Namespace):

--- a/tools/schemacode/bidsschematools/tests/test_rules.py
+++ b/tools/schemacode/bidsschematools/tests/test_rules.py
@@ -84,7 +84,7 @@ def test_split_inheritance_rules():
 def test_stem_rule():
     rule = Namespace.build({"stem": "README", "level": "required", "extensions": ["", ".md"]})
     assert rules._stem_rule(rule) == {
-        "regex": r"README(?P<extension>|\.md)",
+        "regex": r"(?s:README)(?P<extension>|\.md)\Z",
         "mandatory": True,
     }
 
@@ -92,7 +92,21 @@ def test_stem_rule():
         {"stem": "participants", "level": "optional", "extensions": [".tsv", ".json"]}
     )
     assert rules._stem_rule(rule) == {
-        "regex": r"participants(?P<extension>\.tsv|\.json)",
+        "regex": r"(?s:participants)(?P<extension>\.tsv|\.json)\Z",
+        "mandatory": False,
+    }
+
+    # Wildcard stem, with datatype
+    rule = Namespace.build(
+        {
+            "stem": "*",
+            "datatypes": ["phenotype"],
+            "level": "optional",
+            "extensions": [".tsv", ".json"],
+        }
+    )
+    assert rules._stem_rule(rule) == {
+        "regex": r"(?P<datatype>phenotype)/(?s:.*)(?P<extension>\.tsv|\.json)\Z",
         "mandatory": False,
     }
 

--- a/tools/schemacode/bidsschematools/tests/test_rules.py
+++ b/tools/schemacode/bidsschematools/tests/test_rules.py
@@ -21,7 +21,7 @@ def test_entity_rule(schema_obj):
             r"sub-(?P=subject)_"
             r"(?:ses-(?P=session)_)?"
             r"(?P<suffix>T1w)"
-            r"(?P<extension>\.nii)"
+            r"(?P<extension>\.nii)\Z"
         ),
         "mandatory": False,
     }
@@ -43,7 +43,7 @@ def test_entity_rule(schema_obj):
             r"(?:sub-(?P=subject)_)?"
             r"(?:ses-(?P=session)_)?"
             r"(?P<suffix>T1w)"
-            r"(?P<extension>\.json)"
+            r"(?P<extension>\.json)\Z"
         ),
         "mandatory": False,
     }
@@ -84,7 +84,7 @@ def test_split_inheritance_rules():
 def test_stem_rule():
     rule = Namespace.build({"stem": "README", "level": "required", "extensions": ["", ".md"]})
     assert rules._stem_rule(rule) == {
-        "regex": r"(?s:README)(?P<extension>|\.md)\Z",
+        "regex": r"(?P<stem>(?s:README))(?P<extension>|\.md)\Z",
         "mandatory": True,
     }
 
@@ -92,7 +92,7 @@ def test_stem_rule():
         {"stem": "participants", "level": "optional", "extensions": [".tsv", ".json"]}
     )
     assert rules._stem_rule(rule) == {
-        "regex": r"(?s:participants)(?P<extension>\.tsv|\.json)\Z",
+        "regex": r"(?P<stem>(?s:participants))(?P<extension>\.tsv|\.json)\Z",
         "mandatory": False,
     }
 
@@ -106,7 +106,7 @@ def test_stem_rule():
         }
     )
     assert rules._stem_rule(rule) == {
-        "regex": r"(?P<datatype>phenotype)/(?s:.*)(?P<extension>\.tsv|\.json)\Z",
+        "regex": r"(?P<datatype>phenotype)/(?P<stem>(?s:.*))(?P<extension>\.tsv|\.json)\Z",
         "mandatory": False,
     }
 
@@ -114,12 +114,12 @@ def test_stem_rule():
 def test_path_rule():
     rule = Namespace.build({"path": "dataset_description.json", "level": "required"})
     assert rules._path_rule(rule) == {
-        "regex": r"dataset_description\.json",
+        "regex": r"(?P<path>dataset_description\.json)(?:/.*)?\Z",
         "mandatory": True,
     }
 
     rule = Namespace.build({"path": "LICENSE", "level": "optional"})
-    assert rules._path_rule(rule) == {"regex": "LICENSE", "mandatory": False}
+    assert rules._path_rule(rule) == {"regex": r"(?P<path>LICENSE)(?:/.*)?\Z", "mandatory": False}
 
 
 def test_regexify_all():


### PR DESCRIPTION
This PR slightly amends how `stem` rules work, by making the stem a [glob](https://www.man7.org/linux/man-pages/man7/glob.7.html) pattern and allowing it to coexist with `datatype`. This hacks 'phenotype' into the `datatype` structure; in the absence of entities, it works correctly for now.

I don't know that this is a long-term solution, but it seems good enough for now with minimal changes required to the schematools or the JS schema validator.

This is intended to be compatible with, but not actually dependent on #1693.