### PR TITLE
[FIX] Change hipCT microscopy suffix to XPCT

### DIFF
--- a/src/modality-specific-files/microscopy.md
+++ b/src/modality-specific-files/microscopy.md
@@ -28,7 +28,7 @@ and a guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
 {{ MACROS___make_filename_template("raw", datatypes=["micr"], suffixes=["TEM", "SEM", "uCT", "BF", "DF",
-"PC", "DIC", "FLUO", "CONF", "PLI", "CARS", "2PE", "MPE", "SR", "NLO", "OCT", "SPIM", "hipCT"], n_dupes_to_combine=4) }}
+"PC", "DIC", "FLUO", "CONF", "PLI", "CARS", "2PE", "MPE", "SR", "NLO", "OCT", "SPIM", "XPCT"], n_dupes_to_combine=4) }}
 
 Microscopy data MUST be stored in the `micr` directory.
 
@@ -88,7 +88,7 @@ and a guide for using macros can be found at
          "NLO",
          "OCT",
          "SPIM",
-         "hipCT",
+         "XPCT",
       ]
    )
 }}

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -607,11 +607,11 @@ headshape:
   description: |
     The 3-D locations of points that describe the head shape and/or electrode
     locations can be digitized and stored in separate files.
-hipCT:
-  value: hipCT
-  display_name: HiP-CT
+XPCT:
+  value: XPCT
+  display_name: X-ray Phase-Contrast Tomography
   description: |
-    Hierarchical Phase-Contrast Tomography imaging data
+    X-ray phase-contrast tomography imaging data
 ieeg:
   value: ieeg
   display_name: Intracranial Electroencephalography

--- a/src/schema/rules/files/raw/micr.yaml
+++ b/src/schema/rules/files/raw/micr.yaml
@@ -18,7 +18,7 @@ microscopy:
     - NLO
     - OCT
     - SPIM
-    - hipCT
+    - XPCT
   extensions:
     - .ome.tif
     - .ome.btf


### PR DESCRIPTION
Following the discussion at #1646, I am reverting @balbasty's PR #1686 with `XPCT` instead of `hipCT`: it is more suited for a broader audience.