### PR TITLE
[INFRA] Publish schema to Javascript Registry (https://jsr.io/@bids/schema) on changes and releases

### DIFF
--- a/.github/workflows/publish_schema.yml
+++ b/.github/workflows/publish_schema.yml
@@ -1,0 +1,83 @@
+name: "Publish schema"
+
+on:
+  push:
+    branches:
+      - "master"
+      - "jsr/*"
+    tags:
+      - "schema-*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  GIT_AUTHOR_NAME: BIDS CI
+  GIT_AUTHOR_EMAIL: bids.maintenance@gmail.com
+  GIT_COMMITTER_NAME: BIDS CI
+  GIT_COMMITTER_EMAIL: bids.maintenance@gmail.com
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3
+      - name: Install bidsschematools
+        run: |
+          pip install --upgrade tools/schemacode
+          git clean -fxd tools/schemacode
+      - name: Checkout jsr-dist
+        run: |
+          git fetch --depth=1 origin jsr-dist
+          git checkout -t origin/jsr-dist
+      - name: Regenerate schema
+        run: bst export > schema.json
+      - name: Regenerate context types
+        run: |
+          jq .meta.context schema.json \
+          | npx quicktype --src-lang schema --lang ts -t Context --just-types \
+          > context.ts
+      - name: Regenerate metaschema types
+        run: |
+          # Name the file schema so the type will be named Schema
+          bst export-metaschema > /tmp/schema.json
+          npx --package=json-schema-to-typescript json2ts --unknownAny /tmp/schema.json > metaschema.ts
+      - name: Determine next version
+        run: |
+          BASE=$( jq -r .schema_version schema.json )
+          if [[ "$BASE" =~ ^[0-9]*.[0-9]*.[0-9]*$ ]]; then
+            # Release, so unconditionally update version
+            VERSION=$BASE
+            jq ".version = \"$VERSION\"" jsr.json > tmp.json && mv tmp.json jsr.json
+          else
+            DENOVER=$( jq -r .version jsr.json )
+            # Should switch to using the commit hash of the source repo?
+            HASH=$( sha256sum schema.json | head -c 7 )
+            if [[ $DENOVER =~ ^"$BASE".[0-9] ]]; then
+              PREFIX=${DENOVER%+*}
+              let SERIAL=1+${PREFIX#$BASE.}
+            else
+              SERIAL=1
+            fi
+            VERSION="$BASE.$SERIAL+$HASH"
+          fi
+          echo VERSION=$VERSION | tee -a $GITHUB_ENV
+      - name: Check for changes, set version and commit
+        run: |
+          if ! git diff -s --exit-code; then
+            jq ".version = \"$VERSION\"" jsr.json > tmp.json && mv tmp.json jsr.json
+            git add jsr.json schema.json context.ts metaschema.ts
+            git commit -m "Update schema JSR distribution"
+          fi
+      - name: Publish to JSR
+        if: success()
+        run: |
+          npx jsr publish --dry-run

--- a/.github/workflows/publish_schema.yml
+++ b/.github/workflows/publish_schema.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "jsr/*"
     tags:
       - "schema-*"
 
@@ -21,6 +20,10 @@ env:
   GIT_AUTHOR_EMAIL: bids.maintenance@gmail.com
   GIT_COMMITTER_NAME: BIDS CI
   GIT_COMMITTER_EMAIL: bids.maintenance@gmail.com
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -80,8 +83,9 @@ jobs:
             jq ".version = \"$VERSION\"" jsr.json > tmp.json && mv tmp.json jsr.json
             git add jsr.json schema.json context.ts metaschema.ts
             git commit -m "Update schema JSR distribution"
+            git push
           fi
       - name: Publish to JSR
         if: success()
         run: |
-          npx jsr publish --dry-run
+          npx jsr publish

--- a/.github/workflows/publish_schema.yml
+++ b/.github/workflows/publish_schema.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: "blob:none"
       - uses: actions/setup-python@v5
         with:
           python-version: 3
@@ -36,7 +39,6 @@ jobs:
           git clean -fxd tools/schemacode
       - name: Checkout jsr-dist
         run: |
-          git fetch --depth=1 origin jsr-dist
           git checkout -t origin/jsr-dist
       - name: Regenerate schema
         run: bst export > schema.json
@@ -59,8 +61,8 @@ jobs:
             jq ".version = \"$VERSION\"" jsr.json > tmp.json && mv tmp.json jsr.json
           else
             DENOVER=$( jq -r .version jsr.json )
-            # Should switch to using the commit hash of the source repo?
-            HASH=$( sha256sum schema.json | head -c 7 )
+            # Get the reference of the latest commit to touch the schema directory
+            HASH=$( git log -n 1 --pretty=%h $REF -- src/schema )
             if [[ $DENOVER =~ ^"$BASE".[0-9] ]]; then
               PREFIX=${DENOVER%+*}
               let SERIAL=1+${PREFIX#$BASE.}
@@ -70,6 +72,8 @@ jobs:
             VERSION="$BASE.$SERIAL+$HASH"
           fi
           echo VERSION=$VERSION | tee -a $GITHUB_ENV
+        env:
+          REF: ${{ github.ref }}
       - name: Check for changes, set version and commit
         run: |
           if ! git diff -s --exit-code; then

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -71,7 +71,7 @@ properties:
         additionalProperties: false
         properties:
           sub_dirs:
-            description: 'Subjects as determined by sub-*/ directories'
+            description: 'Subjects as determined by sub-* directories'
             type: array
             items:
               type: string
@@ -100,7 +100,7 @@ properties:
         additionalProperties: false
         properties:
           ses_dirs:
-            description: 'Sessions as determined by ses-*/ directories'
+            description: 'Sessions as determined by ses-* directories'
             type: array
             items:
               type: string

--- a/tools/schemacode/bidsschematools/__main__.py
+++ b/tools/schemacode/bidsschematools/__main__.py
@@ -1,7 +1,14 @@
 import logging
 import os
+import sys
 
 import click
+
+if sys.version_info < (3, 9):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
+
 
 from .schema import export_schema, load_schema
 
@@ -30,6 +37,20 @@ def export(ctx, schema, output):
         logger.debug(f"Writing to {output}")
         with open(output, "w") as fobj:
             fobj.write(text)
+
+
+@cli.command()
+@click.option("--output", default="-")
+@click.pass_context
+def export_metaschema(ctx, output):
+    """Export BIDS schema to JSON document"""
+    metaschema = files("bidsschematools.data").joinpath("metaschema.json").read_text()
+    if output == "-":
+        print(metaschema, end="")
+    else:
+        output = os.path.abspath(output)
+        with open(output, "w") as fobj:
+            fobj.write(metaschema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a GitHub action that will push dev versions and release versions to https://jsr.io/@bids/schema.

I have been testing this for use in the BIDS validator. Currently we are able to load the [schema](https://jsr.io/@bids/schema/0.0.202408200837/schema.json) from the registry via:

```typescript
import { default as schema } from 'jsr:@bids/schema@0.0.202408200837/schema' with { type: 'json' }
```

We are also able to load the type of the schema with:

```typescript
import type { Metaschema } from 'jsr:@bids/schema@0.0.202408200837/metaschema'
import type { Context }  from 'jsr:@bids/schema@0.0.202408200837/context'
```

The version scheme will be `{schema.schema_version}` if the version is a full release (X.Y.Z), and `{schema.schema_version}.{serial}+{hash}` for development versions.

The serial number is purely to ensure that development versions of the schema can be ordered, and is derived by parsing the previous version. The purpose of the hash is to help make clear when the content of the schema changes. It currently uses `sha256sum schema.json | head -c 7`, but I think a more useful hash would probably be the latest commit to touch the schema: `git log -n 1 --pretty=%h src/schema/`.

---

This PR incidentally changes the name of the `Metaschema` type to just `Schema`, so `schema` will have type `Schema`.