### PR TITLE
[ENH] Add stimulus and annotation entities

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -603,6 +603,14 @@ stim_file:
     For example `images/cat03.jpg` will be translated to `/stimuli/images/cat03.jpg`.
   type: string
   format: stimuli_relative
+stim_id:
+  name: stim_id
+  display_name: Stimulus ID
+  description: |
+    A stimulus identifier of the form `stim-<label>`,
+    matching a stimulus entity found in `stimuli/` directory.
+  type: string
+  pattern: ^stim-[0-9a-zA-Z]+$
 strain:
   name: strain
   display_name: Strain

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -436,7 +436,7 @@ annotation:
   display_name: Annotation
   description: |
     The `annot-<label>` entity can be used to distinguish different annotations
-    of the stimlus data.
+    of the stimulus data.
 
     This entity is only applicable to stimulus files.
   type: string

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -422,3 +422,22 @@ tracksys:
     may be longer and more human readable.
   type: string
   format: label
+stimulus:
+  name: stim
+  display_name: Stimulus
+  description: |
+    The `stim-<label>` entity can be used to distinguish stimulus files stored in the `stimuli/` directory.
+
+    This entity is only applicable to stimulus files.
+  type: string
+  format: label
+annotation:
+  name: annot
+  display_name: Annotation
+  description: |
+    The `annot-<label>` entity can be used to distinguish different annotations
+    of the stimlus data.
+
+    This entity is only applicable to stimulus files.
+  type: string
+  format: label

--- a/src/schema/rules/entities.yaml
+++ b/src/schema/rules/entities.yaml
@@ -30,3 +30,5 @@
 - density
 - label
 - description
+- stimulus
+- annotation


### PR DESCRIPTION
**stimulus** and **annotation** entities are necessary to distinguish various stimulus files and possible different annotations per each stimulus file.

A sample use-case of these entities is presented in bids-standard/bids-examples#433.

Both entities are being discussed in #153, and this [Google Doc](https://docs.google.com/document/d/1DoQghbJlQksCHEFs0boT816p3ejX2Hd9l-OWDTXFtV8/edit?usp=sharing).
The `stim-` entity was suggested first in #751.
The `annot-` entity might be of use in #1771 as well.

This pull request would likely require a minor version change.

