### PR TITLE
[ENH] Use deidentification consistently in place of anonymization

### DIFF
--- a/src/modality-agnostic-files.md
+++ b/src/modality-agnostic-files.md
@@ -534,7 +534,7 @@ ses-followup	2009-06-17T13:45:30	110
 Template: `code/*`
 
 Source code of scripts that were used to prepare the dataset MAY be stored here.
-Examples include anonymization or defacing of the data, or
+Examples include deidentification or defacing of the data, or
 the conversion from the format of the source data to the BIDS format
 (see [source vs. raw vs. derived data](./common-principles.md#source-vs-raw-vs-derived-data)).
 Extra care should be taken to avoid including original IDs or

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -925,7 +925,7 @@ NIfTI headers.
 
 ### `*_asllabeling.*`
 
-An anonymized screenshot of the planning of the labeling slab/plane
+A deidentified screenshot of the planning of the labeling slab/plane
 with respect to the imaging slab or slices.
 This screenshot is based on DICOM macro C.8.13.5.14.
 

--- a/src/modality-specific-files/positron-emission-tomography.md
+++ b/src/modality-specific-files/positron-emission-tomography.md
@@ -177,7 +177,7 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_sidecar_table("pet.PETTime") }}
 
-We refer to the common principles for the standards for describing dates and timestamps, including possibilities for anonymization (see [Units](../common-principles.md#units)).
+We refer to the common principles for the standards for describing dates and timestamps, including possibilities for deidentification (see [Units](../common-principles.md#units)).
 
 #### Reconstruction
 

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -19,7 +19,7 @@ acq_time__scans:
     Acquisition time refers to when the first data point in each run was acquired.
     Furthermore, if this header is provided, the acquisition times of all files
     from the same recording MUST be identical.
-    Datetime format and their anonymization are described in
+    Datetime format and their deidentification are described in
     [Units](SPEC_ROOT/common-principles.md#units).
   type: string
   format: datetime
@@ -28,7 +28,7 @@ acq_time__sessions:
   display_name: Session acquisition time
   description: |
     Acquisition time refers to when the first data point of the first run was acquired.
-    Datetime format and their anonymization are described in
+    Datetime format and their deidentification are described in
     [Units](SPEC_ROOT/common-principles.md#units).
   type: string
   format: datetime

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1646,7 +1646,7 @@ LabelingLocationDescription:
     Description of the location of the labeling plane (`"CASL"` or `"PCASL"`) or
     the labeling slab (`"PASL"`) that cannot be captured by fields
     `LabelingOrientation` or `LabelingDistance`.
-    May include a link to an anonymized screenshot of the planning of the
+    May include a link to a deidentified screenshot of the planning of the
     labeling slab/plane with respect to the imaging slab or slices
     `*_asllabeling.*`.
     Based on DICOM macro C.8.13.5.14.

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -505,7 +505,7 @@ asllabeling:
   value: asllabeling
   display_name: ASL Labeling Screenshot
   description: |
-    An anonymized screenshot of the planning of the labeling slab/plane
+    A deidentified screenshot of the planning of the labeling slab/plane
     with respect to the imaging slab or slices.
     This screenshot is based on DICOM macro C.8.13.5.14.
 beh:


### PR DESCRIPTION
In the vast majority of cases, strict anonymisation is impossible. Use the more generic term deidentification instead.

I suggest #1769 is merged first, then I can rebase and fix all occurrences.

Fixes #1782.