### PR TITLE
BEP021: Electrophysiological Derivatives

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
           - BIDS Derivatives: derivatives/introduction.md
           - Common data types and metadata: derivatives/common-data-types.md
           - Imaging data types: derivatives/imaging.md
+          - Electrophysiology data types: derivatives/ephys.md
       - Longitudinal and multi-site studies: longitudinal-and-multi-site-studies.md
       - Glossary: glossary.md
       - BIDS Extension Proposals: extensions.md

--- a/src/derivatives/ephys.md
+++ b/src/derivatives/ephys.md
@@ -5,16 +5,16 @@ This includes minimally processed data, but excludes data that has undergone ext
 
 ## Minimally processed  electrophysiological data
 
-A minimally processed EEG, MEG or iEEG data can be stored as a derivative, using the same file formats as specified for raw EEG, MEG, or iEEG.
-Examples for this are MaxFiltered MEG data, or re-referenced and bandpass-filtered EEG data.
+A minimally processed EEG, MEG or iEEG data can be stored as a derivative using the same file formats as specified for raw EEG, MEG, or iEEG.
+Examples of this are MaxFiltered MEG data or re-referenced and bandpass-filtered EEG data.
 Certain file formats that are allowed in BIDS for raw data have limited representation to some extent,
-for example the EDF and BDF formats cannot be used to store epoched (or "segmented") data in a standardized way,
-whereas the BrainVision and FIF file formats can.
+for example, the EDF and BDF formats cannot be used to store epoched (or "segmented") data in a standardized way,
+whereas the EEGLAB .set, the BrainVision Core Data Format 1.0 and the FIF file formats can.
 These limitations should be taken into account when writing derivative data back to disk.
