### PR TITLE
Update circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,7 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
-      - setup_remote_docker:
-          version: 17.11.0-ce
+      - setup_remote_docker
       # checkout code to default ~/project
       - checkout
       - attach_workspace:


### PR DESCRIPTION
as per: https://support.circleci.com/hc/en-us/articles/23614965074459-2024-Image-Deprecations-and-Brownouts-Android-Linux-VM-Remote-Docker-Linux-VM

see: https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176

We will not see in the CI here whether or not this works, but only once we create a "merge commit" and let the CI run on master.