### PR TITLE
[FIX] Typo in reference_frame description (SpatialAxis -> SpatialAxes)

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -397,7 +397,7 @@ reference_frame:
   description: |
     Specification of a reference frame in which the motion data are to be interpreted.
     The description of the levels in `*_channels.json` SHOULD use `RotationRule`,
-    `RotationOrder`, and `SpatialAxis`, and MAY use `Description` for the specification.
+    `RotationOrder`, and `SpatialAxes`, and MAY use `Description` for the specification.
   anyOf:
     - type: string
     - type: string


### PR DESCRIPTION
Should be plural
```
❯ git grep SpatialAxes
src/modality-specific-files/motion.md:| SpatialAxes   | RECOMMENDED                                            | [string][] | The coordinate system in which the motion data are to be interpreted. A sequence of characters from the set `{'A', 'P', 'L', 'R', 'S', 'I', '_'}` indicating the direction of each axis. For example `"ARS"` indicates positive values in the X, Y, Z axes are respectively anterior, right, and superior of the origin, while `"PLI"` indicates positive values are posterior, left, and inferior of the origin. The `"_"` character may be used for unused axes. |
src/modality-specific-files/motion.md:        "SpatialAxes": "ALS",
src/schema/objects/columns.yaml:    `RotationOrder`, and `SpatialAxes`, and MAY use `Description` for the specification.
src/schema/objects/metadata.yaml:SpatialAxes:
src/schema/objects/metadata.yaml:  name: SpatialAxes
```