### PR TITLE
ENH: Clarify the relation of motion.tsv columns to channels.tsv rows

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -430,7 +430,8 @@ Tabular data MUST be saved as tab delimited values (`.tsv`) files, that is, CSV
 files where commas are replaced by tabs. Tabs MUST be true tab characters and
 MUST NOT be a series of space characters. Each TSV file MUST start with a header
 line listing the names of all columns (with the exception of
-[physiological and other continuous recordings](modality-specific-files/physiological-and-other-continuous-recordings.md)).
+[physiological and other continuous recordings](modality-specific-files/physiological-and-other-continuous-recordings.md)
+as well as [motion recording data](modality-specific-files/motion.md)).
 It is RECOMMENDED that the column names in the header of the TSV file are
 written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case) with the
 first letter in lower case (for example, `variable_name`, not `Variable_name`).

--- a/src/modality-specific-files/motion.md
+++ b/src/modality-specific-files/motion.md
@@ -42,7 +42,10 @@ each of which is accompanied by `*_tracksys-<label>_motion.json` and `*_tracksys
 Between `tracksys-<label>` entity and `*_motion.tsv`, `*_motion.json`, or `*_channels.tsv` suffixes, optional [`acq-<label>`](../appendices/entities.md#acq) or [`run-<index>`](../appendices/entities.md#run) entity MAY be inserted.
 
 One column in the `*_tracksys-<label>_motion.tsv` file represents one data channel.
-The ordering of columns MUST match the order of rows in the `*_channels.tsv` file for unambiguous assignment.
+Motion files MUST NOT have a header row;
+the ordering of columns is given by the order of rows in the associated `*_channels.tsv` file.
+The number of columns in `_motion.tsv` files MUST equal the number of rows
+in the associated `_channels.tsv` file.
 All relevant metadata about a tracking systems is stored in accompanying sidecar `*_tracksys-<label>_motion.json` file.
 
 The source data from each tracking system in their original format, if different from `.tsv`,


### PR DESCRIPTION
The motion spec does not say whether there is a header column or not, only that the columns must match the rows of channels.tsv. From unofficial communications, I believe the intent is that motion.tsv files do not have column headers, and channels.tsv defines the column names.

This changes it to state explicitly that there are no column headers, and that the ordering is defined by the rows in channels.tsv.

cc @sjeung @JuliusWelzel 