### PR TITLE
[ENH] Add BEP032 (microelectrode electrophysiology) specification

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -42,6 +42,38 @@ age:
     for privacy purposes.
   type: number
   unit: year
+alpha_rotation:
+  name: alpha_rotation
+  display_name: Alpha rotation
+  description: |
+    Euler angle to match probe extension dimensions (width, height, depth) to global x, y, z coordinates.
+  unit:
+    degree
+associated_brain_region:
+  name: associated_brain_region
+  display_name: Associated brain region
+  description: |
+    A textual indication on the location of the probe, preferably species-independent terms as obtained e.g. from Uberon.
+  type: string
+associated_brain_region_id:
+  name: associated_uberon_brain_region_id
+  display_name: Associated brain region identifier
+  description: |
+    An identifier of the associated brain region based on the Uberon ontology for  anatomical structures in animals. E.g. “UBERON:0010415”
+  type: number
+associated_brain_region_quality_type:
+  name: associated_brain_region_quality_type
+  display_name: Associated brain region quality type
+  description: |
+     The method used to identify the associated brain region (estimated|proof) depending on anatomical pictures proofing the location or indirect estimation of the location.
+  type: string
+beta_rotation:
+  name: beta_rotation
+  display_name: Beta rotation
+  description: |
+    Euler angle to match probe extension dimensions (width, height, depth) to global x, y, z coordinates.
+  unit:
+    degree
 cardiac:
   name: cardiac
   display_name: Cardiac measurement
@@ -84,6 +116,19 @@ component:
     - $ref: objects.enums.quat_z.value
     - $ref: objects.enums.quat_w.value
     - n/a
+contact_count:
+  name: contact_count
+  display_name: Contact count
+  description: |
+    Number of miscellaneous analog contacts for auxiliary signals.
+  type: number
+depth__probes:
+  name: height
+  display_name: Height
+  description: |
+    Physical height of the probe.
+  type: number
+  unit: mm
 detector__channels:
   name: detector
   display_name: Detector Name
@@ -115,6 +160,12 @@ description:
   display_name: Description
   description: |
     Brief free-text description of the channel, or other information of interest.
+  type: string
+device_serial_number:
+  name: device_serial_number
+  display_name: Device serial number
+  description: |
+    The serial number of the probe (provided by the manufacturer).
   type: string
 description__optode:
   name: description
@@ -151,6 +202,13 @@ filename:
     Relative paths to files.
   type: string
   format: participant_relative
+gamma_rotation:
+  name: gamma_rotation
+  display_name: Gamma rotation
+  description: |
+    Euler angle to match probe extension dimensions (width, height, depth) to global x, y, z coordinates.
+  unit:
+    degree
 group__channel:
   name: group
   display_name: Channel group
@@ -192,6 +250,13 @@ handedness:
     - AMBIDEXTROUS
     - Ambidextrous
     - n/a
+height__probes:
+  name: height
+  display_name: Height
+  description: |
+    Physical height of the probe.
+  type: number
+  unit: mm
 hemisphere:
   name: hemisphere
   display_name: Electrode hemisphere
@@ -266,6 +331,12 @@ material:
   display_name: Electrode material
   description: |
     Material of the electrode (for example, `Tin`, `Ag/AgCl`, `Gold`).
+  type: string
+material__probes:
+  name: material__probes
+  display_name: Material
+  description: |
+    A textual description of the base material of the probe.
   type: string
 metabolite_parent_fraction:
   name: metabolite_parent_fraction
@@ -391,6 +462,12 @@ reference__ieeg:
     - type: string
       enum:
         - n/a
+reference_atlas:
+  name: reference_atlas
+  display_name: Reference atlas
+  description: |
+    Name of reference atlas used for associated brain region identification, preferrably an ebrains supported atlas.
+  type: string
 reference_frame:
   name: reference_frame
   display_name: Reference frame
