### PR TITLE
[FIX] Missing word in `genetic-descriptor.md`

### DIFF
--- a/src/modality-specific-files/genetic-descriptor.md
+++ b/src/modality-specific-files/genetic-descriptor.md
@@ -1,6 +1,6 @@
 # Genetic Descriptor
 
-Support genetic descriptors was developed as a
+Support for genetic descriptors was developed as a
 [BIDS Extension Proposal](../extensions.md#bids-extension-proposals).
 Please see [Citing BIDS](../introduction.md#citing-bids)
 on how to appropriately credit this extension when referring to it in the


### PR DESCRIPTION
Add a missing word to the first line of `genetic-descriptor.md`.