### PR TITLE
SCHEMA: Update existence checks to consider empty lists

### DIFF
--- a/src/schema/rules/checks/references.yaml
+++ b/src/schema/rules/checks/references.yaml
@@ -1,39 +1,65 @@
 ---
-SubjectRelativeIntendedFor:
+SubjectRelativeIntendedForString:
   selectors:
     - datatype != "ieeg"
-    - type(sidecar.IntendedFor) != "null"
-    - length(sidecar.IntendedFor) > 0
+    - type(sidecar.IntendedFor) == "string"
   checks:
-    - exists(sidecar.IntendedFor, "bids-uri") || exists(sidecar.IntendedFor, "subject")
+    - exists(sidecar.IntendedFor, "bids-uri") + exists(sidecar.IntendedFor, "subject") == 1
 
-DatasetRelativeIntendedFor:
+SubjectRelativeIntendedForArray:
+  selectors:
+    - datatype != "ieeg"
+    - type(sidecar.IntendedFor) == "array"
+  checks:
+    - exists(sidecar.IntendedFor, "bids-uri") + exists(sidecar.IntendedFor, "subject") == length(sidecar.IntendedFor)
+
+DatasetRelativeIntendedForString:
   selectors:
     - datatype == "ieeg"
-    - type(sidecar.IntendedFor) != "null"
-    - length(sidecar.IntendedFor) > 0
+    - type(sidecar.IntendedFor) == "string"
   checks:
-    - exists(sidecar.IntendedFor, "bids-uri") || exists(sidecar.IntendedFor, "dataset")
+    - exists(sidecar.IntendedFor, "bids-uri") + exists(sidecar.IntendedFor, "dataset") == 1
 
-AssociatedEmptyRoom:
+DatasetRelativeIntendedForArray:
   selectors:
-    - suffix == "meg"
-    - type(sidecar.AssociatedEmptyRoom) != "null"
-    - length(sidecar.AssociatedEmptyRoom) > 0
+    - datatype == "ieeg"
+    - type(sidecar.IntendedFor) == "array"
   checks:
-    - exists(sidecar.AssociatedEmptyRoom, "bids-uri") || exists(sidecar.AssociatedEmptyRoom, "dataset")
+    - exists(sidecar.IntendedFor, "bids-uri") + exists(sidecar.IntendedFor, "dataset") == length(sidecar.IntendedFor)
+
+AssociatedEmptyRoomString:
+  selectors:
+    - datatype == "meg"
+    - type(sidecar.AssociatedEmptyRoom) == "string"
+  checks:
+    - exists(sidecar.AssociatedEmptyRoom, "bids-uri") + exists(sidecar.AssociatedEmptyRoom, "dataset") == 1
+
+AssociatedEmptyRoomArray:
+  selectors:
+    - datatype == "meg"
+    - type(sidecar.AssociatedEmptyRoom) == "array"
+  checks:
+    - |
+      exists(sidecar.AssociatedEmptyRoom, "bids-uri") + exists(sidecar.AssociatedEmptyRoom, "dataset")
+      == length(sidecar.AssociatedEmptyRoom)
 
 Sources:
   selectors:
     - dataset.dataset_description.DatasetType == "derivatives"
     - type(sidecar.Sources) != "null"
-    - length(sidecar.Sources) > 0
   checks:
-    - exists(sidecar.Sources, "bids-uri") || exists(sidecar.Sources, "dataset")
+    - exists(sidecar.Sources, "bids-uri") + exists(sidecar.Sources, "dataset") == length(sidecar.Sources)
 
-SpatialReferences:
+SpatialReferencesString:
   selectors:
     - dataset.dataset_description.DatasetType == "derivatives"
-    - type(sidecar.SpatialReference.URI) != "null"
+    - type(sidecar.SpatialReference.URI) == "string"
   checks:
