### PR TITLE
SCHEMA: Allow surrounding whitespace in integers

### DIFF
--- a/src/schema/objects/formats.yaml
+++ b/src/schema/objects/formats.yaml
@@ -22,12 +22,12 @@ integer:
   display_name: Integer
   description: |
     An integer which may be positive or negative.
-  pattern: '[+-]?\d+'
+  pattern: ' *[+-]?\d+ *'
 number:
   display_name: Number
   description: |
     A number which may be an integer or float, positive or negative.
-  pattern: '[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?'
+  pattern: ' *[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)? *'
 string:
   display_name: String
   description: |


### PR DESCRIPTION
Discovered thanks to @ericearl's magical database. Some people generated TSVs that space-pad their numerical columns. Actual tools don't have a problem interpreting these numbers (pandas, deno, Python), just our regular expressions that we use to validate the columns as strings.