-The representation of the data MUST follow the general derivative conventions and the Common file level metadata fields,
+The representation of the data MUST follow the general derivative conventions and the Common file-level metadata fields,
 notably the use of the [`desc` entity](../appendices/entities.md#desc).
 
-If minimally processed data is the result from processing a BIDS dataset, then it MUST be marked as a derivative and the source data must be specified.
+If minimally processed data is the result of processing a BIDS dataset, then it MUST be marked as a derivative dataset in the dataset_description.json file, and the source data must be specified.
 The processing steps MUST be indicated in the [`desc` entity](../appendices/entities.md#desc),
 where the label is a description identifier that distinguishes it from the original raw data.
 
@@ -26,12 +26,12 @@ the [`desc` entity](../appendices/entities.md#desc) is not needed to distinguish
 
 The description of the processing in the derivative MUST be clarified in the [descriptions.tsv](common-data-types.md#descriptions-tsv) file,
 with at least two columns for desc_id and the actual description.
-Other columns MAY be added but are at this moment not standardized.
+Other columns MAY be added but are, at this moment, not standardized.
 The [descriptions.tsv](common-data-types.md#descriptions-tsv) file SHOULD include sufficient information to document the details of the data processing that resulted in the derivative.
 
 The `_eeg.json`, `_meg.json`, or `_ieeg.json` sidecar files MUST be replicated alongside the respective derivative `_eeg.<ext>`, `_meg.<ext>`, or `_ieeg.<ext>` data files,
 so that they can be processed as if it were a raw BIDS dataset.
-The json sidecar file must be compliant with those for raw data and SHOULD NOT include fields that are specific to the processing that was done on the data.
+The JSON sidecar file must be compliant with those for raw data and SHOULD NOT include fields that are specific to the processing that was done on the data.
 
 ## MaxFiltered MEG data
 

--- a/src/derivatives/ephys.md
+++ b/src/derivatives/ephys.md
@@ -40,4 +40,3 @@ to be done
 ## Other sections (to be done)
 
 to be done
-

--- a/src/derivatives/ephys.md
+++ b/src/derivatives/ephys.md
@@ -1,0 +1,43 @@
+# Electrophysiology data types
+
+This section pertains to human electrophysiological data, including EEG, MEG and iEEG, which characteristically have channels and time.
+This includes minimally processed data, but excludes data that has undergone extensive processing, such as source reconstruction.
+
+## Minimally processed  electrophysiological data
+
+A minimally processed EEG, MEG or iEEG data can be stored as a derivative, using the same file formats as specified for raw EEG, MEG, or iEEG.
+Examples for this are MaxFiltered MEG data, or re-referenced and bandpass-filtered EEG data.
+Certain file formats that are allowed in BIDS for raw data have limited representation to some extent,
+for example the EDF and BDF formats cannot be used to store epoched (or "segmented") data in a standardized way,
+whereas the BrainVision and FIF file formats can.
+These limitations should be taken into account when writing derivative data back to disk.
+The representation of the data MUST follow the general derivative conventions and the Common file level metadata fields,
+notably the use of the [`desc` entity](../appendices/entities.md#desc).
+
+If minimally processed data is the result from processing a BIDS dataset, then it MUST be marked as a derivative and the source data must be specified.
+The processing steps MUST be indicated in the [`desc` entity](../appendices/entities.md#desc),
+where the label is a description identifier that distinguishes it from the original raw data.
+
+If minimal processing was performed on the source data,
+but the raw data itself does not exist as a BIDS dataset,
+then the minimally processed data MAY be marked as a raw BIDS dataset.
+When represented as a raw BIDS dataset,
+the [`desc` entity](../appendices/entities.md#desc) is not needed to distinguish the data and MUST NOT be used.
+
+The description of the processing in the derivative MUST be clarified in the [descriptions.tsv](common-data-types.md#descriptions-tsv) file,
+with at least two columns for desc_id and the actual description.
+Other columns MAY be added but are at this moment not standardized.
+The [descriptions.tsv](common-data-types.md#descriptions-tsv) file SHOULD include sufficient information to document the details of the data processing that resulted in the derivative.
+
+The `_eeg.json`, `_meg.json`, or `_ieeg.json` sidecar files MUST be replicated alongside the respective derivative `_eeg.<ext>`, `_meg.<ext>`, or `_ieeg.<ext>` data files,
+so that they can be processed as if it were a raw BIDS dataset.
+The json sidecar file must be compliant with those for raw data and SHOULD NOT include fields that are specific to the processing that was done on the data.
+
+## MaxFiltered MEG data
+
+to be done
+
+## Other sections (to be done)
+
+to be done
+


### PR DESCRIPTION
This PR aims to integrate BEP021 (Electrophysiological Derivatives) into the BIDS specification.

It is a work in progress (a draft PR). As a group we decided in several meetings that we might profit from taking the agreed upon aspects of the [BEP in the Google Doc](https://docs.google.com/document/d/1PmcVs7vg7Th-cGC-UrX8rAhKUHIzOI-uIOh69_mvdlw/edit?usp=sharing) and formalizing them within this PR.

Please comment both in this thread, as well as with inline code reviews as to what you'd like to see changed / improved.

You are welcome to add changes directly via Pull Requests to this branch: https://github.com/bids-standard/bids-specification/tree/bep021

My personal goal is to keep adding to this PR over the next days/weeks so that all applicable points from the BEP Google Doc are incorporated here.

**To Do:**

- [ ] Carry over changes from the Google Doc
- [ ] Review internally with the BEP021 team for completeness
- [ ] Community review
- [ ] Merging into the specification

**General Links:**

- [Rendered preview](https://bids-specification.readthedocs.io/en/bep021/derivatives/ephys.html)
- [BEP repo](https://github.com/bids-standard/bep021)
- [BEP Google Doc](https://docs.google.com/document/d/1PmcVs7vg7Th-cGC-UrX8rAhKUHIzOI-uIOh69_mvdlw/edit?usp=sharing)

**Related PRs:**

- https://github.com/bids-standard/bids-specification/pull/1614
- https://github.com/bids-standard/bids-specification/pull/1537
- https://github.com/bids-standard/bids-specification/pull/1613

cc @christinerogers @CPernet @guiomar @robertoostenveld @arnodelorme @dorahermes 