-    - exists(sidecar.SpatialReference.URI, "bids-uri") || exists(sidecar.SpatialReference.URI, "dataset")
+    - exists(sidecar.SpatialReference.URI, "bids-uri") + exists(sidecar.SpatialReference.URI, "dataset") == 1
+
+SpatialReferencesArray:
+  selectors:
+    - dataset.dataset_description.DatasetType == "derivatives"
+    - type(sidecar.SpatialReference.URI) == "array"
+  checks:
+    - exists(sidecar.SpatialReference.URI, "bids-uri") + exists(sidecar.SpatialReference.URI, "dataset") == length(sidecar.SpatialReference.URI)

--- a/src/schema/rules/checks/references.yaml
+++ b/src/schema/rules/checks/references.yaml
@@ -50,16 +50,15 @@ Sources:
   checks:
     - exists(sidecar.Sources, "bids-uri") + exists(sidecar.Sources, "dataset") == length(sidecar.Sources)
 
-SpatialReferencesString:
-  selectors:
-    - dataset.dataset_description.DatasetType == "derivatives"
-    - type(sidecar.SpatialReference.URI) == "string"
-  checks:
-    - exists(sidecar.SpatialReference.URI, "bids-uri") + exists(sidecar.SpatialReference.URI, "dataset") == 1
-
-SpatialReferencesArray:
-  selectors:
-    - dataset.dataset_description.DatasetType == "derivatives"
-    - type(sidecar.SpatialReference.URI) == "array"
-  checks:
-    - exists(sidecar.SpatialReference.URI, "bids-uri") + exists(sidecar.SpatialReference.URI, "dataset") == length(sidecar.SpatialReference.URI)
+## Verifying the existence of SpatialReferences is out-of-scope for schema validation
+## The ability to use any URI leaves this field too open-ended for effective validation, and the
+## object of key/URI pairs is worse.
+##
+## 2024.04.18 CJM & RWB
+#
+# SpatialReferencesString:
+#   selectors:
+#     - dataset.dataset_description.DatasetType == "derivatives"
+#     - type(sidecar.SpatialReference) == "string"
+#   checks:
+#     - exists(sidecar.SpatialReference, "bids-uri") + exists(sidecar.SpatialReference, "dataset") == 1

--- a/src/schema/rules/checks/references.yaml
+++ b/src/schema/rules/checks/references.yaml
@@ -3,6 +3,7 @@ SubjectRelativeIntendedFor:
   selectors:
     - datatype != "ieeg"
     - type(sidecar.IntendedFor) != "null"
+    - length(sidecar.IntendedFor) > 0
   checks:
     - exists(sidecar.IntendedFor, "bids-uri") || exists(sidecar.IntendedFor, "subject")
 
@@ -10,6 +11,7 @@ DatasetRelativeIntendedFor:
   selectors:
     - datatype == "ieeg"
     - type(sidecar.IntendedFor) != "null"
+    - length(sidecar.IntendedFor) > 0
   checks:
     - exists(sidecar.IntendedFor, "bids-uri") || exists(sidecar.IntendedFor, "dataset")
 
@@ -17,21 +19,15 @@ AssociatedEmptyRoom:
   selectors:
     - suffix == "meg"
     - type(sidecar.AssociatedEmptyRoom) != "null"
+    - length(sidecar.AssociatedEmptyRoom) > 0
   checks:
     - exists(sidecar.AssociatedEmptyRoom, "bids-uri") || exists(sidecar.AssociatedEmptyRoom, "dataset")
-
-Stimuli:
-  selectors:
-    - suffix == "events"
-    - extension == ".tsv"
-    - type(columns.stim_file) != "null"
-  checks:
-    - exists(columns.stim_file, "stimuli")
 
 Sources:
   selectors:
     - dataset.dataset_description.DatasetType == "derivatives"
     - type(sidecar.Sources) != "null"
+    - length(sidecar.Sources) > 0
   checks:
     - exists(sidecar.Sources, "bids-uri") || exists(sidecar.Sources, "dataset")
 


### PR DESCRIPTION
Fixes two issues found in real datasets:

1) ~~`stim_file` columns with all `n/a`. This is already handled in a duplicated check:~~ Guessing this got rebased out before pushing.

2) `IntendedFor` fields with an empty array (`[]`) as a value. Other reference checks suffer the same potential bug, so fixed at the same time.