### PR TITLE
fix(schema): Point to correct DigitizedHeadPoints definition for MEG coordsystem

### DIFF
--- a/src/schema/rules/sidecars/meg.yaml
+++ b/src/schema/rules/sidecars/meg.yaml
@@ -205,7 +205,7 @@ MEGCoordsystemDigitizedHeadPoints:
     - datatype == "meg"
     - suffix == "coordsystem"
   fields:
-    DigitizedHeadPoints: optional
+    DigitizedHeadPoints__coordsystem: optional
     DigitizedHeadPointsCoordinateSystem: optional
     DigitizedHeadPointsCoordinateUnits: optional
     DigitizedHeadPointsCoordinateSystemDescription:


### PR DESCRIPTION
Discovered when attempting to validate ds000117 using the JSON schema-snippets in `objects.metadata`. The old JSON schema also made this distinction.

xref https://github.com/bids-standard/bids-validator/pull/2020