### PR TITLE
feat(schema): Improve type annotations of schema.context

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -18,6 +18,7 @@
 #
 ---
 type: object
+additionalProperties: false
 properties:
   schema:
     description: 'The BIDS specification schema'
@@ -25,6 +26,7 @@ properties:
   dataset:
     description: 'Properties and contents of the entire dataset'
     type: object
+    additionalProperties: false
     properties:
       dataset_description:
         description: 'Contents of /dataset_description.json'
@@ -44,6 +46,7 @@ properties:
       subjects:
         description: 'Collections of subjects in dataset'
         type: object
+        additionalProperties: false
         properties:
           sub_dirs:
             description: 'Subjects as determined by sub-*/ directories'
@@ -63,10 +66,12 @@ properties:
   subject:
     description: 'Properties and contents of the current subject'
     type: object
+    additionalProperties: false
     properties:
       sessions:
         description: 'Collections of sessions in subject'
         type: object
+        additionalProperties: false
         properties:
           ses_dirs:
             description: 'Sessions as determined by ses-*/ directories'
@@ -117,10 +122,12 @@ properties:
     description: |
       Associated files, indexed by suffix, selected according to the inheritance principle
     type: object
+    additionalProperties: false
     properties:
       events:
         description: 'Events file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated events file'
@@ -133,6 +140,7 @@ properties:
       aslcontext:
         description: 'ASL context file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated aslcontext file'
@@ -148,6 +156,7 @@ properties:
       m0scan:
         description: 'M0 scan file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated M0 scan file'
@@ -155,6 +164,7 @@ properties:
       magnitude:
         description: 'Magnitude image file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated magnitude file'
@@ -162,6 +172,7 @@ properties:
       magnitude1:
         description: 'Magnitude1 image file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated magnitude1 file'
@@ -169,6 +180,7 @@ properties:
       bval:
         description: 'B value file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated bval file'
@@ -187,6 +199,7 @@ properties:
       bvec:
         description: 'B vector file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated bvec file'
@@ -200,6 +213,7 @@ properties:
       channels:
         description: 'Channels file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated channels file'
@@ -222,6 +236,7 @@ properties:
       coordsystem:
         description: 'Coordinate system file'
         type: object
+        additionalProperties: false
         properties:
           path:
             description: 'Path to associated coordsystem file'
@@ -238,6 +253,7 @@ properties:
   gzip:
     description: 'Parsed contents of gzip header'
     type: object
+    additionalProperties: false
     properties:
       timestamp:
         description: 'Modification time, unix timestamp'
@@ -252,11 +268,13 @@ properties:
     name: 'NIfTI Header'
     description: 'Parsed contents of NIfTI header referenced elsewhere in schema.'
     type: object
+    additionalProperties: false
     properties:
       dim_info:
         name: 'Dimension Information'
         description: 'Metadata about dimensions data.'
         type: object
+        additionalProperties: false
         properties:
           freq:
             name: 'Frequency'
@@ -306,6 +324,7 @@ properties:
         name: 'XYZT Units'
         description: 'Units of pixdim[1..4]'
         type: object
+        additionalProperties: false
         properties:
           xyz:
             name: 'XYZ Units'
@@ -339,6 +358,7 @@ properties:
     name: 'Open Microscopy Environment fields'
     description: 'Parsed contents of OME-XML header, which may be found in OME-TIFF or OME-ZARR files'
     type: object
+    additionalProperties: false
     properties:
       PhysicalSizeX:
         name: 'PhysicalSizeX'
@@ -368,6 +388,7 @@ properties:
     name: 'TIFF'
     description: 'TIFF file format metadata'
     type: object
+    additionalProperties: false
     properties:
       version:
         name: 'Version'

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -52,12 +52,18 @@ properties:
       ignored:
         description: 'Set of ignored files'
         type: array
+        items:
+          type: string
       datatypes:
         description: 'Data types present in the dataset'
         type: array
+        items:
+          type: string
       modalities:
         description: 'Modalities present in the dataset'
         type: array
+        items:
+          type: string
       subjects:
         description: 'Collections of subjects in dataset'
         type: object
@@ -120,6 +126,8 @@ properties:
   entities:
     description: 'Entities parsed from the current filename'
     type: object
+    additionalProperties:
+      type: string
   datatype:
     description: 'Datatype of current file, for examples, anat'
     type: string
@@ -277,6 +285,8 @@ properties:
     type: object
     additionalProperties:
       type: array
