### PR TITLE
Clarify that age Units could be overriden + that type is number OR "89+" string

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -36,11 +36,16 @@ age:
   name: age
   display_name: Subject age
   description: |
-    Numeric value in years (float or integer value).
+    Numeric value (float or integer value), by default in Years.
 
     It is recommended to tag participant ages that are 89 or higher as 89+,
     for privacy purposes.
-  type: number
+    If age is in not in years, Units field should specify the unit.
+  anyOf:
+    - type: number
+    - type: string
+      enum:
+        - 89+
   unit: year
 cardiac:
   name: cardiac


### PR DESCRIPTION
Ultimately closes https://github.com/bids-standard/bids-specification/issues/1633

FWIW here is what I see among openneuro datasets ATM

```
$> for j in ds*/participants.json; do jq '.age.Units' $j; done | sort | uniq -c
jq: error (at ds002873/participants.json:577): Cannot index array with string "age"
      2 "Measurement units. [<prefix symbol>]<unit symbol> format following the SI standard is RECOMMENDED"
    227 null
      1 "weeks"
    206 "years"
     21 "Years"
      2 "years old"
      1 "years (rounded down)"
      3 "Years, with one quantile precision"
```

and among examples

```
❯ for j in ds*/participants.json; do jq '.age.Units' $j; done | sort | uniq -c
      2 null
      7 "year"
      9 "years"
```

so nobody uses it really besides 1 "weeks".  If we decide to go for it we need
- [ ] extend list of units with "month", "week", "day", ...
- [ ] see if / how we could adjust validation rules in the schema (attn @effigies as guided me on #1633)