### PR TITLE
[SCHEMA] Remove stale test comment -- test no longer fails!

### DIFF
--- a/tools/schemacode/bidsschematools/data/tests/test_rules.py
+++ b/tools/schemacode/bidsschematools/data/tests/test_rules.py
@@ -29,12 +29,8 @@ def _dict_key_lookup(_dict, key, path=[]):
 @pytest.mark.validate_schema
 def test_rule_objects(schema_obj):
     """Ensure that all objects referenced in the schema rules are defined in
-    its object portion.
+    their object portion.
 
-    This test currently fails because rules files reference object keys for some object types,
-    including entities, columns, and metadata fields,
-    but reference "name" or "value" elements of the object definitions for other object types,
-    including suffixes and extensions.
     In the case of datatypes, the key and "value" field are always the same.
 
     Some other object types, such as associated_data, common_principles, formats, modalities,


### PR DESCRIPTION
Test was written by @TheChymera awhile back.  I didn't check if it was failing at that point but it is all nice and green now:

```
❯ python -m pytest -s -v bidsschematools/data/tests/test_rules.py::test_rule_objects
======================================== test session starts ========================================
platform linux -- Python 3.11.8, pytest-8.1.1, pluggy-1.4.0 -- /home/yoh/proj/bids/bids-specification/tools/schemacode/venvs/dev3/bin/python
cachedir: .pytest_cache
rootdir: /home/yoh/proj/bids/bids-specification/tools/schemacode
configfile: pyproject.toml
plugins: cov-4.1.0
collected 1 item                                                                                    

bidsschematools/data/tests/test_rules.py::test_rule_objects PASSED
```

on master (does fail on #1705)