### PR TITLE
[ENH] Add noRF and n/a ASL volume types

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -925,13 +925,13 @@ for more information on `control` and  `label`.
 
 | **volume_type** | **Definition**                                                                                                                                                                         |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| control         | The control image is acquired in the exact same way as the label image, except that the magnetization of the blood flowing into the imaging region has not been inverted.              |
-| label           | The label image is acquired in the exact same way as the control image, except that the blood magnetization flowing into the imaging region has been inverted.                         |
-| m0scan          | The M0 image is a calibration image, used to estimate the equilibrium magnetization of blood.                                                                                          |
-| deltam          | The deltaM image is a perfusion-weighted image, obtained by the subtraction of `control` - `label`.                                                                                    |
-| cbf             | The cerebral blood flow (CBF) image is produced by dividing the deltaM by the M0, quantified into `mL/100g/min` (See also [doi:10.1002/mrm.25197](https://doi.org/10.1002/mrm.25197)). |
-| noRF            | No radio frequency excitation (noRF) images are produced by disabling the radio frequency excitation, while maintaining all other parameters from the associated scan.                 |
-| n/a             | In some cases, there may be volume types that are not yet supported by BIDS, or which cannot be used by tools.                                                                         |
+| `control`       | The control image is acquired in the exact same way as the label image, except that the magnetization of the blood flowing into the imaging region has not been inverted.              |
+| `label`         | The label image is acquired in the exact same way as the control image, except that the blood magnetization flowing into the imaging region has been inverted.                         |
+| `m0scan`        | The M0 image is a calibration image, used to estimate the equilibrium magnetization of blood.                                                                                          |
+| `deltam`        | The deltaM image is a perfusion-weighted image, obtained by the subtraction of `control` - `label`.                                                                                    |
+| `cbf`           | The cerebral blood flow (CBF) image is produced by dividing the deltaM by the M0, quantified into `mL/100g/min` (See also [doi:10.1002/mrm.25197](https://doi.org/10.1002/mrm.25197)). |
+| `noRF`          | No radio frequency excitation (noRF) images are produced by disabling the radio frequency excitation, while maintaining all other parameters from the associated scan.                 |
+| `n/a`           | In some cases, there may be volume types that are not yet supported by BIDS, or which cannot be used by tools.                                                                         |
 
 If the `control` and `label` images are not available,
 their derivative `deltam` should be stored within the `*_asl.nii[.gz]`

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -930,6 +930,8 @@ for more information on `control` and  `label`.
 | m0scan          | The M0 image is a calibration image, used to estimate the equilibrium magnetization of blood.                                                                                          |
 | deltam          | The deltaM image is a perfusion-weighted image, obtained by the subtraction of `control` - `label`.                                                                                    |
 | cbf             | The cerebral blood flow (CBF) image is produced by dividing the deltaM by the M0, quantified into `mL/100g/min` (See also [doi:10.1002/mrm.25197](https://doi.org/10.1002/mrm.25197)). |
+| noRF            | No radio frequency excitation (noRF) images are produced by disabling the radio frequency excitation, while maintaining all other parameters from the associated scan.                 |
+| n/a             | In some cases, there may be volume types that are not yet supported by BIDS, or which cannot be used by tools.                                                                         |
 
 If the `control` and `label` images are not available,
 their derivative `deltam` should be stored within the `*_asl.nii[.gz]`

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -756,7 +756,6 @@ volume_type:
     - $ref: objects.enums.deltam.value
     - $ref: objects.enums.cbf.value
     - $ref: objects.enums.noRF.value
-    - n/a
 wavelength_nominal:
   name: wavelength_nominal
   display_name: Wavelength nominal

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -755,6 +755,8 @@ volume_type:
     - $ref: objects.enums.m0scan.value
     - $ref: objects.enums.deltam.value
     - $ref: objects.enums.cbf.value
+    - $ref: objects.enums.noRF.value
+    - n/a
 wavelength_nominal:
   name: wavelength_nominal
   display_name: Wavelength nominal

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1235,27 +1235,45 @@ control:
   value: control
   display_name: control
   description: |
-    An ASL volume type: control
+    An ASL volume type: control.
+    The control image is acquired in the exact same way as the label image,
+    except that the magnetization of the blood flowing into the imaging region has not been inverted.
 label:
   value: label
   display_name: label
   description: |
-    An ASL volume type: label
+    An ASL volume type: label.
+    The label image is acquired in the exact same way as the control image,
+    except that the blood magnetization flowing into the imaging region has been inverted.
 m0scan:
   value: m0scan
   display_name: m0scan
   description: |
-    An ASL volume type: m0scan
+    An ASL volume type: m0scan.
+    The M0 image is a calibration image, used to estimate the equilibrium magnetization of blood.
+    These volumes may optionally be separated into a separate file with the ``m0scan`` suffix.
 deltam:
   value: deltam
   display_name: deltam
   description: |
-    An ASL volume type: deltam
+    An ASL volume type: deltam.
+    The deltaM image is a perfusion-weighted image, obtained by the subtraction of `control` - `label`.
 cbf:
   value: cbf
   display_name: cbf
   description: |
-    An ASL volume type: cbf
+    An ASL volume type: cbf.
+    The cerebral blood flow (CBF) image is produced by dividing the deltaM by the M0,
+    quantified into `mL/100g/min` (See also [doi:10.1002/mrm.25197](https://doi.org/10.1002/mrm.25197)).
+noRF:
+  value: noRF
+  display_name: noRF
+  description: |
+    An ASL volume type: noRF.
+    The no radio frequency excitation (noRF) image is a noise scan acquired by disabling the
+    radio frequency excitation,
+    while maintaining all other parameters from the associated scan.
+    These volumes may optionally be separated into a separate file with the ``noRF`` suffix.
 single_coil:
   value: single-coil
   display_name: single-coil

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2614,12 +2614,12 @@ PostLabelingDelay:
     `InversionTime`.
   anyOf:
     - type: number
-      exclusiveMinimum: 0
+      minimum: 0
       unit: s
     - type: array
       items:
         type: number
-        exclusiveMinimum: 0
+        minimum: 0
         unit: s
 PowerLineFrequency:
   name: PowerLineFrequency

--- a/src/schema/rules/files/raw/perf.yaml
+++ b/src/schema/rules/files/raw/perf.yaml
@@ -16,6 +16,8 @@ asl:
     reconstruction: optional
     direction: optional
     run: optional
+    echo: optional
+    part: optional
 
 aslcontext:
   suffixes:
@@ -49,9 +51,9 @@ asllabeling:
     run: optional
 
 norf:
-  $ref: rules.files.raw.perf.func
+  $ref: rules.files.raw.perf.asl
   suffixes:
     - noRF
   entities:
-    $ref: rules.files.raw.perf.func.entities
+    $ref: rules.files.raw.perf.asl.entities
     modality: optional

--- a/src/schema/rules/files/raw/perf.yaml
+++ b/src/schema/rules/files/raw/perf.yaml
@@ -47,3 +47,11 @@ asllabeling:
     acquisition: optional
     reconstruction: optional
     run: optional
+
+norf:
+  $ref: rules.files.raw.perf.func
+  suffixes:
+    - noRF
+  entities:
+    $ref: rules.files.raw.perf.func.entities
+    modality: optional


### PR DESCRIPTION
Closes #1762, but does not fully describe control-like "dummy" scans.

Changes proposed:

- Allow `noRF` and `n/a` as allowed `volume_type` values in aslcontext files.
- Allow `noRF` as a suffix for perfusion data.
- Allow `echo` and `part` entities for `_asl` and `_m0scan` files.