### PR TITLE
[ENH] Clarify that electrodes.tsv are REQUIRED for iEEG data

### DIFF
--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -17,6 +17,12 @@
                 "target": {
                   "type": "object",
                   "properties": {
+                    "entities": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "suffix": {
                       "type": "string"
                     },
@@ -498,7 +504,7 @@
       "required": [
         "entities",
         "files",
-	"json",
+        "json",
         "sidecars",
         "tabular_data",
         "metaentities",

--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -296,11 +296,11 @@ and a guide for using macros can be found at
 -->
 {{ MACROS___make_filename_template("raw", datatypes=["ieeg"], suffixes=["electrodes"]) }}
 
-File that gives the location, size and other properties of iEEG electrodes. Note
-that coordinates are expected in cartesian coordinates according to the
-`iEEGCoordinateSystem` and `iEEGCoordinateUnits` fields in
-`*_coordsystem.json`. If an `*_electrodes.tsv` file is specified, a
-`*_coordsystem.json` file MUST be specified as well.
+This REQUIRED file gives the location, size and other properties of iEEG electrodes.
+Note that coordinates are expected in cartesian coordinates according to the
+`iEEGCoordinateSystem` and `iEEGCoordinateUnits` fields in `*_coordsystem.json`.
+For each `*_electrodes.tsv` file specified,
+a `*_coordsystem.json` file MUST be specified as well.
 
 The optional [`space-<label>`](../appendices/entities.md#space) entity (`*[_space-<label>]_electrodes.tsv`) can be used to
 indicate the way in which electrode positions are interpreted.

--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -90,3 +90,14 @@ coordsystem:
     suffix: coordsystem
     extension: .json
   inherit: true
+
+electrodes:
+  selectors:
+    - intersects([suffix], ['eeg', 'ieeg', 'meg'])
+    - extension != '.json'
+  target:
+    suffix: electrodes
+    extension: .tsv
+    entities:
+      - space
+  inherit: true

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -259,6 +259,15 @@ properties:
             type: array
             items:
               type: string
+      electrodes:
+        description: 'Electrodes file'
+        type: object
+        required: [path]
+        additionalProperties: false
+        properties:
+          path:
+            description: 'Path to associated electrodes.tsv file'
+            type: string
       coordsystem:
         description: 'Coordinate system file'
         type: object

--- a/src/schema/rules/checks/channels.yaml
+++ b/src/schema/rules/checks/channels.yaml
@@ -32,3 +32,15 @@ CoordsystemSpecificity:
     - '!("task" in entities)'
     - '!("acquisition" in entities)'
     - '!("run" in entities)'
+
+RequiredCoordsystem:
+  issue:
+    code: REQUIRED_COORDSYSTEM
+    message: |
+      If an electrodes.tsv file is provided, an associated coordsystem.json must also be present.
+    level: error
+  selectors:
+    - suffix == "electrodes"
+    - extension == ".tsv"
+  checks:
+    - associations.coordsystem != null

--- a/src/schema/rules/checks/ieeg.yaml
+++ b/src/schema/rules/checks/ieeg.yaml
@@ -1,0 +1,14 @@
+---
+iEEGElectrodesRequired:
+  issue:
+    code: IEEG_ELECTRODES_REQUIRED
+    message: |
+      iEEG data files must have an associated electrodes.tsv.
+      A single electrodes file may apply to multiple data files
+      via the inheritance principle.
+    level: error
+  selectors:
+    - suffix == "ieeg"
+    - extension != ".json"
+  checks:
+    - associations.electrodes.path != ""


### PR DESCRIPTION
The original iEEG spec intended electrodes.tsv to be REQUIRED, but the language was unintentionally softened during the inclusion in BIDS. This PR clarifies the language, and adds a validation rule to enforce the presence of electrodes.tsv files. Paired with https://github.com/bids-standard/bids-validator/pull/207, this will support detecting multiple electrodes.tsv files that are distinguished by the `space-<label>` entity.

This PR also adds a check that each electrodes.tsv file has a corresponding coordsystem.json file. This was already enforced for optodes.tsv in NIRS datasets, but was missing for electrodes.tsv in *EG datasets.

This follows extensive discussion in https://github.com/bids-standard/bids-validator/issues/206.

Closes https://github.com/bids-standard/bids-specification/issues/1854.