### PR TITLE
FIX: Declare context definition to be JSON schema, fix validation errors

### DIFF
--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -51,7 +51,13 @@
           "additionalProperties": false
         },
         "context": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "context": {
+              "description": "The context object is itself JSON schema",
+              "$ref": "http://json-schema.org/draft-07/schema#"
+            }
+          }
         },
         "expression_tests": {
           "type": "array",

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -337,15 +337,15 @@ context:
         PhysicalSizeX:
           name: 'PhysicalSizeX'
           description: 'Pixels / @PhysicalSizeX'
-          type: float
+          type: number
         PhysicalSizeY:
           name: 'PhysicalSizeY'
           description: 'Pixels / @PhysicalSizeY'
-          type: float
+          type: number
         PhysicalSizeZ:
           name: 'PhysicalSizeZ'
           description: 'Pixels / @PhysicalSizeZ'
-          type: float
+          type: number
         PhysicalSizeXUnit:
           name: 'PhysicalSizeXUnit'
           description: 'Pixels / @PhysicalSizeXUnit'

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -94,7 +94,7 @@ context:
       type: string
     size:
       description: 'Length of the current file in bytes'
-      type: int
+      type: integer
     entities:
       description: 'Entities parsed from the current filename'
       type: object
@@ -366,4 +366,4 @@ context:
         version:
           name: 'Version'
           description: 'TIFF file format version (the second 2-byte block)'
-          type: int
+          type: integer


### PR DESCRIPTION
`meta.context.context` is a JSON schema document embedded in the BIDS schema. This establishes that in `metaschema.json` and resolves the bugs that would have been discovered sooner if we had done this.