### PR TITLE
rf(metaschema): Validate object definitions that are JSON schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,8 @@ repos:
           - types-PyYAML
           - types-tabulate
           - types-jsonschema
+          - jsonschema
+          - httpx
         args: ["tools/schemacode/bidsschematools"]
         pass_filenames: false
   - repo: https://github.com/koalaman/shellcheck-precommit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,16 @@ repos:
       - id: check-ast
       - id: check-added-large-files
       - id: check-case-conflict
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.0
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows
+        args: ["--verbose"]
+      - id: check-metaschema
+        files: src/metaschema.json
+      - id: check-readthedocs
+        files: readthedocs.yml
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:

--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -199,6 +199,7 @@
             "allOf": [
               { "$ref": "#/definitions/generalTerm" },
               {
+                "type": "object",
                 "properties": {
                   "pattern": {
                     "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/pattern"
@@ -219,6 +220,7 @@
                 { "$ref": "#/definitions/generalTerm" },
                 { "$ref": "#/definitions/nameValueTerm" },
                 {
+                  "type": "object",
                   "properties": {
                     "recommended": {
                       "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/required"
@@ -250,6 +252,7 @@
                 { "$ref": "#/definitions/generalTerm" },
                 { "$ref": "#/definitions/valueTerm" },
                 {
+                  "type": "object",
                   "properties": {
                     "unit": { "type": "string" },
                     "anyOf": {

--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -98,9 +98,7 @@
                 "type": {
                   "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
                 },
-                "format": {
-                  "type": "string"
-                },
+                "format": { "$ref": "#/definitions/formats" },
                 "pattern": {
                   "type": "string"
                 },
@@ -185,9 +183,7 @@
                 "type": {
                   "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
                 },
-                "format": {
-                  "type": "string"
-                },
+                "format": { "$ref": "#/definitions/formats" },
                 "enum": {
                   "type": "array"
                 }
@@ -280,25 +276,22 @@
         },
         "formats": {
           "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "pattern": {
-                  "format": "regex"
-                }
+          "propertyNames": { "$ref": "#/definitions/formats" },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "display_name": {
+                "type": "string"
               },
-              "required": ["display_name", "description", "pattern"],
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
+              "description": {
+                "type": "string"
+              },
+              "pattern": {
+                "format": "regex"
+              }
+            },
+            "required": ["display_name", "description", "pattern"]
+          }
         },
         "metadata": {
           "type": "object",
@@ -605,6 +598,30 @@
   "required": ["meta", "objects", "rules", "bids_version", "schema_version"],
   "additionalProperties": false,
   "definitions": {
+    "formats": {
+      "$comment": "Formats whose patterns are defined in BIDS schema",
+      "type": "string",
+      "enum": [
+        "index",
+        "label",
+        "boolean",
+        "integer",
+        "number",
+        "string",
+        "hed_version",
+        "bids_uri",
+        "dataset_relative",
+        "date",
+        "datetime",
+        "file_relative",
+        "participant_relative",
+        "rrid",
+        "stimuli_relative",
+        "time",
+        "unit",
+        "uri"
+      ]
+    },
     "entities": {
       "type": "object",
       "patternProperties": {

--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -84,42 +84,19 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "type": {
-                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
-                },
-                "format": { "$ref": "#/definitions/formats" },
-                "pattern": {
-                  "type": "string"
-                },
-                "unit": {
-                  "type": "string"
-                },
-                "enum": {
-                  "type": "array"
-                },
-                "anyOf": {
-                  "$ref": "https://json-schema.org/draft/2020-12/meta/applicator#/properties/anyOf"
-                },
-                "maximum": {
-                  "type": "number"
-                },
-                "minimum": {
-                  "type": "number"
+              "allOf": [
+                { "$ref": "#/definitions/schemaTerm" },
+                { "$ref": "#/definitions/generalTerm" },
+                { "$ref": "#/definitions/nameValueTerm" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "format": { "$ref": "#/definitions/formats" },
+                    "unit": { "type": "string" }
+                  }
                 }
-              },
-              "required": ["name", "display_name"],
-              "additionalProperties": false
+              ],
+              "unevaluatedProperties": false
             }
           },
           "additionalProperties": false
@@ -128,17 +105,8 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
-              },
-              "required": ["display_name", "description"],
-              "additionalProperties": false
+              "$ref": "#/definitions/generalTerm",
+              "unevaluatedProperties": false
             },
             "additionalProperties": false
           }
@@ -147,20 +115,11 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
-              },
-              "required": ["value", "display_name", "description"],
-              "additionalProperties": false
+              "allOf": [
+                { "$ref": "#/definitions/generalTerm" },
+                { "$ref": "#/definitions/valueTerm" }
+              ],
+              "unevaluatedProperties": false
             }
           },
           "additionalProperties": false
@@ -169,33 +128,19 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "type": {
-                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
-                },
-                "format": { "$ref": "#/definitions/formats" },
-                "enum": {
-                  "type": "array"
+              "allOf": [
+                { "$ref": "#/definitions/schemaTerm" },
+                { "$ref": "#/definitions/generalTerm" },
+                { "$ref": "#/definitions/nameValueTerm" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "format": { "$ref": "#/definitions/formats" }
+                  },
+                  "required": ["format"]
                 }
-              },
-              "required": [
-                "name",
-                "display_name",
-                "description",
-                "type",
-                "format"
               ],
-              "additionalProperties": false
+              "unevaluatedProperties": false
             }
           },
           "additionalProperties": false
