### PR TITLE
Inheritance Principle: Advise against value overloading. Plan to deprecate support for overloading for BIDS 2.0

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -669,7 +669,10 @@ to which the metadata contained within are not applicable.
 The Inheritance Principle defines a systematized set of rules
 to determine which metadata files to associate with which data files.
 Further, because multiple metadata files may apply to an individual data file,
-the Principle defines the *order of precedence* of such metadata files contents.
+the Principle defines the *order of precedence* of such metadata content;
+this is necessary for resolution of conflicts if the same metadata field
+contains different values in different metadata files
+(though it is RECOMMENDED to avoid such overloading).
 
 ### Rules
 


### PR DESCRIPTION
Re-commit of b7a3ab625a7c1994d3984f3eb79c4811449e7e2b that was rejected as a late addition to #1807; re-posting here for separate review as suggested.

I've become progressively convinced that the ability to overload metadata fields via Inheritance is a major source of the disparity in opinions about the Inheritance Principle. Regardless of whether you like or hate it, where I think there should be consensus is that overloading should not be intentionally used, even if BIDS 1.x explicitly permits it and it was used as one of the key demonstrative examples.

The proposed change hopefully also helps to contextualise why the subsequent text is a complex but necessary set of rules.