### PR TITLE
BIDS 2.0: flex BIDS layout (bids-2-devel/issues/54)

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -246,6 +246,14 @@ B1ShimmingTechnique:
     The technique used to shim the *B<sub>1</sub>* field (for example, `"Simple phase align"`
     or `"Pre-saturated TurboFLASH"`).
   type: string
+BIDSEntitiesLayout:
+  name: BIDSEntitiesLayout
+  display_name: BIDS Entities Layout
+  description: |
+    The specification of the hierarchy of directories and leading entities
+    in the filenames of BIDS files.
+    TODO: expand on type etc. Formalization is WiP within docs...
+  type: object
 BIDSVersion:
   name: BIDSVersion
   display_name: BIDS Version


### PR DESCRIPTION
Aims to provide a solution to

- https://github.com/bids-standard/bids-2-devel/issues/54

### Name rationale:

Originally I thought to name it `BIDSLayout` but that one was/is used as a class in pybids. On one hand it is great because corresponds in "principles". But I thought to avoid confusion at least ATM so to make it easier to find issues/code where such a term is used/mentioned.  So for now decided to go with `BIDSEntitiesLayout` but it would be easy to change to anything we want.

### TODOs

- [ ] seek initial feedback (attn @bids-standard/maintainers @bids-standard/steering et al)
- [ ] elaborate on having multiple paths (e.g. `"."` and `"atlases/" : attn #1714 folks TODO: add a team)
- [ ] provide migration for datasets with sessions: would need to be added explicitly
- [ ] add examples to bids2.0-examples
   - [ ] add few examples with alternative layouts (e.g. without `session` and `modality` folders, thus getting very close to DANDI BIDS-like setup. Attn @TheChymera who is trying nwb2bids on DANDI dandisets)
   - [ ] may be even just migrate them all into some alternative layouts and see validator to still operate correctly... 
- [ ] adjust schema where needed
  - dissolve `entities` in [rules/files/common/tables.yaml](https://github.com/bids-standard/bids-specification/blob/master/src/schema/rules/files/common/tables.yaml)
  - ...
- [ ] adjust `bidsschematools` to support
- [ ] extend `bids-validator` to support