### PR TITLE
FIX: Re-add run entity to electrodes.tsv

### DIFF
--- a/src/modality-specific-files/electroencephalography.md
+++ b/src/modality-specific-files/electroencephalography.md
@@ -310,6 +310,12 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_columns_table("eeg.EEGElectrodes") }}
 
+`*_electrodes.tsv` files SHOULD NOT be duplicated for each data file,
+for example, during multiple runs of a task.
+The [inheritance principle](../common-principles.md#the-inheritance-principle) MUST
+be used to find the appropriate electrode positions for a given data file.
+If electrodes are repositioned, it is RECOMMENDED to use multiple sessions to indicate this.
+
 ### Example `*_electrodes.tsv`
 
 See also the corresponding [`electrodes.tsv` example](#example-channelstsv).

--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -351,6 +351,12 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_columns_table("ieeg.iEEGElectrodes") }}
 
+`*_electrodes.tsv` files SHOULD NOT be duplicated for each data file,
+for example, during multiple runs of a task.
+The [inheritance principle](../common-principles.md#the-inheritance-principle) MUST
+be used to find the appropriate electrode positions for a given data file.
+If electrodes are repositioned, it is RECOMMENDED to use multiple sessions to indicate this.
+
 ### Example `*_electrodes.tsv`
 
 ```Text

--- a/src/schema/rules/checks/electrodes.yaml
+++ b/src/schema/rules/checks/electrodes.yaml
@@ -1,0 +1,15 @@
+---
+ElectrodeSpecificity:
+  issue:
+    code: EXCESSIVE_ELECTRODE_SPECIFICITY
+    message: |
+      Run or acquisition entities detected in electrodes.tsv.
+      Electrode definitions should generally not vary within a session.
+      Consider creating a new session each time electrodes are reconfigured.
+    level: warning
+  selectors:
+    - suffix == 'electrodes'
+    - extension == '.tsv'
+  checks:
+    - '!("run" in entities)'
+    - '!("acquisition" in entities)'

--- a/src/schema/rules/files/raw/channels.yaml
+++ b/src/schema/rules/files/raw/channels.yaml
@@ -70,6 +70,7 @@ electrodes:
     subject: required
     session: optional
     acquisition: optional
+    run: optional
     space: optional
 
 # MEG has an additional entity available


### PR DESCRIPTION
In BIDS 1.3, EEG had

```
sub-<label>[_ses-<label>][_acq-<label>][_run-<index>]_electrodes.tsv
```

and iEEG had 

```
sub-<label>[_ses-<label>][_space-<label>]_electrodes.tsv
```

As of 1.5, presumably due to schema stuff, they both became

```
sub-<label>[_ses-<label>][_acq-<label>][_space-<label>]_electrodes.tsv
```

So EEG lost `run` and gained `space`, and iEEG gained `acq`. Looking in OpenNeuro, there are iEEG electrodes files with `acq` and `run` and EEG with `space`. So we should just permit all three for both, as trying to bottle this genie isn't worth the pain.