@@ -203,30 +148,18 @@
         "enums": {
           "type": "object",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
-                },
-                "enum": {
-                  "type": "array"
-                },
-                "value": {
-                  "type": "string"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "tags": {
-                  "type": "array"
-                }
-              },
-              "additionalProperties": false
-            }
+            "^[a-zA-Z0-9][a-zA-Z0-9_-]*$": {
+              "allOf": [
+                { "$ref": "#/definitions/generalTerm" },
+                { "$ref": "#/definitions/valueTerm" },
+                { "properties": { "tags": { "type": "array" } } }
+              ]
+            },
+            "^_[a-zA-Z0-9_-]+$": {
+              "$ref": "https://json-schema.org/draft/2020-12/schema#",
+              "required": ["type", "enum"]
+            },
+            "unevaluatedProperties": false
           },
           "additionalProperties": false
         },
@@ -234,20 +167,11 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
-              },
-              "required": ["display_name", "description", "value"],
-              "additionalProperties": false
+              "allOf": [
+                { "$ref": "#/definitions/generalTerm" },
+                { "$ref": "#/definitions/valueTerm" }
+              ],
+              "unevaluatedProperties": false
             }
           },
           "additionalProperties": false
@@ -256,20 +180,14 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "display_name": {
-                  "type": "string"
-                },
-                "file_type": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
+              "allOf": [
+                { "$ref": "#/definitions/generalTerm" },
+                {
+                  "properties": { "file_type": { "type": "string" } },
+                  "required": ["file_type"]
                 }
-              },
-              "required": ["display_name", "file_type", "description"],
-              "additionalProperties": false
+              ],
+              "unevaluatedProperties": false
             }
           },
           "additionalProperties": false
@@ -278,41 +196,38 @@
           "type": "object",
           "propertyNames": { "$ref": "#/definitions/formats" },
           "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "display_name": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              },
-              "pattern": {
-                "format": "regex"
+            "allOf": [
+              { "$ref": "#/definitions/generalTerm" },
+              {
+                "properties": {
+                  "pattern": {
+                    "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/pattern"
+                  }
+                },
+                "required": ["pattern"]
               }
-            },
-            "required": ["display_name", "description", "pattern"]
+            ],
+            "unevaluatedProperties": false
           }
         },
         "metadata": {
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "type": {
-                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
+              "allOf": [
+                { "$ref": "#/definitions/schemaTerm" },
+                { "$ref": "#/definitions/generalTerm" },
+                { "$ref": "#/definitions/nameValueTerm" },
+                {
+                  "properties": {
+                    "recommended": {
+                      "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/required"
+                    },
+                    "unit": { "type": "string" }
+                  }
                 }
-              },
-              "required": ["name", "display_name", "description"]
+              ],
+              "unevaluatedProperties": false
             }
           },
           "additionalProperties": false
@@ -321,17 +236,8 @@
           "type": "object",
           "patternProperties": {
             "^[a-z]+$": {
-              "type": "object",
-              "properties": {
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
-              },
-              "required": ["display_name", "description"],
-              "additionalProperties": false
+              "$ref": "#/definitions/generalTerm",
+              "unevaluatedProperties": false
             }
           },
           "additionalProperties": false
@@ -340,19 +246,21 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]+$": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
+              "allOf": [
+                { "$ref": "#/definitions/generalTerm" },
+                { "$ref": "#/definitions/valueTerm" },
+                {
+                  "properties": {
+                    "unit": { "type": "string" },
+                    "anyOf": {
+                      "$ref": "https://json-schema.org/draft/2020-12/meta/applicator#/properties/anyOf"
+                    },
+                    "maxValue": { "type": "number" },
+                    "minValue": { "type": "number" }
+                  }
                 }
-              },
-              "required": ["value", "display_name", "description"]
+              ],
+              "unevaluatedProperties": false
             },
             "additionalProperties": false
           }
