### PR TITLE
Multiple changes to DWI scanner derivatives

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -698,7 +698,7 @@ The user is free to choose any other label than `singleband` and
 
 Scanner-generated TRACE, ADC and fractional anisotropy (FA and colFA) volumes MAY be included
 using the `TRACE`, `ADC`, `FA` and `colFA` suffixes, respectively.
-If TRACE, ADC, FA, colFA volume filenames match a diffusion series with all applicable entities,
+If TRACE, ADC, FA, or colFA volume filenames match a diffusion series with all applicable entities,
 such volumes SHOULD be computed from that series.
 Otherwise, some entity, such as [`acq-<label>`](../appendices/entities.md#acq),
 SHOULD be used to indicate that the files are unrelated.

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -667,7 +667,7 @@ The definitions of these fields can be found in
 and a guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
-{{ MACROS___make_suffix_table(["ADC", "TRACE", "FA", "colFA"]) }}
+{{ MACROS___make_suffix_table(["ADC", "expADC", "trace", "FA", "colFA"]) }}
 
 <!--
 This block generates a filename templates.
@@ -696,10 +696,10 @@ In such a case, two files could have the following names:
 The user is free to choose any other label than `singleband` and
 `multiband`, as long as they are consistent across subjects and sessions.
 
-Scanner-generated TRACE, ADC and fractional anisotropy (FA and colFA) volumes MAY be included
-using the `TRACE`, `ADC`, `FA` and `colFA` suffixes, respectively.
-If TRACE, ADC, FA, or colFA volume filenames match a diffusion series with all applicable entities,
-such volumes SHOULD be computed from that series.
+Scanner-generated trace-weighted, ADC, exponentiated ADC, and fractional anisotropy (FA and colFA) volumes
+MAY be included using the `trace`, `ADC`, `expADC`, `FA` and `colFA` suffixes, respectively.
+If trace, ADC, expADC, FA, or colFA volume filenames match a diffusion series with all applicable entities,
+such volumes SHOULD have been computed from that series.
 Otherwise, some entity, such as [`acq-<label>`](../appendices/entities.md#acq),
 SHOULD be used to indicate that the files are unrelated.
 

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -697,7 +697,7 @@ The user is free to choose any other label than `singleband` and
 `multiband`, as long as they are consistent across subjects and sessions.
 
 Scanner-generated TRACE, ADC and fractional anisotropy (FA and colFA) volumes MAY be included
-using the `TRACE`, `ADC`, `FA` and `colFA` suffixes, respectively
+using the `TRACE`, `ADC`, `FA` and `colFA` suffixes, respectively.
 If TRACE, ADC, FA, colFA volume filenames match a diffusion series with all applicable entities,
 such volumes SHOULD be computed from that series.
 Otherwise, some entity, such as [`acq-<label>`](../appendices/entities.md#acq),

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -696,8 +696,8 @@ In such a case, two files could have the following names:
 The user is free to choose any other label than `singleband` and
 `multiband`, as long as they are consistent across subjects and sessions.
 
-Scanner-generated TRACE and ADC volumes MAY be included using the
-`TRACE` and `ADC` suffixes.
+Scanner-generated TRACE, ADC and FA volumes MAY be included using the
+`TRACE`, `FA` and `ADC` suffixes.
 If TRACE or ADC volume filenames match a diffusion series with all applicable entities,
 such volumes SHOULD be computed from that series.
 Otherwise, some entity, such as [`acq-<label>`](../appendices/entities.md#acq),

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -696,9 +696,9 @@ In such a case, two files could have the following names:
 The user is free to choose any other label than `singleband` and
 `multiband`, as long as they are consistent across subjects and sessions.
 
-Scanner-generated TRACE, ADC and FA volumes MAY be included using the
-`TRACE`, `FA` and `ADC` suffixes.
-If TRACE or ADC volume filenames match a diffusion series with all applicable entities,
+Scanner-generated TRACE, ADC and fractional anisotropy (FA) volumes MAY be included
+using the `TRACE`, `ADC`, and `FA` suffixes, respectively
+If TRACE, ADC or FA volume filenames match a diffusion series with all applicable entities,
 such volumes SHOULD be computed from that series.
 Otherwise, some entity, such as [`acq-<label>`](../appendices/entities.md#acq),
 SHOULD be used to indicate that the files are unrelated.

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -667,7 +667,7 @@ The definitions of these fields can be found in
 and a guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
-{{ MACROS___make_suffix_table(["ADC", "TRACE"]) }}
+{{ MACROS___make_suffix_table(["ADC", "TRACE", "FA", "colFA"]) }}
 
 <!--
 This block generates a filename templates.
@@ -696,9 +696,9 @@ In such a case, two files could have the following names:
 The user is free to choose any other label than `singleband` and
 `multiband`, as long as they are consistent across subjects and sessions.
 
-Scanner-generated TRACE, ADC and fractional anisotropy (FA) volumes MAY be included
-using the `TRACE`, `ADC`, and `FA` suffixes, respectively
-If TRACE, ADC or FA volume filenames match a diffusion series with all applicable entities,
+Scanner-generated TRACE, ADC and fractional anisotropy (FA and colFA) volumes MAY be included
+using the `TRACE`, `ADC`, `FA` and `colFA` suffixes, respectively
+If TRACE, ADC, FA, colFA volume filenames match a diffusion series with all applicable entities,
 such volumes SHOULD be computed from that series.
 Otherwise, some entity, such as [`acq-<label>`](../appendices/entities.md#acq),
 SHOULD be used to indicate that the files are unrelated.

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -42,13 +42,6 @@ DIC:
   display_name: Differential interference contrast microscopy
   description: |
     Differential interference contrast microscopy imaging data
-colFA:
-  value: colFA
-  display_name: Colored Fractional Anisotropy image
-  description: |
-    Diffusion images reflecting the directionality of the diffusion tensor color-coded in red for
-    left-right oriented fibers, in blue for superior-inferior oriented fibers and green for
-    anterior-posterior oriented fibers.
 DF:
   value: DF
   display_name: Dark-field microscopy
@@ -58,7 +51,8 @@ FA:
   value: FA
   display_name: Fractional Anisotropy image
   description: |
-    Diffusion images reflecting the directionality of the diffusion tensor
+    Scanner-generated derivative parametric map
+    reflecting the anisotropy of the diffusion tensor
 FLAIR:
   value: FLAIR
   display_name: Fluid attenuated inversion recovery image
@@ -477,11 +471,6 @@ TEM:
   display_name: Transmission electron microscopy
   description: |
     Transmission electron microscopy imaging data
-TRACE:
-  value: TRACE
-  display_name: Trace diffusion weighted image
-  description: |
-    Diffusion images proportional to the trace of the diffusion tensor
 UNIT1:
   value: UNIT1
   display_name: Homogeneous (flat) T1-weighted MP2RAGE image
@@ -559,6 +548,15 @@ channels:
   display_name: Channels File
   description: |
     Channel information.
+colFA:
+  value: colFA
+  display_name: Colored Fractional Anisotropy image
+  description: |
+    Scanner-derived parametric map encoding both the anisotropy and principal direction of the diffusion tensor.
+    Image intensity is proportional to the Fractional Anisotropy (FA) measure;
+    image colour is determined by the principal eigenvector of the diffusion tensor,
+    where red encodes the magnitude of the left-right component of that orientation,
+    with green and blue similarly encoding the anterior-posterior and inferior-superior components respectively.
 coordsystem:
   value: coordsystem
   display_name: Coordinate System File
@@ -617,6 +615,12 @@ events:
   display_name: Events
   description: |
     Event timing information from a behavioral task.
+expADC:
+  value: expADC
+  display_name: Exponental ADC
+  description: |
+    Exponental ADC / Attenuation Coefficient / Attenuation Factor map,
+    as the ratio of trace-weighted to non-diffusion-weighted image intensity
 fieldmap:
   value: fieldmap
   display_name: Fieldmap
@@ -831,6 +835,11 @@ stim:
   display_name: Continuous recording
   description: |
     Continuous measures, such as parameters of a film or audio stimulus.
+trace:
+  value: trace
+  display_name: Trace-weighted diffusion image
+  description: |
+    Trace-weighted image, as the mean intensity of diffusion-weighted images
 uCT:
   value: uCT
   display_name: Micro-CT

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -42,6 +42,13 @@ DIC:
   display_name: Differential interference contrast microscopy
   description: |
     Differential interference contrast microscopy imaging data
+colFA:
+  value: colFA
+  display_name: coloured Fractional Anisotropy image
+  description: |
+    Diffusion images reflecting the directionality of the diffusion tensor color-coded in red for 
+    left-right oriented fibers, in blue for superior-inferior oriented fibers and green for 
+    anterior-posterior oriented fibers.
 DF:
   value: DF
   display_name: Dark-field microscopy

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -47,6 +47,11 @@ DF:
   display_name: Dark-field microscopy
   description: |
     Dark-field microscopy imaging data
+FA:
+  value: FA
+  display_name: Fractional Anisotropy image
+  description: |
+    Diffusion images reflecting the directionality of the diffusion tensor
 FLAIR:
   value: FLAIR
   display_name: Fluid attenuated inversion recovery image

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -46,8 +46,8 @@ colFA:
   value: colFA
   display_name: coloured Fractional Anisotropy image
   description: |
-    Diffusion images reflecting the directionality of the diffusion tensor color-coded in red for 
-    left-right oriented fibers, in blue for superior-inferior oriented fibers and green for 
+    Diffusion images reflecting the directionality of the diffusion tensor color-coded in red for
+    left-right oriented fibers, in blue for superior-inferior oriented fibers and green for
     anterior-posterior oriented fibers.
 DF:
   value: DF

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -44,7 +44,7 @@ DIC:
     Differential interference contrast microscopy imaging data
 colFA:
   value: colFA
-  display_name: coloured Fractional Anisotropy image
+  display_name: Colored Fractional Anisotropy image
   description: |
     Diffusion images reflecting the directionality of the diffusion tensor color-coded in red for
     left-right oriented fibers, in blue for superior-inferior oriented fibers and green for

--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -26,10 +26,10 @@ dwi_volumetric:
     density: optional
     description: optional
 
-dwi_isotropic:
-  $ref: rules.files.raw.dwi.isotropic
+dwi_scannerderivatives:
+  $ref: rules.files.raw.dwi.ScannerDerivatives
   entities:
-    $ref: rules.files.raw.dwi.isotropic.entities
+    $ref: rules.files.raw.dwi.ScannerDerivatives.entities
     space: optional
     resolution: optional
     density: optional

--- a/src/schema/rules/files/raw/dwi.yaml
+++ b/src/schema/rules/files/raw/dwi.yaml
@@ -40,7 +40,7 @@ sbref:
     chunk: optional
 
 # Common scanner-generated derivatives need raw names
-isotropic:
+ScannerDerivatives:
   suffixes:
     - ADC
     - FA

--- a/src/schema/rules/files/raw/dwi.yaml
+++ b/src/schema/rules/files/raw/dwi.yaml
@@ -43,9 +43,10 @@ sbref:
 ScannerDerivatives:
   suffixes:
     - ADC
-    - colFA
     - FA
-    - TRACE
+    - colFA
+    - expADC
+    - trace
   extensions:
     - .nii.gz
     - .nii

--- a/src/schema/rules/files/raw/dwi.yaml
+++ b/src/schema/rules/files/raw/dwi.yaml
@@ -43,6 +43,7 @@ sbref:
 ScannerDerivatives:
   suffixes:
     - ADC
+    - colFA
     - FA
     - TRACE
   extensions:

--- a/src/schema/rules/files/raw/dwi.yaml
+++ b/src/schema/rules/files/raw/dwi.yaml
@@ -43,6 +43,7 @@ sbref:
 isotropic:
   suffixes:
     - ADC
+    - FA
     - TRACE
   extensions:
     - .nii.gz


### PR DESCRIPTION
This PR is intended to supersede #1831 with additional content, as well as resolve #1862.

Rather than incrementing the spec with different aspects of scanner-generated DWI derivatives, as happened previously with #1725 and now #1831, it makes more sense to me to establish what that set is, and resolve the specification against the entirety of that set.

I have additionally created an exemplar dataset that shows all of the derivatives that can be generated by the product diffusion sequence on the Siemens XA platform:
https://github.com/bids-standard/bids-examples/pull/452
If anybody knows of other derivatives that can be generated by other sequences / platforms, it would make sense to add those as extra subjects within that dataset.

While the sequence exports can include data encoding the outcomes of the tensor fit itself, those are exported in a proprietary format, cannot be trivially converted to NIfTI, and are therefore excluded from this list.

-----

Some points requiring discussion (hence draft PR):

- [ ] The "exponential ADC" map is explained [here](https://mriquestions.com/exponential-adc.html). I've confirmed that if you compute the ratio of the trace-weighted image to the mean *b*=0 image you get the same result. This is the name that parameter is given in the protocol editor on the scanner console, but it's not a unique name; it can also be called "attenuation coefficient" or "attenuation factor". Most likely "`expADC`" is the most sensible suffix, but requires agreement.
- [ ] I've de-capitalised the existing `TRACE` suffix, and set these new suffices, based on my thinking [registered over on bids-2-devel](https://github.com/bids-standard/bids-2-devel/issues/26#issuecomment-2187692072) where capitalisation should apply to acronyms.
- [ ] I've not confirmed compatibility between the proposed exemplar dataset and the proposed changes to the spec. I presume this can be done, just not something I've done before.
- [ ] One of the scanner-generated derivatives is labelled as "TENSOR_B0". This is not precisely equivalent to the mean *b*=0 image; rather, it is the estimated *b*=0 signal intensity based on the tensor model fit ("*S0*" is more commonly used for this term in diffusion model space). So it's just a T2-weighted image, but it's arisen from a tensor model fit. Therefore in the exemplar dataset, I've named these data "`*_desc-tensor_T2w.*`". I presume this is not currently permissible; I would personally prefer this kind of encoding as opposed to giving it its own suffix, but if others dislike it we'll need to figure out some different encoding.