### PR TITLE
DOC: Updates to how changelog generator is working

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -721,17 +721,12 @@ The decision-making rules are outlined in
 
 The changelog (see `src/CHANGES.md`) is generated automatically using
 [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
-You can see the workflow in the CircleCI configuration file (`.circleci/config.yml`).
+You can see the workflow in the following GitHub Actions configuration file: `.github/workflows/changelog_generator.yml`.
 
-As it stands, the changelog is generated whenever a pull request is integrated into
-the `master` branch of the specification via a "Merge commit"
-(as opposed to "Squash and merge" or "Rebase and merge";
-see the [GitHub help page](https://help.github.com/en/articles/about-merge-methods-on-github)
-for more information on merge methods).
-
-![merge-commit](release_images/merge_commit.png "merge-commit")
-
-Note that for pull requests starting with `REL:`, no changelog is generated.
+This workflow is triggered for every commit to `master` that contains string `[build changelog]` in its commit message.
+If you push several commits at once, you need to make sure that the "youngest commit" (the HEAD commit) contains that string.
+The workflow will then open a Pull Request to incorporate the updated changelog.
+Check the proposed changes and merge the Pull Request at will.
 
 To exclude pull requests from showing up in the changelog, they have to be labeled with
 the "exclude-from-changelog" label.

--- a/Release_Protocol.md
+++ b/Release_Protocol.md
@@ -12,10 +12,6 @@ your fork locally to a directory called `bids-specification`.
 
 Before you start a release, you have to ensure that the automatically generated changelog is **up to date**.
 See the relevant [section in CONTRIBUTING.md](CONTRIBUTING.md#how-is-the-changelog-generated) for further information.
-In practice this means ensuring that the most recently merged pull request
-was merged into the `master` branch using the "Merge commit" option.
-
-![merge-commit](release_images/merge_commit.png.png "merge-commit")
 
 ### 1. Fetch the latest version of the [master branch of the BIDS-specification](https://github.com/bids-standard/bids-specification/tree/master)
 


### PR DESCRIPTION
documentation for the commit I pushed here: https://github.com/bids-standard/bids-specification/commit/eba3e08e2dbfd3ad2e57c2a52c3bda8c1961dc6c

This PR should be merged only after it has been shown that that commit (☝️ ) actually works ...

see:

- #1852 

Xrefs:

- https://github.com/bids-standard/bids-specification/pull/1836
- https://github.com/bids-standard/bids-specification/pull/1850 
