### PR TITLE
BIDS 2.0: harmonize TSV columns to be singular (ATM "units" and "migrate_plural_columns")

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -481,6 +481,7 @@ with two exceptions:
 It is RECOMMENDED that the column names in the header of the TSV file are
 written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case) with the
 first letter in lower case (for example, `variable_name`, not `Variable_name`).
+It is RECOMMENDED that the column names are singular (for example, `variable_name`, not `variable_names`).
 Column names defined in the header MUST be separated with tabs as for the data contents.
 Furthermore, column names MUST NOT be blank (that is, an empty string) and MUST NOT
 be duplicated within a single TSV file.

--- a/tools/schemacode/bidsschematools/migrations.py
+++ b/tools/schemacode/bidsschematools/migrations.py
@@ -58,6 +58,25 @@ def migrate_participants(dataset_path: Path):
                 lgr.info(f"   - migrated content in {new_file}")
 
 
+def migrate_tsv_columns(dataset_path: Path):
+    """
+    Rename some columns in .tsv (and corresponding sidecar .json)
+    """
+    # TODO: ideally here we would not provide file_glob
+    # but rather take schema and deduce which files could have
+    # the column... alternatively - consider all .tsv files and
+    # their .json files (note -- could be above and multiple given
+    # inheritance principle)
+    for col_from, col_to, file_glob in (
+        # https://github.com/bids-standard/bids-2-devel/issues/78
+        ("hplc_recovery_fractions", "hplc_recovery_fraction", "*_blood.*"),
+        # https://github.com/bids-standard/bids-2-devel/issues/15
+        ("units", "unit", "_channels.*"),  # dependency on migrate_participants
+        # ??? Any other columns to rename for some reason?
+    ):
+        raise NotImplementedError()
+
+
 def migrate_dataset(dataset_path):
     lgr.info(f"Migrating dataset at {dataset_path}")
     dataset_path = Path(dataset_path)
@@ -74,6 +93,7 @@ def migrate_dataset(dataset_path):
     for migration in [
         migrate_participants,
         migrate_version,
+        migrate_tsv_columns,  # depends on migrate_participants
     ]:
         lgr.info(f" - applying migration {migration.__name__}")
         migration(dataset_path)


### PR DESCRIPTION
Closes
- https://github.com/bids-standard/bids-2-devel/issues/15
- https://github.com/bids-standard/bids-2-devel/issues/78

TODOs
- [ ] review if any other renames are due (not necessarily plural -> singular but might be done along here)
- [x] RECOMMEND for the user added columns to be singular
  - [ ] consider possibility for adding a check to bids-validator -- might be too tricky to be worth it since not trivial to determine plurality AFAIK
- [ ] compliment with changes to "CONTRIBUTION" guide of some kind (@effigies please remind where should we place those)
  - [ ] add a test for schema tests to ensure that nobody inadvertently adds another plural column 
    - might be worth for BIDS 1.0 with whitelisting of known 2 culprits so we prevent possibly adding more
- [ ] implement migration code