@@ -703,6 +780,12 @@ type__optodes:
     - $ref: objects.enums.source.value
     - $ref: objects.enums.detector.value
     - n/a
+type__probes:
+  name: type
+  display_name: Type
+  description: |
+    The type of the probe.
+  type: string
 units:
   name: units
   display_name: Units
@@ -785,6 +868,13 @@ whole_blood_radioactivity:
     Radioactivity in whole blood samples,
     in unit of radioactivity measurements in whole blood samples (for example, `kBq/mL`).
   type: number
+width__probes:
+  name: width
+  display_name: Width
+  description: |
+    Physical width of the probe.
+  type: number
+  unit: mm
 x:
   name: x
   display_name: X position
@@ -855,6 +945,16 @@ template_y:
   display_name: Y template position
   description: |
     Assumed or ideal position along the y axis.
+  anyOf:
+    - type: number
+    - type: string
+      enum:
+        - n/a
+template_z:
+  name: template_z
+  display_name: Z template position
+  description: |
+    Assumed or ideal position along the z axis.
   anyOf:
     - type: number
     - type: string

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -331,12 +331,12 @@ split:
   display_name: Split
   description: |
     In the case of long data recordings that exceed a file size of 2Gb,
-    `.fif` files are conventionally split into multiple parts.
-    Each of these files has an internal pointer to the next file.
+    `.fif`, `.nwb`, `.nix` files are conventionally split into multiple parts.
+    Each of the `.fif` files has an internal pointer to the next file.
     This is important when renaming these split recordings to the BIDS convention.
 
     Instead of a simple renaming, files should be read in and saved under their
