### PR TITLE
FIX: Move ``_stim.<ext>`` specification within the Task Events module

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ nav:
           - Electroencephalography: modality-specific-files/electroencephalography.md
           - Intracranial Electroencephalography: modality-specific-files/intracranial-electroencephalography.md
           - Task events: modality-specific-files/task-events.md
-          - Physiological and other continuous recordings: modality-specific-files/physiological-and-other-continuous-recordings.md
+          - Physiological recordings: modality-specific-files/physiological-recordings.md
           - Behavioral experiments (with no neural recordings): modality-specific-files/behavioral-experiments.md
           - Genetic Descriptor: modality-specific-files/genetic-descriptor.md
           - Positron Emission Tomography: modality-specific-files/positron-emission-tomography.md
@@ -122,7 +122,7 @@ plugins:
         "04-modality-specific-files/03-electroencephalography.md": "modality-specific-files/electroencephalography.md"
         "04-modality-specific-files/04-intracranial-electroencephalography.md": "modality-specific-files/intracranial-electroencephalography.md"
         "04-modality-specific-files/05-task-events.md": "modality-specific-files/task-events.md"
-        "04-modality-specific-files/06-physiological-and-other-continuous-recordings.md": "modality-specific-files/physiological-and-other-continuous-recordings.md"
+        "04-modality-specific-files/06-physiological-and-other-continuous-recordings.md": "modality-specific-files/physiological-recordings.md"
         "04-modality-specific-files/07-behavioral-experiments.md": "modality-specific-files/behavioral-experiments.md"
         "04-modality-specific-files/08-genetic-descriptor.md": "modality-specific-files/genetic-descriptor.md"
         "04-modality-specific-files/09-positron-emission-tomography.md": "modality-specific-files/positron-emission-tomography.md"

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -46,9 +46,9 @@ the eyetracking data in a certain sampling frequency, and
 `sub-01_task-bart_recording-breathing_physio.tsv.gz` to contain respiratory
 measurements in a different sampling frequency.
 
-Physiological recordings (including eyetracking) SHOULD use the `_physio` suffix.
+Physiological recordings (including eyetracking) MUST use the `_physio` suffix.
 
-The following table specifies metadata fields for the `*_physio.json` file.
+The following tables specifiy metadata fields for the `*_physio.json` file.
 
 <!-- This block generates a metadata table.
 These tables are defined in
@@ -169,7 +169,7 @@ stored in separate files
 entity MAY be used to distinguish these files).
 
 For motion parameters acquired from MRI scanner side motion correction, the
-`_physio` suffix SHOULD be used.
+`_physio` suffix MUST be used.
 
 For multi-echo data, a given `physio.tsv` file is applicable to all echos of
 a particular run.

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -46,7 +46,7 @@ the eyetracking data in a certain sampling frequency, and
 `sub-01_task-bart_recording-breathing_physio.tsv.gz` to contain respiratory
 measurements in a different sampling frequency.
 
-Physiological recordings (including eyetracking) SHOULD use the `_physio`.
+Physiological recordings (including eyetracking) SHOULD use the `_physio` suffix.
 
 The following table specifies metadata fields for the `*_physio.json` file.
 

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -48,7 +48,7 @@ measurements in a different sampling frequency.
 
 Physiological recordings (including eyetracking) MUST use the `_physio` suffix.
 
