### PR TITLE
[ENH] Additional age related columns for participants.tsv file to cover animal data

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -42,6 +42,31 @@ age:
     for privacy purposes.
   type: number
   unit: year
+age_category:
+  name: age_category
+  display_name: Age category
+  description: |
+    For non-numeric description of the age (e.g. developmental stage) a string can be provided.
+    We RECOMMEND to use the [UBERON life cycle stage](http://purl.obolibrary.org/obo/UBERON_0000105) to specify it.
+  type: string
+age_type:
+  name: age_type
+  display_name: Age type
+  description: |
+    Type of age measurement (e.g. `postnatal`, `fetal`, `gestational`). If not specified, `postnatal` is assumed.
+  type: string
+  enum:
+    - $ref: objects.enums.postnatal.value
+    - $ref: objects.enums.fetal.value
+    - $ref: objects.enums.gestational.value
+birthdate:
+  name: birthdate
+  display_name: Birthdate
+  description: |
+    Day of birth of the participant. Datetime format and their anonymization are described 
+    in [Units](SPEC_ROOT/common-principles.md#units).
+  type: string
+  format: datetime
 cardiac:
   name: cardiac
   display_name: Cardiac measurement

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1405,3 +1405,24 @@ microvascular:
   display_name: microvascular
   description: |
     The origin of a tissue: microvascular
+postnatal:
+  value: postnatal
+  display_name: postnatal
+  description: |
+    This is the actual time that has passed since a subject's birth,
+    also known as “chronological age”.
+    If age_type is omitted, age is assumed to be this type.
+fetal:
+  value: fetal
+  display_name: fetal
+  description: |
+    Also known as "embryonic age," this measures the age of a
+    fetus or embryo from the time of conception. It's typically about two weeks
+    less than the gestational age.
+gestational:
+  value: gestational
+  display_name: gestational
+  description: |
+    This measures the duration of pregnancy from the first day of the
+    mother's last menstrual period to the current date. This should be included
+    for experiments where some subjects have not been born.

--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -15,6 +15,9 @@ Participants:
     handedness: recommended
     strain: recommended
     strain_rrid: recommended
+    age_category: recommended
+    age_type: recommended
+    birthdate: recommended
   index_columns: [participant_id]
   additional_columns: allowed
 


### PR DESCRIPTION
The PR adds columns for `age_category`, `age_type`, `birthdate` as discussed and suggested by yarik in #1826 

This is open for discussion.

Related issues:

- #1705
-  #1634 
- #1791 