### PR TITLE
[FIX] Remove extra bracket

### DIFF
--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -290,7 +290,7 @@ A guide for using macros can be found at
 A segmentation can be used to generate a binary mask that functions as a
 discrete "label" for a single structure.
 In this case, the mask suffix MUST be used,
-the [`label` entity](../appendices/entities.md#label)) SHOULD be used
+the [`label` entity](../appendices/entities.md#label) SHOULD be used
 to specify the masked structure
 (see [Common image-derived labels](#common-image-derived-labels)),
 and the [`seg` entity](../appendices/entities.md#segmentation) SHOULD be defined.


### PR DESCRIPTION
Minor fix to remove an extra parenthesis from the [Discrete Segmentations](https://bids-specification.readthedocs.io/en/stable/derivatives/imaging.html#discrete-segmentations) section:

![image](https://github.com/bids-standard/bids-specification/assets/871137/d2c4982e-2541-4e57-8cd0-aa0829185c45)