-    new names with dedicated tools like [MNE-Python](https://mne.tools/),
+    new names with dedicated tools like [MNE-Python](https://mne.tools/) for `.fif`,
     which will ensure that not only the filenames, but also the internal file pointers, will be updated.
 
     It is RECOMMENDED that `.fif` files with multiple parts use the `split-<index>` entity to indicate each part.

--- a/src/schema/objects/extensions.yaml
+++ b/src/schema/objects/extensions.yaml
@@ -189,6 +189,11 @@ niigz:
   display_name: Compressed NIfTI
   description: |
     A compressed Neuroimaging Informatics Technology Initiative (NIfTI) data file.
+nix:
+  value: .nix
+  display_name: Neuroscience Information Exchange Format
+  description: |
+    A [Neuroscience Information Exchange](https://nixio.readthedocs.io) file.
 nwb:
   value: .nwb
   display_name: Neurodata Without Borders Format

--- a/src/schema/objects/modalities.yaml
+++ b/src/schema/objects/modalities.yaml
@@ -35,3 +35,6 @@ motion:
 nirs:
   display_name: Near-Infrared Spectroscopy
   description: Data acquired with NIRS.
+ephys:
+  display_name: Electrophysiology
+  description: Data acquired using microelectrodes.

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -571,6 +571,11 @@ electrodes:
   display_name: Electrodes
   description: |
     File that gives the location of (i)EEG electrodes.
+ephys:
+  value: ephys
+  display_name: Electrophysiology
+  description: |
+    Extra- or intracellular microelectrode recording data.
 epi:
   value: epi
   display_name: EPI
@@ -727,6 +732,11 @@ physio:
   display_name: Physiological recording
   description: |
     Physiological recordings such as cardiac and respiratory signals.
+probe:
+  value: probe
+  display_name: A recording probe
+  description: |
+    A probe with one or more recording contacts.
 probseg:
   value: probseg
   display_name: Probabilistic Segmentation

--- a/src/schema/rules/files/raw/channels.yaml
+++ b/src/schema/rules/files/raw/channels.yaml
@@ -16,6 +16,16 @@ channels:
     acquisition: optional
     run: optional
 
+# ephys has one removed
+# TODO: see if to be added for consistency etc.
+channels__ephys:
+  $ref: rules.files.raw.channels.channels
+  datatypes:
+    - meg
+  entities:
+    $ref: rules.files.raw.channels.channels.entities
+    acquisition:
+
 # MEG has an additional entity available
 channels__meg:
   $ref: rules.files.raw.channels.channels

--- a/src/schema/rules/files/raw/channels.yaml
+++ b/src/schema/rules/files/raw/channels.yaml
@@ -16,15 +16,14 @@ channels:
     acquisition: optional
     run: optional
 
-# ephys has one removed
-# TODO: see if to be added for consistency etc.
+# ephys has an additional 'sample' entity
 channels__ephys:
   $ref: rules.files.raw.channels.channels
   datatypes:
-    - meg
+    - ephys
   entities:
     $ref: rules.files.raw.channels.channels.entities
-    acquisition:
+    sample: optional
 
 # MEG has an additional entity available
 channels__meg:
@@ -65,6 +64,17 @@ coordsystem__eeg:
     - ieeg
   entities:
     $ref: rules.files.raw.channels.coordsystem.entities
+    space: optional
+
+# ephys has sample AND space entities
+coordsystem__ephys:
+  $ref: rules.files.raw.channels.coordsystem
+  datatypes:
+    - ephys
+    - iephys
+  entities:
+    $ref: rules.files.raw.channels.coordsystem.entities
+    sample: optional
     space: optional
 
 electrodes:

--- a/src/schema/rules/files/raw/ephys.yaml
+++ b/src/schema/rules/files/raw/ephys.yaml
@@ -14,5 +14,6 @@ ephys:
     session: optional
     sample: optional
     task: optional
+    acquisition: optional
     run: optional
     split: optional

--- a/src/schema/rules/files/raw/ephys.yaml
+++ b/src/schema/rules/files/raw/ephys.yaml
@@ -1,0 +1,18 @@
+---
+ephys:
+  suffixes:
+    - ephys
+  extensions:
+    - .nwb
+    # possible future: serialization in .zarr format to accompany .ome.zarr
+    # - .nwb.zarr
+    - .nix
+  datatypes:
+    - ephys
+  entities:
+    subject: required
+    session: optional
+    sample: optional
+    task: optional
+    run: optional
+    split: optional


### PR DESCRIPTION
Replaces https://github.com/bids-standard/bids-specification/pull/1352 submitted from a fork outside of bids-specification.

Add specification for microelectrode electrohpysiology datasets based on the [BEP032 proposal](https://bids.neuroimaging.io/bep032)

- To use this WiP schema on sample datasets, see https://deno.land/x/bids_validator@v1.13.2-dev.0#modifying-and-building-a-new-schema on how to use "stock" `bids-validator` with a custom schema. (attn @TheChymera)


ToDos
- [ ] Please ensure your name is credited on our [Contributors appendix](https://github.com/bids-standard/bids-specification/blob/master/src/appendices/contributors.md).
  To add your name, please edit our [Contributors wiki](https://github.com/bids-standard/bids-specification/wiki/Contributors) and add your name with the type of contribution.
  For assistance, please tag @bids-standard/maintainers.
- [ ] After opening the PR, our continuous integration services will automatically check your contribution  for formatting errors and render a preview of the BIDS specification with your changes.
  To see the checks and preview, scroll down and click on the `show all checks` link.
  From the list, select the `Details` link of the `ci/circleci: build_docs artifact` check to see the preview of the BIDS specification.
- [ ] Add instructions here on how to run new `bids-validator` using schema in this PR
- [ ] Populate schema with specifications from the google doc ...
   - [ ] ... 
- [ ] Add CI action (likely github) to run `bids-validator` on sample datasets and this modified schema (@yarikoptic)

Issues this PR would likely to address
- Fixes #1375

Issues to see being addressed while working on this BEP (likely to move above) or not (moved below):
- #1634
- #1481

Other issues which relate but not in scope here and provided for reference/backreference
- #1669
- #1133
- #1165
- #197 
- https://github.com/bids-standard/bids-2-devel/issues/54