### PR TITLE
ENH: Add compressed TSV files to the common principles

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -434,9 +434,13 @@ Tabular data MUST be saved as plain-text, tab-delimited values (TSV) files
 (with [extension `.tsv`](glossary.md#tsv-extensions)),
 that is, CSV files where commas are replaced by tab characters.
 Tabs MUST be true tab characters and MUST NOT be a series of space characters.
-Tabular data containing large numbers of rows MAY be saved as
-[compressed tabular files (with extension `.tsv.gz`)](#compressed-tabular-files)
-as prescribed below.
+Tabular data such as continuous physiology recordings typically containing
+large numbers of rows MAY be saved as
+[compressed tabular files (with extension `.tsv.gz`)](#compressed-tabular-files),
+which are introduced below.
+Plain-text TSV and compressed TSV are not interchangeable, that is, each section
+of the specification prescribes which one SHOULD be used for the data type at
+hand.
 Each TSV file MUST start with a header line listing the names of all columns
 with two exceptions:
 
@@ -558,8 +562,9 @@ like in the example below.
 
 ### Compressed tabular files
 
-Large tabular information such as physiological recordings MAY be stored with
-[compressed tab-delineated (TSVGZ) files](glossary.md#tsvgz-extensions).
+Large tabular information, such as physiological recordings, SHOULD be stored with
+[compressed tab-delineated (TSVGZ) files](glossary.md#tsvgz-extensions) when
+so established by the specifications.
 Rules for formatting plain-text tabular files apply to TSVGZ files with three exceptions:
 
 1.  The contents of TSVGZ files MUST be compressed with

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -463,8 +463,8 @@ TSV files MUST be in UTF-8 encoding.
 Example:
 
 ```Text
-onset	duration	response_time	correct	stop_trial	go_trial
-200     200         0               n/a     n/a         n/a
+onset   duration    response_time   trial_type        trial_extra
+200     20.0        127.34e-1       ⌂ (UTF-8 char)    n/a
 ```
 
 !!! warning "The TSV examples in this document (like the one above this note) are occasionally formatted using space characters instead of tabs to improve human readability."

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -430,16 +430,22 @@ NIfTI header.
 
 ### Tabular files
 
-Tabular data MUST be saved as plain-text, tab-delimited values (`.tsv`) files,
+Tabular data MUST be saved as plain-text, tab-delimited values (TSV) files
+(with [extension `.tsv`](glossary.md#tsv-extensions)),
 that is, CSV files where commas are replaced by tab characters.
 Tabs MUST be true tab characters and MUST NOT be a series of space characters.
 Tabular data containing large numbers of rows MAY be saved as
 [compressed tabular files (with extension `.tsv.gz`)](#compressed-tabular-files)
 as prescribed below.
 Each TSV file MUST start with a header line listing the names of all columns
-with the exception of [compressed tabular files](#compressed-tabular-files)
-where column names are defined in a sidecar metadata
-[JSON object](https://www.json.org/json-en.html) described below.
+with two exceptions:
+
+1.  [compressed tabular files](#compressed-tabular-files),
+    for which column names are defined in a sidecar metadata
+    [JSON object](https://www.json.org/json-en.html) described below; and
+1.  [motion recording data](modality-specific-files/motion.md),
+    which use plain-text TSV and columns are defined as described
+    in its corresponding of the specifications.
 
 It is RECOMMENDED that the column names in the header of the TSV file are
 written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case) with the

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -571,8 +571,7 @@ Rules for formatting plain-text tabular files apply to TSVGZ files with three ex
     [gzip](https://datatracker.ietf.org/doc/html/rfc1952).
 1.  Compressed tabular files MUST NOT contain a header in the first row
     indicating the column names.
-1.  TSVGZ files MUST be accompanied by a JSON file with the same name as their
-    corresponding tabular file but with a `.json` extension.
+1.  TSVGZ files MUST have an associated JSON file that defines the columns in the tabular file.
 
 
 !!! warning "Attention"

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -430,36 +430,41 @@ NIfTI header.
 
 ### Tabular files
 
-Tabular data MUST be saved as tab delimited values (`.tsv`) files, that is, CSV
-files where commas are replaced by tabs. Tabs MUST be true tab characters and
-MUST NOT be a series of space characters. Each TSV file MUST start with a header
-line listing the names of all columns (with the exception of
-[physiological and other continuous recordings](modality-specific-files/physiological-and-other-continuous-recordings.md)
-as well as [motion recording data](modality-specific-files/motion.md)).
+Tabular data MUST be saved as plain-text, tab-delimited values (`.tsv`) files,
+that is, CSV files where commas are replaced by tab characters.
+Tabs MUST be true tab characters and MUST NOT be a series of space characters.
+Tabular data containing large numbers of rows MAY be saved as
+[compressed tabular files (with extension `.tsv.gz`)](#compressed-tabular-files)
+as prescribed below.
+Each TSV file MUST start with a header line listing the names of all columns
+with the exception of [compressed tabular files](#compressed-tabular-files)
+where column names are defined in a sidecar metadata
+[JSON object](https://www.json.org/json-en.html) described below.
+
 It is RECOMMENDED that the column names in the header of the TSV file are
 written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case) with the
 first letter in lower case (for example, `variable_name`, not `Variable_name`).
-As for all other data in the TSV files, column names MUST be separated with tabs.
+Column names defined in the header MUST be separated with tabs as for the data contents.
 Furthermore, column names MUST NOT be blank (that is, an empty string) and MUST NOT
 be duplicated within a single TSV file.
-String values containing tabs MUST be escaped using double
-quotes. Missing and non-applicable values MUST be coded as `n/a`. Numerical
-values MUST employ the dot (`.`) as decimal separator and MAY be specified
+String values containing tabs MUST be escaped using double quotes.
+Missing and non-applicable values MUST be coded as `n/a`.
+Numerical values MUST employ the dot (`.`) as decimal separator and MAY be specified
 in scientific notation, using `e` or `E` to separate the significand from the
-exponent. TSV files MUST be in UTF-8 encoding.
+exponent.
+TSV files MUST be in UTF-8 encoding.
 
 Example:
 
 ```Text
 onset	duration	response_time	correct	stop_trial	go_trial
-200	200	0	n/a	n/a	n/a
+200     200         0               n/a     n/a         n/a
 ```
 
-**Note**: The TSV examples in this document (like the one above this note)
-are occasionally formatted using space characters instead of tabs to improve
-human readability.
-Directly copying and then pasting these examples from the specification
-for use in new BIDS datasets can lead to errors and is discouraged.
+!!! warning "The TSV examples in this document (like the one above this note) are occasionally formatted using space characters instead of tabs to improve human readability."
+
+    Directly copying and then pasting these examples from the specification
+    for use in new BIDS datasets can lead to errors and is discouraged.
 
 Tabular files MAY be optionally accompanied by a simple data dictionary
 in the form of a JSON [object](https://www.json.org/json-en.html)
@@ -536,7 +541,7 @@ like in the example below.
             "F": {
                 "Description": "Female",
                 "TermURL": "https://www.ncbi.nlm.nih.gov/mesh/68005260"
-            },
+            }
         }
     }
 }

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -571,9 +571,11 @@ Rules for formatting plain-text tabular files apply to TSVGZ files with three ex
     In contrast to plain-text TSV files, compressed tabular files files
     MUST NOT include a header line.
     Column names MUST be specified in the JSON file following the
-    [`Columns` metadata](glossary.md#columns-metadata) specifications.
-    As plain-text tabular data, column names MUST NOT be blank (that is, an empty string),
-    and MUST NOT be duplicated within a single JSON file describing a TSVGZ file.
+    [`Columns` metadata](glossary.md#columns-metadata) specifications
+    provided with plain-text tabular data.
+    Similarly, specific column metadata stored with dictionaries such as
+    the `sex` column in the example above MUST be specified following the
+    plain-text tabular metadata prescriptions.
 
     TSVGZ are header-less to improve compatibility with existing software
     (for example, FSL, or PNM), and to facilitate the support for other file formats

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -468,7 +468,7 @@ onset   duration    response_time   trial_type        trial_extra
 240     5.0         17.34e-1        visual            n/a
 ```
 
-!!! warning "TSV example formatting"
+!!! warning "Attention"
 
     The TSV examples in this document (like the one above this note) are occasionally
     formatted using space characters instead of tabs to improve human readability.
@@ -570,7 +570,7 @@ Rules for formatting plain-text tabular files apply to TSVGZ files with three ex
     corresponding tabular file but with a `.json` extension.
 
 
-!!! note "Column definitions in compressed tabular files"
+!!! warning "Attention"
 
     In contrast to plain-text TSV files,
     compressed tabular files files MUST NOT include a header line.

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -467,8 +467,10 @@ onset   duration    response_time   trial_type        trial_extra
 200     20.0        127.34e-1       ⌂ (UTF-8 char)    n/a
 ```
 
-!!! warning "The TSV examples in this document (like the one above this note) are occasionally formatted using space characters instead of tabs to improve human readability."
+!!! warning "TSV example formatting"
 
+    The TSV examples in this document (like the one above this note) are occasionally
+    formatted using space characters instead of tabs to improve human readability.
     Directly copying and then pasting these examples from the specification
     for use in new BIDS datasets can lead to errors and is discouraged.
 
@@ -566,16 +568,15 @@ Rules for formatting plain-text tabular files apply to TSVGZ files with three ex
 1.  TSVGZ files MUST be accompanied by a JSON file with the same name as their
     corresponding tabular file but with a `.json` extension.
 
-???+ warning "Columns of TSVGZ files MUST be defined in the corresponding JSON sidecar and the tabular content MUST NOT include a header line."
 
-    In contrast to plain-text TSV files, compressed tabular files files
-    MUST NOT include a header line.
-    Column names MUST be specified in the JSON file following the
-    [`Columns` metadata](glossary.md#columns-metadata) specifications
-    provided with plain-text tabular data.
-    Similarly, specific column metadata stored with dictionaries such as
-    the `sex` column in the example above MUST be specified following the
-    plain-text tabular metadata prescriptions.
+!!! note "Column definitions in compressed tabular files"
+
+    In contrast to plain-text TSV files,
+    compressed tabular files files MUST NOT include a header line.
+    Column names MUST be provided in the JSON file with the
+    [`Columns`](glossary.md#columns-metadata) field.
+    Each column MAY additionally be described with a column description,
+    as described in [Tabular files](#tabular-files).
 
     TSVGZ are header-less to improve compatibility with existing software
     (for example, FSL, or PNM), and to facilitate the support for other file formats

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -559,11 +559,11 @@ Large tabular information such as physiological recordings MAY be stored with
 [compressed tab-delineated (TSVGZ) files](glossary.md#tsvgz-extensions).
 Rules for formatting plain-text tabular files apply to TSVGZ files with three exceptions:
 
-1.  The contents of TSVGZ files SHOULD be compressed with
+1.  The contents of TSVGZ files MUST be compressed with
     [gzip](https://datatracker.ietf.org/doc/html/rfc1952).
-1.  Compressed tabular files SHOULD NOT contain a header in the first row
+1.  Compressed tabular files MUST NOT contain a header in the first row
     indicating the column names.
-1.  TSVGZ files SHOULD be accompanied by a JSON file with the same name as their
+1.  TSVGZ files MUST be accompanied by a JSON file with the same name as their
     corresponding tabular file but with a `.json` extension.
 
 ???+ warning "Columns of TSVGZ files MUST be defined in the corresponding JSON sidecar and the tabular content MUST NOT include a header line."

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -439,7 +439,7 @@ large numbers of rows MAY be saved as
 [compressed tabular files (with extension `.tsv.gz`)](#compressed-tabular-files),
 which are introduced below.
 Plain-text TSV and compressed TSV are not interchangeable, that is, each section
-of the specification prescribes which one SHOULD be used for the data type at
+of the specification prescribes which one MUST be used for the data type at
 hand.
 Each TSV file MUST start with a header line listing the names of all columns
 with two exceptions:
@@ -562,7 +562,7 @@ like in the example below.
 
 ### Compressed tabular files
 
-Large tabular information, such as physiological recordings, SHOULD be stored with
+Large tabular information, such as physiological recordings, MUST be stored with
 [compressed tab-delineated (TSVGZ) files](glossary.md#tsvgz-extensions) when
 so established by the specifications.
 Rules for formatting plain-text tabular files apply to TSVGZ files with three exceptions:

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -464,7 +464,8 @@ Example:
 
 ```Text
 onset   duration    response_time   trial_type        trial_extra
-200     20.0        127.34e-1       ⌂ (UTF-8 char)    n/a
+200     20.0        15.8            word              中国人
+240     5.0         17.34e-1        visual            n/a
 ```
 
 !!! warning "TSV example formatting"

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -563,7 +563,7 @@ like in the example below.
 ### Compressed tabular files
 
 Large tabular information, such as physiological recordings, MUST be stored with
-[compressed tab-delineated (TSVGZ) files](glossary.md#tsvgz-extensions) when
+[compressed tab-delineated (TSV.GZ) files](glossary.md#tsvgz-extensions) when
 so established by the specifications.
 Rules for formatting plain-text tabular files apply to TSVGZ files with three exceptions:
 

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -573,7 +573,6 @@ Rules for formatting plain-text tabular files apply to TSVGZ files with three ex
     indicating the column names.
 1.  TSVGZ files MUST have an associated JSON file that defines the columns in the tabular file.
 
-
 !!! warning "Attention"
 
     In contrast to plain-text TSV files,

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -432,7 +432,7 @@ NIfTI header.
 
 Tabular data MUST be saved as plain-text, tab-delimited values (TSV) files
 (with [extension `.tsv`](glossary.md#tsv-extensions)),
-that is, CSV files where commas are replaced by tab characters.
+that is, [CSV files](https://en.wikipedia.org/wiki/Comma-separated_values) where commas are replaced by tab characters.
 Tabs MUST be true tab characters and MUST NOT be a series of space characters.
 Tabular data such as continuous physiology recordings typically containing
 large numbers of rows MAY be saved as

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -542,6 +542,32 @@ like in the example below.
 }
 ```
 
+### Compressed tabular files
+
+Large tabular information such as physiological recordings MAY be stored with
+[compressed tab-delineated (TSVGZ) files](glossary.md#tsvgz-extensions).
+Rules for formatting plain-text tabular files apply to TSVGZ files with three exceptions:
+
+1.  The contents of TSVGZ files SHOULD be compressed with
+    [gzip](https://datatracker.ietf.org/doc/html/rfc1952).
+1.  Compressed tabular files SHOULD NOT contain a header in the first row
+    indicating the column names.
+1.  TSVGZ files SHOULD be accompanied by a JSON file with the same name as their
+    corresponding tabular file but with a `.json` extension.
+
+???+ warning "Columns of TSVGZ files MUST be defined in the corresponding JSON sidecar and the tabular content MUST NOT include a header line."
+
+    In contrast to plain-text TSV files, compressed tabular files files
+    MUST NOT include a header line.
+    Column names MUST be specified in the JSON file following the
+    [`Columns` metadata](glossary.md#columns-metadata) specifications.
+    As plain-text tabular data, column names MUST NOT be blank (that is, an empty string),
+    and MUST NOT be duplicated within a single JSON file describing a TSVGZ file.
+
+    TSVGZ are header-less to improve compatibility with existing software
+    (for example, FSL, or PNM), and to facilitate the support for other file formats
+    in the future.
+
 ### Key-value files (dictionaries)
 
 JavaScript Object Notation (JSON) files MUST be used for storing key-value

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -445,7 +445,7 @@ with two exceptions:
     [JSON object](https://www.json.org/json-en.html) described below; and
 1.  [motion recording data](modality-specific-files/motion.md),
     which use plain-text TSV and columns are defined as described
-    in its corresponding of the specifications.
+    in its corresponding section of the specifications.
 
 It is RECOMMENDED that the column names in the header of the TSV file are
 written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case) with the

--- a/src/modality-specific-files/physiological-and-other-continuous-recordings.md
+++ b/src/modality-specific-files/physiological-and-other-continuous-recordings.md
@@ -35,7 +35,7 @@ before the suffix.
 For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 `<matches>` would correspond to `sub-control01_task-nback_run-1`.
 
-!!! warning "TSVGZ files SHOULD NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))"
+!!! warning "TSVGZ files MUST NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))"
 
     As a result, when supplying a `*_<physio|stim>.tsv.gz` file, an accompanying
     `*_<physio|stim>.json` MUST be supplied as well.

--- a/src/modality-specific-files/physiological-and-other-continuous-recordings.md
+++ b/src/modality-specific-files/physiological-and-other-continuous-recordings.md
@@ -2,12 +2,9 @@
 
 Physiological recordings such as cardiac and respiratory signals and other
 continuous measures (such as parameters of a film or audio stimuli) MAY be
-specified using two files:
-
-1.  a [gzip](https://datatracker.ietf.org/doc/html/rfc1952)
-    compressed TSV file with data (without header line)
-
-1.  a JSON file for storing metadata fields (see below)
+specified using a [compressed tabular file](../common-principles.md#compressed-tabular-files)
+([TSVGZ file](../glossary.md#tsvgz-extensions)) and a corresponding
+JSON file for storing metadata fields (see below).
 
 !!! example "Example datasets"
 
@@ -38,8 +35,10 @@ before the suffix.
 For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 `<matches>` would correspond to `sub-control01_task-nback_run-1`.
 
-Note that when supplying a `*_<physio|stim>.tsv.gz` file, an accompanying
-`*_<physio|stim>.json` MUST be supplied as well.
+!!! warning "TSVGZ files SHOULD NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))"
+
+    As a result, when supplying a `*_<physio|stim>.tsv.gz` file, an accompanying
+    `*_<physio|stim>.json` MUST be supplied as well.
 
 The [`recording-<label>`](../appendices/entities.md#recording)
 entity MAY be used to distinguish between several recording files.
@@ -66,15 +65,6 @@ A guide for using macros can be found at
 Additional metadata may be included as in
 [any TSV file](../common-principles.md#tabular-files) to specify, for
 example, the units of the recorded time series.
-Please note that, in contrast to other TSV files in BIDS, the TSV files specified
-for physiological and other continuous recordings *do not* include a header
-line.
-Instead the name of columns are specified in the JSON file (see `Columns` field).
-This is to improve compatibility with existing software (for example, FSL, PNM)
-as well as to make support for other file formats possible in the future.
-As in any TSV file, column names MUST NOT be blank (that is, an empty string),
-and MUST NOT be duplicated within a single JSON file describing a headerless
-TSV file.
 
 Example `*_physio.tsv.gz`:
 

--- a/src/modality-specific-files/physiological-and-other-continuous-recordings.md
+++ b/src/modality-specific-files/physiological-and-other-continuous-recordings.md
@@ -38,7 +38,7 @@ For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 !!! note "TSVGZ headers are specified in metadata files."
 
     TSVGZ files MUST NOT include a header line,
-    as established by the [common-principles](../common-principles.md#compressed-tabular-files)).
+    as established by the [common-principles](../common-principles.md#compressed-tabular-files).
     As a result, when supplying a `*_<physio|stim>.tsv.gz` file, an accompanying
     `*_<physio|stim>.json` MUST be supplied as well.
 

--- a/src/modality-specific-files/physiological-and-other-continuous-recordings.md
+++ b/src/modality-specific-files/physiological-and-other-continuous-recordings.md
@@ -35,8 +35,10 @@ before the suffix.
 For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 `<matches>` would correspond to `sub-control01_task-nback_run-1`.
 
-!!! warning "TSVGZ files MUST NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))"
+!!! note "TSVGZ headers are specified in metadata files."
 
+    TSVGZ files MUST NOT include a header line,
+    as established by the [common-principles](../common-principles.md#compressed-tabular-files)).
     As a result, when supplying a `*_<physio|stim>.tsv.gz` file, an accompanying
     `*_<physio|stim>.json` MUST be supplied as well.
 


### PR DESCRIPTION
Their description is hedged within the physiological recordings so upcasting them to the common principles seems important.