### PR TITLE
[ENH] use full width entity page

### DIFF
--- a/src/appendices/entity-table.md
+++ b/src/appendices/entity-table.md
@@ -1,7 +1,7 @@
 ---
 hide:
-  - navigation
-  - toc
+- navigation
+- toc
 ---
 
 # Entity table

--- a/src/appendices/entity-table.md
+++ b/src/appendices/entity-table.md
@@ -1,6 +1,5 @@
 ---
 hide:
--   navigation
 -   toc
 ---
 

--- a/src/appendices/entity-table.md
+++ b/src/appendices/entity-table.md
@@ -1,7 +1,7 @@
 ---
 hide:
-- navigation
-- toc
+-   navigation
+-   toc
 ---
 
 # Entity table

--- a/src/appendices/entity-table.md
+++ b/src/appendices/entity-table.md
@@ -1,3 +1,9 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 # Entity table
 
 This section compiles the entities (key-value pairs within filenames)


### PR DESCRIPTION
closes none

Tiny tweak that helps for all tables but that of MRI.

### Before

![image](https://github.com/bids-standard/bids-specification/assets/6961185/f9be3312-6848-4fb9-bbba-4010777dc1e5)

https://bids-specification.readthedocs.io/en/latest/appendices/entity-table.html#biopotential-amplification-eeg-and-ieeg


### After

<!--![image](https://github.com/bids-standard/bids-specification/assets/6961185/cf2ea631-f85a-464a-ade9-71fc23807c99)-->

![image](https://github.com/bids-standard/bids-specification/assets/83442/6065a682-4ed8-4edb-a6a0-fd4ea1aa6806)


https://bids-specification--1784.org.readthedocs.build/en/1784/appendices/entity-table.html