### PR TITLE
[FIX] Add `rawdata` to glossary

### DIFF
--- a/src/schema/objects/files.yaml
+++ b/src/schema/objects/files.yaml
@@ -115,7 +115,9 @@ rawdata:
   display_name: Raw data
   file_type: directory
   description: |
-    A directory where to store raw (unprocessed or minimally processed due to file format conversion) data that have been curated into BIDS from a non-BIDS source.
+    A directory where to store raw (unprocessed or minimally processed due to 
+    file format conversion) data that have been curated into BIDS from a 
+    non-BIDS source.
     See the [relevant section](SPEC_ROOT/common-principles.md#source-vs-raw-vs-derived-data)
     for more information.
 sourcedata:

--- a/src/schema/objects/files.yaml
+++ b/src/schema/objects/files.yaml
@@ -111,6 +111,13 @@ phenotype:
     individual files separate from `participants.tsv`.
     See the [relevant section](SPEC_ROOT/modality-agnostic-files.md#phenotypic-and-assessment-data)
     for more information.
+rawdata:
+  display_name: Raw data
+  file_type: directory
+  description: |
+    A directory where to store raw (unprocessed or minimally processed due to file format conversion) data that have been curated into BIDS from a non-BIDS source.
+    See the [relevant section](SPEC_ROOT/common-principles.md#source-vs-raw-vs-derived-data)
+    for more information.
 sourcedata:
   display_name: Source data
   file_type: directory

--- a/src/schema/objects/files.yaml
+++ b/src/schema/objects/files.yaml
@@ -115,8 +115,8 @@ rawdata:
   display_name: Raw data
   file_type: directory
   description: |
-    A directory where to store raw (unprocessed or minimally processed due to 
-    file format conversion) data that have been curated into BIDS from a 
+    A directory where to store raw (unprocessed or minimally processed due to
+    file format conversion) data that have been curated into BIDS from a
     non-BIDS source.
     See the [relevant section](SPEC_ROOT/common-principles.md#source-vs-raw-vs-derived-data)
     for more information.


### PR DESCRIPTION
## Changes

- [x] Add the `rawdata` description to the glossary by combining text from other parts of the BIDS specification.