+      items:
+        type: string
   json:
     description: 'Contents of the current JSON file'
     type: object

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -21,7 +21,6 @@ type: object
 required:
   - schema
   - dataset
-  - subject
   - path
   - size
   - sidecar

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -18,6 +18,14 @@
 #
 ---
 type: object
+required:
+  - schema
+  - dataset
+  - subject
+  - path
+  - size
+  - sidecar
+  - associations
 additionalProperties: false
 properties:
   schema:
@@ -26,6 +34,13 @@ properties:
   dataset:
     description: 'Properties and contents of the entire dataset'
     type: object
+    required:
+      - dataset_description
+      - tree
+      - ignored
+      - datatypes
+      - modalities
+      - subjects
     additionalProperties: false
     properties:
       dataset_description:
@@ -46,6 +61,8 @@ properties:
       subjects:
         description: 'Collections of subjects in dataset'
         type: object
+        required:
+          - sub_dirs
         additionalProperties: false
         properties:
           sub_dirs:
@@ -66,11 +83,15 @@ properties:
   subject:
     description: 'Properties and contents of the current subject'
     type: object
+    required:
+      - sessions
     additionalProperties: false
     properties:
       sessions:
         description: 'Collections of sessions in subject'
         type: object
+        required:
+          - ses_dirs
         additionalProperties: false
         properties:
           ses_dirs:
@@ -127,6 +148,7 @@ properties:
       events:
         description: 'Events file'
         type: object
+        required: [path, onset]
         additionalProperties: false
         properties:
           path:
@@ -140,6 +162,7 @@ properties:
       aslcontext:
         description: 'ASL context file'
         type: object
+        required: [path, n_rows, volume_type]
         additionalProperties: false
         properties:
           path:
@@ -156,6 +179,7 @@ properties:
       m0scan:
         description: 'M0 scan file'
         type: object
+        required: [path]
         additionalProperties: false
         properties:
           path:
@@ -164,6 +188,7 @@ properties:
       magnitude:
         description: 'Magnitude image file'
         type: object
+        required: [path]
         additionalProperties: false
         properties:
           path:
@@ -172,6 +197,7 @@ properties:
       magnitude1:
         description: 'Magnitude1 image file'
         type: object
+        required: [path]
         additionalProperties: false
         properties:
           path:
@@ -180,6 +206,7 @@ properties:
       bval:
         description: 'B value file'
         type: object
+        required: [path, n_cols, n_rows, values]
         additionalProperties: false
         properties:
           path:
@@ -199,6 +226,7 @@ properties:
       bvec:
         description: 'B vector file'
         type: object
+        required: [path, n_cols, n_rows]
         additionalProperties: false
         properties:
           path:
@@ -213,6 +241,7 @@ properties:
       channels:
         description: 'Channels file'
         type: object
+        required: [path, type]
         additionalProperties: false
         properties:
           path:
@@ -236,6 +265,7 @@ properties:
       coordsystem:
         description: 'Coordinate system file'
         type: object
+        required: [path]
         additionalProperties: false
         properties:
           path:
@@ -253,6 +283,7 @@ properties:
   gzip:
     description: 'Parsed contents of gzip header'
     type: object
+    required: [timestamp, filename]
     additionalProperties: false
     properties:
       timestamp:
@@ -268,12 +299,22 @@ properties:
     name: 'NIfTI Header'
     description: 'Parsed contents of NIfTI header referenced elsewhere in schema.'
     type: object
+    required:
+      - dim_info
+      - dim
+      - pixdim
+      - shape
+      - voxel_sizes
+      - xyzt_units
+      - qform_code
+      - sform_code
     additionalProperties: false
     properties:
       dim_info:
         name: 'Dimension Information'
         description: 'Metadata about dimensions data.'
         type: object
+        required: [freq, phase, slice]
         additionalProperties: false
         properties:
           freq:
@@ -324,6 +365,7 @@ properties:
         name: 'XYZT Units'
         description: 'Units of pixdim[1..4]'
         type: object
+        required: [xyz, t]
         additionalProperties: false
         properties:
           xyz:
@@ -388,6 +430,8 @@ properties:
     name: 'TIFF'
     description: 'TIFF file format metadata'
     type: object
+    required:
+      - version
     additionalProperties: false
     properties:
       version:


### PR DESCRIPTION
This is intended to give better guidance to tooling that would auto-generate classes or interfaces for the validation context.

For example, we can run:

<details><summary><code>bst export | jq .meta.context | npx quicktype --src-lang schema --lang ts -t Context --just-types</code></summary>

```typescript
export interface Context {
    /**
     * Associated files, indexed by suffix, selected according to the inheritance principle
     */
    associations: Associations;
    /**
     * TSV columns, indexed by column header, values are arrays with column contents
     */
    columns?: { [key: string]: string[] };
    /**
     * Properties and contents of the entire dataset
     */
    dataset: Dataset;
    /**
     * Datatype of current file, for examples, anat
     */
    datatype?: string;
    /**
     * Entities parsed from the current filename
     */
    entities?: { [key: string]: string };
    /**
     * Extension of current file including initial dot
     */
    extension?: string;
    /**
     * Parsed contents of gzip header
     */
    gzip?: Gzip;
    /**
     * Contents of the current JSON file
     */
    json?: { [key: string]: any };
    /**
     * Modality of current file, for examples, MRI
     */
    modality?: string;
    /**
     * Parsed contents of NIfTI header referenced elsewhere in schema.
     */
    nifti_header?: NiftiHeader;
    /**
     * Parsed contents of OME-XML header, which may be found in OME-TIFF or OME-ZARR files
     */
    ome?: Ome;
    /**
     * Path of the current file
     */
    path: string;
    /**
     * The BIDS specification schema
     */
    schema: { [key: string]: any };
    /**
     * Sidecar metadata constructed via the inheritance principle
     */
    sidecar: { [key: string]: any };
    /**
     * Length of the current file in bytes
     */
    size: number;
    /**
     * Properties and contents of the current subject
     */
    subject: Subject;
    /**
     * Suffix of current file
     */
    suffix?: string;
    /**
     * TIFF file format metadata
     */
    tiff?: Tiff;
}

/**
 * Associated files, indexed by suffix, selected according to the inheritance principle
 */
export interface Associations {
    /**
     * ASL context file
     */
    aslcontext?: Aslcontext;
    /**
     * B value file
     */
    bval?: Bval;
    /**
     * B vector file
     */
    bvec?: Bvec;
    /**
     * Channels file
     */
    channels?: Channels;
    /**
     * Coordinate system file
     */
    coordsystem?: Coordsystem;
    /**
     * Events file
     */
    events?: Events;
    /**
     * M0 scan file
     */
    m0scan?: M0Scan;
    /**
     * Magnitude image file
     */
    magnitude?: Magnitude;
    /**
     * Magnitude1 image file
     */
    magnitude1?: Magnitude1;
}

/**
 * ASL context file
 */
export interface Aslcontext {
    /**
     * Number of rows in aslcontext.tsv
     */
    n_rows: number;
    /**
     * Path to associated aslcontext file
     */
    path: string;
    /**
     * Contents of the volume_type column
     */
    volume_type: string[];
}

/**
 * B value file
 */
export interface Bval {
    /**
     * Number of columns in bval file
     */
    n_cols: number;
    /**
     * Number of rows in bval file
     */
    n_rows: number;
    /**
     * Path to associated bval file
     */
    path: string;
    /**
     * B-values contained in bval file
     */
    values: number[];
}

/**
 * B vector file
 */
export interface Bvec {
    /**
     * Number of columns in bvec file
     */
    n_cols: number;
    /**
     * Number of rows in bvec file
     */
    n_rows: number;
    /**
     * Path to associated bvec file
     */
    path: string;
}

/**
 * Channels file
 */
export interface Channels {
    /**
     * Path to associated channels file
     */
    path: string;
    /**
     * Contents of the type column
     */
    type: string[];
}

/**
 * Coordinate system file
 */
export interface Coordsystem {
    /**
     * Path to associated coordsystem file
     */
    path: string;
}

/**
 * Events file
 */
export interface Events {
    /**
     * Contents of the onset column
     */
    onset: string[];
    /**
     * Path to associated events file
     */
    path: string;
}

/**
 * M0 scan file
 */
export interface M0Scan {
    /**
     * Path to associated M0 scan file
     */
    path: string;
}

/**
 * Magnitude image file
 */
export interface Magnitude {
    /**
     * Path to associated magnitude file
     */
    path: string;
}

/**
 * Magnitude1 image file
 */
export interface Magnitude1 {
    /**
     * Path to associated magnitude1 file
     */
    path: string;
}

/**
 * Properties and contents of the entire dataset
 */
export interface Dataset {
    /**
     * Contents of /dataset_description.json
     */
    dataset_description: { [key: string]: any };
    /**
     * Data types present in the dataset
     */
    datatypes: string[];
    /**
     * Set of ignored files
     */
    ignored: string[];
    /**
     * Modalities present in the dataset
     */
    modalities: string[];
    /**
     * Collections of subjects in dataset
     */
    subjects: Subjects;
    /**
     * Tree view of all files in dataset
     */
    tree: { [key: string]: any };
}

/**
 * Collections of subjects in dataset
 */
export interface Subjects {
    /**
     * The participant_id column of participants.tsv
     */
    participant_id?: string[];
    /**
     * The union of participant_id columns in phenotype files
     */
    phenotype?: string[];
    /**
     * Subjects as determined by sub-*/ directories
     */
    sub_dirs: string[];
}

/**
 * Parsed contents of gzip header
 */
export interface Gzip {
    /**
     * Comment
     */
    comment?: string;
    /**
     * Filename
     */
    filename: string;
    /**
     * Modification time, unix timestamp
     */
    timestamp: number;
}

/**
 * Parsed contents of NIfTI header referenced elsewhere in schema.
 */
export interface NiftiHeader {
    /**
     * Data seq dimensions.
     */
    dim: number[];
    /**
     * Metadata about dimensions data.
     */
    dim_info: DimInfo;
    /**
     * Grid spacings (unit per dimension).
     */
    pixdim: number[];
    /**
     * Use of the quaternion fields.
     */
    qform_code: number;
    /**
     * Use of the affine fields.
     */
    sform_code: number;
    /**
     * Data array shape, equal to dim[1:dim[0] + 1]
     */
    shape: number[];
    /**
     * Voxel sizes, equal to pixdim[1:dim[0] + 1]
     */
    voxel_sizes: number[];
    /**
     * Units of pixdim[1..4]
     */
    xyzt_units: XyztUnits;
}

/**
 * Metadata about dimensions data.
 */
export interface DimInfo {
    /**
     * These fields encode which spatial dimension (1, 2, or 3).
     */
    freq: number;
    /**
     * Corresponds to which acquisition dimension for MRI data.
     */
    phase: number;
    /**
     * Slice dimensions.
     */
    slice: number;
}

/**
 * Units of pixdim[1..4]
 */
export interface XyztUnits {
    /**
     * String representing the unit of inter-volume intervals.
     */
    t: T;
    /**
     * String representing the unit of voxel spacing.
     */
    xyz: Xyz;
}

/**
 * String representing the unit of inter-volume intervals.
 */
export enum T {
    Msec = "msec",
    SEC = "sec",
    Unknown = "unknown",
    Usec = "usec",
}

/**
 * String representing the unit of voxel spacing.
 */
export enum Xyz {
    Meter = "meter",
    Mm = "mm",
    Um = "um",
    Unknown = "unknown",
}

/**
 * Parsed contents of OME-XML header, which may be found in OME-TIFF or OME-ZARR files
 */
export interface Ome {
    /**
     * Pixels / @PhysicalSizeX
     */
    PhysicalSizeX?: number;
    /**
     * Pixels / @PhysicalSizeXUnit
     */
    PhysicalSizeXUnit?: string;
    /**
     * Pixels / @PhysicalSizeY
     */
    PhysicalSizeY?: number;
    /**
     * Pixels / @PhysicalSizeYUnit
     */
    PhysicalSizeYUnit?: string;
    /**
     * Pixels / @PhysicalSizeZ
     */
    PhysicalSizeZ?: number;
    /**
     * Pixels / @PhysicalSizeZUnit
     */
    PhysicalSizeZUnit?: string;
}

/**
 * Properties and contents of the current subject
 */
export interface Subject {
    /**
     * Collections of sessions in subject
     */
    sessions: Sessions;
}

/**
 * Collections of sessions in subject
 */
export interface Sessions {
    /**
     * The union of session_id columns in phenotype files
     */
    phenotype?: string[];
    /**
     * Sessions as determined by ses-*/ directories
     */
    ses_dirs: string[];
    /**
     * The session_id column of sessions.tsv
     */
    session_id?: string[];
}

/**
 * TIFF file format metadata
 */
export interface Tiff {
    /**
     * TIFF file format version (the second 2-byte block)
     */
    version: number;
}
```

</details>

Without this patch, most of these interfaces get `[property: string]: any;` as well, e.g.,

```typescript
export interface Tiff {
    /**
     * TIFF file format version (the second 2-byte block)
     */
    version?: number;
    [property: string]: any;
}
```