-The following tables specifiy metadata fields for the `*_physio.json` file.
+The following tables specify metadata fields for the `*_physio.json` file.
 
 <!-- This block generates a metadata table.
 These tables are defined in

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -2,7 +2,7 @@
 
 Physiological recordings such as cardiac and respiratory signals MAY be
 specified using a [compressed tabular file](../common-principles.md#compressed-tabular-files)
-([TSVGZ file](../glossary.md#tsvgz-extensions)) and a corresponding
+([TSV.GZ file](../glossary.md#tsvgz-extensions)) and a corresponding
 JSON file for storing metadata fields (see below).
 
 !!! example "Example datasets"

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -34,11 +34,10 @@ For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 
 !!! warning "Caution"
 
-    TSVGZ files MUST NOT include a header line, as established by the
+    `<matches>_physio.tsv.gz` files MUST NOT include a header line, as established by the
     [common-principles](../common-principles.md#compressed-tabular-files).
-
     As a result, when supplying a `<matches>_physio.tsv.gz` file, an accompanying
-    `<matches>_physio.json` MUST be supplied as well.
+    `<matches>_physio.json` MUST be present to indicate the column names.
 
 The [`recording-<label>`](../appendices/entities.md#recording)
 entity MAY be used to distinguish between several recording files.

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -32,10 +32,11 @@ before the suffix.
 For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 `<matches>` would correspond to `sub-control01_task-nback_run-1`.
 
-!!! note "TSVGZ headers are specified in metadata files."
+!!! warning "Caution"
 
-    TSVGZ files MUST NOT include a header line,
-    as established by the [common-principles](../common-principles.md#compressed-tabular-files).
+    TSVGZ files MUST NOT include a header line, as established by the
+    [common-principles](../common-principles.md#compressed-tabular-files).
+
     As a result, when supplying a `<matches>_physio.tsv.gz` file, an accompanying
     `<matches>_physio.json` MUST be supplied as well.
 

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -1,9 +1,6 @@
-# Physiological and other continuous recordings
+# Physiological recordings
 
-## Physiological recordings
-
-Physiological recordings such as cardiac and respiratory signals and other
-continuous measures (such as parameters of a film or audio stimuli) MAY be
+Physiological recordings such as cardiac and respiratory signals MAY be
 specified using a [compressed tabular file](../common-principles.md#compressed-tabular-files)
 ([TSVGZ file](../glossary.md#tsvgz-extensions)) and a corresponding
 JSON file for storing metadata fields (see below).
@@ -24,8 +21,6 @@ sub-<label>/[ses-<label>/]
     <datatype>/
         <matches>[_recording-<label>]_physio.tsv.gz
         <matches>[_recording-<label>]_physio.json
-        <matches>[_recording-<label>]_stim.tsv.gz
-        <matches>[_recording-<label>]_stim.json
 ```
 
 For the template directory name, `<datatype>` can correspond to any data
@@ -41,8 +36,8 @@ For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 
     TSVGZ files MUST NOT include a header line,
     as established by the [common-principles](../common-principles.md#compressed-tabular-files).
-    As a result, when supplying a `*_<physio|stim>.tsv.gz` file, an accompanying
-    `*_<physio|stim>.json` MUST be supplied as well.
+    As a result, when supplying a `<matches>_physio.tsv.gz` file, an accompanying
+    `<matches>_physio.json` MUST be supplied as well.
 
 The [`recording-<label>`](../appendices/entities.md#recording)
 entity MAY be used to distinguish between several recording files.
@@ -51,10 +46,9 @@ the eyetracking data in a certain sampling frequency, and
 `sub-01_task-bart_recording-breathing_physio.tsv.gz` to contain respiratory
 measurements in a different sampling frequency.
 
-Physiological recordings (including eyetracking) SHOULD use the `_physio`
-suffix, and signals related to the stimulus SHOULD use `_stim` suffix.
+Physiological recordings (including eyetracking) SHOULD use the `_physio`.
 
-The following tables specify metadata fields for the `*_<physio|stim>.json` file.
+The following table specifies metadata fields for the `*_physio.json` file.
 
 <!-- This block generates a metadata table.
 These tables are defined in
@@ -173,11 +167,6 @@ Recordings with different sampling frequencies or starting times should be
 stored in separate files
 (and the [`recording-<label>`](../appendices/entities.md#recording)
 entity MAY be used to distinguish these files).
-
-If the same continuous recording has been used for all subjects (for example in
-the case where they all watched the same movie), one file MAY be used and
-placed in the root directory.
-For example, `task-movie_stim.tsv.gz`
 
 For motion parameters acquired from MRI scanner side motion correction, the
 `_physio` suffix SHOULD be used.

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -337,8 +337,7 @@ sub-<label>/[ses-<label>/]
 ```
 
 For the template directory name, `<datatype>` can correspond to any data
-recording modality, for example `func`, `anat`, `dwi`, `meg`, `eeg`, `ieeg`,
-or `beh`.
+recording modality.
 
 In the template filenames, the `<matches>` part corresponds to task filename
 before the suffix.

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -346,10 +346,11 @@ For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 
 !!! warning "Caution"
 
-    TSVGZ files SHOULD NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))
-
+    `<matches>[_recording-<label>]_stim.tsv.gz` files MUST NOT include a header line,
+    as established by the [common-principles](../common-principles.md#compressed-tabular-files).
     As a result, when supplying a `<matches>[_recording-<label>]_stim.tsv.gz` file,
-    an accompanying `<matches>[_recording-<label>]_stim.json` MUST be supplied as well.
+    an accompanying `<matches>[_recording-<label>]_stim.json` MUST be present to indicate
+    the column names.
 
 The [`recording-<label>`](../appendices/entities.md#recording)
 entity MAY be used to distinguish between several recording files,

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -124,7 +124,7 @@ Note that in the example above:
 
 1.  The `channel` column contains a list of values that are separated
     by a delimiter (`|`), as is declared in the `Delimiter` metadata
-    field of the `events.json file.
+    field of the `events.json` file.
     Thus, the channels related to the event in the third row of the example
     are called `F,1`, `F,2`, and `Cz`.
 

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -309,3 +309,93 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
     "VisionCorrection": "lenses"
 }
 ```
+
+### Continuously-sampled, stimulus-related signals
+
+!!! example "Example datasets"
+
+      At the time of writing, there are no
+      [example datasets](https://bids-standard.github.io/bids-examples/#dataset-index)
+      showcasing stimulus-related signals.
+      However, the following datasets shared on [OpenNeuro](https://openneuro.org)
+      include these type of signals and may be used (with caution, because they are not
+      "official" examples) as a reference when curating a new dataset:
+
+      -   [*Trial timing for multivariate pattern
+          analysis*](https://openneuro.org/datasets/ds000238/versions/00002)
+
+Signals related to stimuli (such as parameters of a film or audio stimuli) that are
+evenly recorded at a constant sampling frequency SHOULD be stored as follows.
+
+Template:
+
+```Text
+sub-<label>/[ses-<label>/]
+    <datatype>/
+        <matches>[_recording-<label>]_stim.tsv.gz
+        <matches>[_recording-<label>]_stim.json
+```
+
+For the template directory name, `<datatype>` can correspond to any data
+recording modality, for example `func`, `anat`, `dwi`, `meg`, `eeg`, `ieeg`,
+or `beh`.
+
+In the template filenames, the `<matches>` part corresponds to task filename
+before the suffix.
+For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
+`<matches>` would correspond to `sub-control01_task-nback_run-1`.
+
+!!! warning "TSVGZ files SHOULD NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))"
+
+    As a result, when supplying a `<matches>[_recording-<label>]_stim.tsv.gz` file,
+    an accompanying `<matches>[_recording-<label>]_stim.json` MUST be supplied as well.
+
+The [`recording-<label>`](../appendices/entities.md#recording)
+entity MAY be used to distinguish between several recording files,
+as prescribed by the specifications for
+[physiological recordings](physiological-recordings.md).
+
+If the same continuous recording has been used for all subjects (for example in
+the case where they all watched the same movie), one file placed in the
+root directory (for example, `<root>/task-movie_stim.<tsv.gz|json>`) MAY be used
+and will apply to all `<matches>_task-movie_<matches>_<suffix>.<ext>` files.
+In the following example, the two `task-nback_stim.<json|tsv.gz>` apply
+to all the `task-nback` runs across the two available subjects:
+
+<!-- This block generates a file tree.
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_filetree_example({
+  "sub-01": {
+    "func": {
+      "sub-01_task-nback_run-1_bold.nii.gz": "",
+      "sub-01_task-nback_run-2_bold.nii.gz": "",
+    },
+  },
+  "sub-02": {
+    "func": {
+      "sub-02_task-nback_run-1_bold.nii.gz": "",
+      "sub-02_task-nback_run-2_bold.nii.gz": "",
+    },
+  },
+  "task-nback_stim.json": "",
+  "task-nback_stim.tsv.gz": "",
+}) }}
+
+The following table specifies metadata fields for the
+`<matches>[_recording-<label>]_stim.json` file.
+
+<!-- This block generates a metadata table.
+These tables are defined in
+  src/schema/rules/sidecars
+The definitions of the fields specified in these tables may be found in
+  src/schema/objects/metadata.yaml
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_sidecar_table(["continuous.Continuous"]) }}
+
+Additional metadata may be included as in
+[any TSV file](../common-principles.md#tabular-files) to specify, for
+example, the units of the recorded time series for each column.

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -314,15 +314,13 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
 
 !!! example "Example datasets"
 
-      At the time of writing, there are no
-      [example datasets](https://bids-standard.github.io/bids-examples/#dataset-index)
-      showcasing stimulus-related signals.
+      At the time of writing, there are no [example datasets][bids-examples] showcasing
+      stimulus-related signals.
       However, the following datasets shared on [OpenNeuro](https://openneuro.org)
       include these type of signals and may be used (with caution, because they are not
       "official" examples) as a reference when curating a new dataset:
 
-      -   [*Trial timing for multivariate pattern
-          analysis*](https://openneuro.org/datasets/ds000238/versions/00002)
+      -   [*Trial timing for multivariate pattern analysis*][ds000238]
 
 Signals related to stimuli (such as parameters of a film or audio stimuli) that are
 evenly recorded at a constant sampling frequency SHOULD be stored as follows.
@@ -401,3 +399,7 @@ A guide for using macros can be found at
 Additional metadata may be included as in
 [any TSV file](../common-principles.md#tabular-files) to specify, for
 example, the units of the recorded time series for each column.
+
+<!-- Link Definitions -->
+[ds000238]: https://openneuro.org/datasets/ds000238/versions/00002
+[bids-examples]: https://bids-standard.github.io/bids-examples/#dataset-index

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -323,15 +323,18 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
       -   [*Trial timing for multivariate pattern analysis*][ds000238]
 
 Signals related to stimuli (such as parameters of a film or audio stimuli) that are
-evenly recorded at a constant sampling frequency MUST be stored as follows.
+evenly recorded at a constant sampling frequency MUST be specified using a
+[compressed tabular file](../common-principles.md#compressed-tabular-files)
+([TSV.GZ file](../glossary.md#tsvgz-extensions)) and a corresponding
+JSON file for storing metadata fields (see below).
 
 Template:
 
 ```Text
 sub-<label>/[ses-<label>/]
     <datatype>/
-        <matches>[_recording-<label>]_stim.tsv.gz
-        <matches>[_recording-<label>]_stim.json
+        <matches>_stim.tsv.gz
+        <matches>_stim.json
 ```
 
 For the template directory name, `<datatype>` can correspond to any data
@@ -344,16 +347,10 @@ For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 
 !!! warning "Caution"
 
-    `<matches>[_recording-<label>]_stim.tsv.gz` files MUST NOT include a header line,
+    `<matches>_stim.tsv.gz` files MUST NOT include a header line,
     as established by the [common-principles](../common-principles.md#compressed-tabular-files).
-    As a result, when supplying a `<matches>[_recording-<label>]_stim.tsv.gz` file,
-    an accompanying `<matches>[_recording-<label>]_stim.json` MUST be present to indicate
-    the column names.
-
-The [`recording-<label>`](../appendices/entities.md#recording)
-entity MAY be used to distinguish between several recording files,
-as prescribed by the specifications for
-[physiological recordings](physiological-recordings.md).
+    As a result, when supplying a `<matches>_stim.tsv.gz` file, an accompanying
+    `<matches>_stim.json` MUST be present to indicate the column names.
 
 If the same continuous recording has been used for all subjects (for example in
 the case where they all watched the same movie), one file placed in the
@@ -384,7 +381,7 @@ A guide for using macros can be found at
 }) }}
 
 The following table specifies metadata fields for the
-`<matches>[_recording-<label>]_stim.json` file.
+`<matches>_stim.json` file.
 
 <!-- This block generates a metadata table.
 These tables are defined in

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -320,7 +320,6 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
 
       -   ["synthetic" example dataset](https://github.com/bids-standard/bids-examples/tree/master/synthetic).
 
-
 Signals related to stimuli (such as parameters of a film or audio stimuli) that are
 evenly recorded at a constant sampling frequency MUST be specified using a
 [compressed tabular file](../common-principles.md#compressed-tabular-files)

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -344,8 +344,10 @@ before the suffix.
 For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 `<matches>` would correspond to `sub-control01_task-nback_run-1`.
 
-!!! warning "TSVGZ files SHOULD NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))"
+!!! warning "Caution"
 
+    TSVGZ files SHOULD NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))
+    
     As a result, when supplying a `<matches>[_recording-<label>]_stim.tsv.gz` file,
     an accompanying `<matches>[_recording-<label>]_stim.json` MUST be supplied as well.
 

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -314,20 +314,12 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
 
 !!! example "Example datasets"
 
-      The following [BIDS-Examples][] showcase stimulus-related signals:
+      The following [BIDS-Examples](https://bids-standard.github.io/bids-examples/#dataset-index)
+      showcase stimulus-related signals and may be used as a reference
+      when curating a new dataset:
 
-      -   ["synthetic" example dataset][synthetic-example].
+      -   ["synthetic" example dataset](https://github.com/bids-standard/bids-examples/tree/master/synthetic).
 
-      The following examples include these type of signals and may be used
-      (with caution, because they are not "official" examples)
-      as a reference when curating a new dataset:
-
-      -   [*Trial timing for multivariate pattern analysis*][ds000238]
-
-      <!-- Link Definitions -->
-      [ds000238]: https://openneuro.org/datasets/ds000238/versions/00002
-      [bids-examples]: https://bids-standard.github.io/bids-examples/#dataset-index
-      [synthetic-example]: https://github.com/bids-standard/bids-examples/tree/master/synthetic
 
 Signals related to stimuli (such as parameters of a film or audio stimuli) that are
 evenly recorded at a constant sampling frequency MUST be specified using a

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -314,11 +314,13 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
 
 !!! example "Example datasets"
 
-      At the time of writing, there are no [example datasets][bids-examples] showcasing
-      stimulus-related signals.
-      However, the following datasets shared on [OpenNeuro](https://openneuro.org)
-      include these type of signals and may be used (with caution, because they are not
-      "official" examples) as a reference when curating a new dataset:
+      The following [BIDS-Examples][] showcase stimulus-related signals:
+
+      -   ["synthetic" example dataset][synthetic-example].
+
+      The following examples include these type of signals and may be used
+      (with caution, because they are not "official" examples)
+      as a reference when curating a new dataset:
 
       -   [*Trial timing for multivariate pattern analysis*][ds000238]
 
@@ -400,3 +402,4 @@ example, the units of the recorded time series for each column.
 <!-- Link Definitions -->
 [ds000238]: https://openneuro.org/datasets/ds000238/versions/00002
 [bids-examples]: https://bids-standard.github.io/bids-examples/#dataset-index
+[synthetic-example]: https://github.com/bids-standard/bids-examples/tree/master/synthetic

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -347,7 +347,7 @@ For example for the file `sub-control01_task-nback_run-1_bold.nii.gz`,
 !!! warning "Caution"
 
     TSVGZ files SHOULD NOT include a header line (as established by the [common-principles](../common-principles.md#compressed-tabular-files))
-    
+
     As a result, when supplying a `<matches>[_recording-<label>]_stim.tsv.gz` file,
     an accompanying `<matches>[_recording-<label>]_stim.json` MUST be supplied as well.
 

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -324,6 +324,11 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
 
       -   [*Trial timing for multivariate pattern analysis*][ds000238]
 
+      <!-- Link Definitions -->
+      [ds000238]: https://openneuro.org/datasets/ds000238/versions/00002
+      [bids-examples]: https://bids-standard.github.io/bids-examples/#dataset-index
+      [synthetic-example]: https://github.com/bids-standard/bids-examples/tree/master/synthetic
+
 Signals related to stimuli (such as parameters of a film or audio stimuli) that are
 evenly recorded at a constant sampling frequency MUST be specified using a
 [compressed tabular file](../common-principles.md#compressed-tabular-files)
@@ -398,8 +403,3 @@ A guide for using macros can be found at
 Additional metadata may be included as in
 [any TSV file](../common-principles.md#tabular-files) to specify, for
 example, the units of the recorded time series for each column.
-
-<!-- Link Definitions -->
-[ds000238]: https://openneuro.org/datasets/ds000238/versions/00002
-[bids-examples]: https://bids-standard.github.io/bids-examples/#dataset-index
-[synthetic-example]: https://github.com/bids-standard/bids-examples/tree/master/synthetic

--- a/src/modality-specific-files/task-events.md
+++ b/src/modality-specific-files/task-events.md
@@ -323,7 +323,7 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
       -   [*Trial timing for multivariate pattern analysis*][ds000238]
 
 Signals related to stimuli (such as parameters of a film or audio stimuli) that are
-evenly recorded at a constant sampling frequency SHOULD be stored as follows.
+evenly recorded at a constant sampling frequency MUST be stored as follows.
 
 Template:
 


### PR DESCRIPTION
This fix builds on #1749 to separate ``_stim`` and ``_physio`` in the specs.

Currently ``_stim`` files are specified sideways as an addon or extra branch of ``_physio``, which can be confusing and misrepresent their intent.

Moving them with the other stimuli definitions increases the consistency of the spec and the findability of ``_stim`` specifications.

This fix requires #1749 for a more consistent prescription of `tsv.gz` files.