### PR TITLE
[FIX] Allow (but discourage) task, acquisition and run entities for coordsystem.json and electrodes.tsv

### DIFF
--- a/src/modality-specific-files/electroencephalography.md
+++ b/src/modality-specific-files/electroencephalography.md
@@ -439,6 +439,12 @@ landmarks or fiducials during an EEG session/run, must be stored separately in
 the corresponding `*_T1w.json` or `*_T2w.json` file and should be expressed in
 voxels (starting from `[0, 0, 0]`).
 
+`*_coordsystem.json` files SHOULD NOT be duplicated for each data file,
+for example, across multiple tasks.
+The [inheritance principle](../common-principles.md#the-inheritance-principle) MUST
+be used to find the appropriate coordinate system description for a given data file.
+If electrodes are repositioned, it is RECOMMENDED to use multiple sessions to indicate this.
+
 ### Example `*_coordsystem.json`
 
 ```JSON

--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -403,6 +403,12 @@ A guide for using macros can be found at
 -->
 {{ MACROS___make_json_table("json.ieeg.iEEGCoordsystemPositions") }}
 
+`*_coordsystem.json` files SHOULD NOT be duplicated for each data file,
+for example, across multiple tasks.
+The [inheritance principle](../common-principles.md#the-inheritance-principle) MUST
+be used to find the appropriate coordinate system description for a given data file.
+If electrodes are repositioned, it is RECOMMENDED to use multiple sessions to indicate this.
+
 ### Recommended 3D coordinate systems
 
 It is preferred that electrodes are localized in a 3D coordinate system (with

--- a/src/modality-specific-files/magnetoencephalography.md
+++ b/src/modality-specific-files/magnetoencephalography.md
@@ -429,6 +429,11 @@ For more information on typical coordinate systems for MEG-MRI coregistration:
 or:
 [Coordinate Systems - Brainstorm toolbox](https://neuroimage.usc.edu/brainstorm/CoordinateSystems)
 
+`*_coordsystem.json` files SHOULD NOT be duplicated for each data file,
+for example, across multiple tasks.
+The [inheritance principle](../common-principles.md#the-inheritance-principle) MUST
+be used to find the appropriate coordinate system description for a given data file.
+
 ## Landmark photos (`*_photo.<extension>`)
 
 Photos of the anatomical landmarks and/or head localization coils

--- a/src/modality-specific-files/near-infrared-spectroscopy.md
+++ b/src/modality-specific-files/near-infrared-spectroscopy.md
@@ -427,6 +427,12 @@ A guide for using macros can be found at
 
 {{ MACROS___make_json_table(["json.nirs.AnatomicalLandmark", "json.nirs.AnatomicalLandmarkCoordinateSystemDescriptionRec"]) }}
 
+`*_coordsystem.json` files SHOULD NOT be duplicated for each data file,
+for example, across multiple tasks.
+The [inheritance principle](../common-principles.md#the-inheritance-principle) MUST
+be used to find the appropriate coordinate system description for a given data file.
+If optodes are repositioned, it is RECOMMENDED to use multiple sessions to indicate this.
+
 ### Example `*_coordsystem.json`
 
 ```json

--- a/src/schema/rules/checks/channels.yaml
+++ b/src/schema/rules/checks/channels.yaml
@@ -13,3 +13,17 @@ ElectrodeSpecificity:
   checks:
     - '!("run" in entities)'
     - '!("acquisition" in entities)'
+
+CoordsystemSpecificity:
+  issue:
+    code: EXCESSIVE_COORDSYSTEM_SPECIFICITY
+    message: |
+      Task entities detected in coordsystem.tsv.
+      Coordinate systems should generally not vary by task.
+      Consider removing the excess entity.
+    level: warning
+  selectors:
+    - suffix == 'coordsystem'
+    - extension == '.json'
+  checks:
+    - '!("task" in entities)'

--- a/src/schema/rules/checks/channels.yaml
+++ b/src/schema/rules/checks/channels.yaml
@@ -3,27 +3,32 @@ ElectrodeSpecificity:
   issue:
     code: EXCESSIVE_ELECTRODE_SPECIFICITY
     message: |
-      Run or acquisition entities detected in electrodes.tsv.
+      Task, acquisition or run entities detected in electrodes.tsv.
       Electrode definitions should generally not vary within a session.
-      Consider creating a new session each time electrodes are reconfigured.
+      Consider removing the excess entity/entities or create a new
+      session each time electrodes are reconfigured.
     level: warning
   selectors:
     - suffix == 'electrodes'
     - extension == '.tsv'
   checks:
-    - '!("run" in entities)'
+    - '!("task" in entities)'
     - '!("acquisition" in entities)'
+    - '!("run" in entities)'
 
 CoordsystemSpecificity:
   issue:
     code: EXCESSIVE_COORDSYSTEM_SPECIFICITY
     message: |
-      Task entities detected in coordsystem.tsv.
-      Coordinate systems should generally not vary by task.
-      Consider removing the excess entity.
+      Task, acquisition or run entities detected in coordsystem.tsv.
+      Coordinate systems should generally not vary within a session.
+      Consider removing the excess entity/entities or create new
+      sessions when multiple coordinate systems are appropriate.
     level: warning
   selectors:
     - suffix == 'coordsystem'
     - extension == '.json'
   checks:
     - '!("task" in entities)'
+    - '!("acquisition" in entities)'
+    - '!("run" in entities)'

--- a/src/schema/rules/files/raw/channels.yaml
+++ b/src/schema/rules/files/raw/channels.yaml
@@ -45,6 +45,7 @@ coordsystem:
   entities:
     subject: required
     session: optional
+    task: optional
     acquisition: optional
 
 # (i)EEG has a space entity

--- a/src/schema/rules/files/raw/channels.yaml
+++ b/src/schema/rules/files/raw/channels.yaml
@@ -70,6 +70,7 @@ electrodes:
   entities:
     subject: required
     session: optional
+    task: optional
     acquisition: optional
     run: optional
     space: optional


### PR DESCRIPTION
We've run into a situation where the regular validator regular expressions were written more laxly than the specification, leading to datasets that use entities that are against the spec but perfectly interpretable. In particular, the `task` entity has been permitted for `coordsystem.json` across EEG, iEEG, MEG and NIRS.

Following the pattern established in #1722, instead of marking these datasets invalid with a schema-based validator, we relax the spec but add warnings.

cc @bids-standard/raw-electrophys and @rob-luke @lpollonini (we should make a NIRS team...).