### PR TITLE
feat(schema): Add schema check for README file

### DIFF
--- a/src/schema/rules/checks/hints.yaml
+++ b/src/schema/rules/checks/hints.yaml
@@ -4,6 +4,21 @@
 
 ### Dataset level
 
+# 101
+# This check should probably be replaced by making sure rules.files.common.core.README is
+# hit, but this is the short path forward.
+ReadmeFileMissing:
+  issue:
+    code: README_FILE_MISSING
+    message: |
+      The recommended file /README is missing.
+      See Section 03 (Modality agnostic files) of the BIDS specification.
+    level: warning
+  selectors:
+    - path == '/dataset_description.json'
+  checks:
+    - exists(["/README", "/README.txt", "/README.md", "/README.rst"], "dataset") > 0
+
 # 102
 TooFewAuthors:
   issue:


### PR DESCRIPTION
Restores issue `README_FILE_MISSING` to the schema-based validator.