@@ -621,6 +529,28 @@
         "unit",
         "uri"
       ]
+    },
+    "generalTerm": {
+      "type": "object",
+      "properties": {
+        "display_name": { "type": "string" },
+        "description": { "type": "string" }
+      },
+      "required": ["display_name", "description"]
+    },
+    "schemaTerm": {
+      "$ref": "https://json-schema.org/draft/2020-12/schema#",
+      "anyOf": [{ "required": ["type"] }, { "required": ["anyOf"] }]
+    },
+    "nameValueTerm": {
+      "type": "object",
+      "properties": { "name": { "type": "string" } },
+      "required": ["name"]
+    },
+    "valueTerm": {
+      "type": "object",
+      "properties": { "value": { "type": "string" } },
+      "required": ["value"]
     },
     "entities": {
       "type": "object",

--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {
@@ -52,7 +52,7 @@
         },
         "context": {
           "description": "The context object is itself JSON schema",
-          "$ref": "http://json-schema.org/draft-07/schema#"
+          "$ref": "https://json-schema.org/draft/2020-12/schema#"
         },
         "expression_tests": {
           "type": "array",
@@ -96,7 +96,7 @@
                   "type": "string"
                 },
                 "type": {
-                  "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
                 },
                 "format": {
                   "type": "string"
@@ -111,7 +111,7 @@
                   "type": "array"
                 },
                 "anyOf": {
-                  "$ref": "http://json-schema.org/draft-07/schema#/properties/anyOf"
+                  "$ref": "https://json-schema.org/draft/2020-12/meta/applicator#/properties/anyOf"
                 },
                 "maximum": {
                   "type": "number"
@@ -183,7 +183,7 @@
                   "type": "string"
                 },
                 "type": {
-                  "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
                 },
                 "format": {
                   "type": "string"
@@ -211,7 +211,7 @@
               "type": "object",
               "properties": {
                 "type": {
-                  "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
                 },
                 "enum": {
                   "type": "array"
@@ -316,7 +316,7 @@
                   "type": "string"
                 },
                 "type": {
-                  "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+                  "$ref": "https://json-schema.org/draft/2020-12/meta/validation#/properties/type"
                 }
               },
               "required": ["name", "display_name", "description"]

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1104,8 +1104,8 @@ GeneratedBy:
   minItems: 1
   items:
     type: object
-    required_fields: [Name]
-    recommended_fields: [Version]
+    required: [Name]
+    recommended: [Version]
     properties:
       Name:
         name: Name
@@ -1136,7 +1136,7 @@ GeneratedBy:
           used to produce the dataset. Valid keys in this object include `Type`, `Tag` and
           [`URI`][uri] with [string][] values.
         type: object
-        recommended_fields:
+        recommended:
           - Type
           - Tag
           - URI
@@ -1170,7 +1170,7 @@ Genetics:
   description: |
     An object containing information about the genetics descriptor.
   type: object
-  required_fields: [Dataset]
+  required: [Dataset]
   properties:
     Dataset:
       name: Dataset
@@ -3353,7 +3353,7 @@ StimulusPresentation:
     Object containing key-value pairs related to the software used to present
     the stimuli during the experiment.
   type: object
-  recommended_fields:
+  recommended:
     - OperatingSystem
     - ScreenDistance
     - ScreenRefreshRate

--- a/tools/schemacode/bidsschematools/render/tables.py
+++ b/tools/schemacode/bidsschematools/render/tables.py
@@ -528,8 +528,8 @@ def make_subobject_table(
         The tabulated table as a Markdown string.
     """
     obj = schema.objects[object_name]
-    required_fields = set(obj.get("required_fields", ()))
-    recommended_fields = set(obj.get("recommended_fields", ()))
+    required_fields = set(obj.get("required", ()))
+    recommended_fields = set(obj.get("recommended", ()))
 
     field_info = {}
     for field in obj.properties:


### PR DESCRIPTION
`schema.objects.metadata` entries are very nearly JSON schema definitions. To allow BIDS validators to stand on the shoulders of JSON schema validators, the goal of this PR is to define them as JSON schema with extra fields. By doing so, BIDS validators can pass these directly to JSON schema validators along with the pieces of JSON objects that they are intended to validate.

In order to do this, I've tried to formalize the different "kinds" of objects (or terms) we have in composable classes.

The main change to the schema is to rename `required_fields` to `required`, which has the same meaning in JSON schema. Similarly, we update `recommended_fields` to `recommended`, although this will have no impact on validation for now.