### PR TITLE
[ENH] Add volspace entity for CIFTI files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,5 +16,5 @@
 /src/derivatives/diffusion-derivatives.md @francopestilli @oesteban @Lestropie
 
 # The schema
-/src/schema/ @tsalo @erdalkaraca
-/tools/schemacode/ @tsalo @erdalkaraca
+/src/schema/ @erdalkaraca
+/tools/schemacode/ @erdalkaraca

--- a/src/derivatives/imaging.md
+++ b/src/derivatives/imaging.md
@@ -11,7 +11,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         <datatype>/
-            <source_entities>[_space-<space>][_res-<label>][_den-<label>][_desc-<label>]_<suffix>.<extension>
+            <source_entities>[_space-<space>][_volspace-<space>][_res-<label>][_den-<label>][_desc-<label>]_<suffix>.<extension>
 ```
 
 Volumetric preprocessing does not modify the number of dimensions, and so
@@ -113,11 +113,11 @@ A guide for using macros can be found at
     "pipeline1": {
         "sub-001": {
             "func": {
-                "sub-001_task-rest_run-1_space-fsLR_res-1_den-10k_bold.dtseries.nii": "",
-                "sub-001_task-rest_run-1_space-fsLR_res-1_den-41k_bold.dtseries.nii": "",
-                "sub-001_task-rest_run-1_space-fsLR_res-2_den-10k_bold.dtseries.nii": "",
-                "sub-001_task-rest_run-1_space-fsLR_res-2_den-41k_bold.dtseries.nii": "",
-                "sub-001_task-rest_run-1_space-fsLR_bold.json": "",
+                "sub-001_task-rest_run-1_space-fsLR_volspace-MNI152NLin6Asym_res-1_den-10k_bold.dtseries.nii": "",
+                "sub-001_task-rest_run-1_space-fsLR_volspace-MNI152NLin6Asym_res-1_den-41k_bold.dtseries.nii": "",
+                "sub-001_task-rest_run-1_space-fsLR_volspace-MNI152NLin6Asym_res-2_den-10k_bold.dtseries.nii": "",
+                "sub-001_task-rest_run-1_space-fsLR_volspace-MNI152NLin6Asym_res-2_den-41k_bold.dtseries.nii": "",
+                "sub-001_task-rest_run-1_space-fsLR_volspace-MNI152NLin6Asym_bold.json": "",
                 },
             },
         }
@@ -265,7 +265,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         anat|func|dwi/
-            <source_entities>[_space-<space>][_seg-<label>][_res-<label>][_den-<label>]_dseg.nii.gz
+            <source_entities>[_space-<space>][_seg-<label>][_res-<label>]_dseg.nii.gz
 ```
 
 Example:
@@ -329,7 +329,7 @@ Template:
 <pipeline_name>/
     sub-<label>/
         func|anat|dwi/
-            <source_entities>[_space-<space>][_seg-<label>][_res-<label>][_den-<label>][_label-<label>]_probseg.nii.gz
+            <source_entities>[_space-<space>][_seg-<label>][_res-<label>][_label-<label>]_probseg.nii.gz
 ```
 
 Example:
@@ -403,7 +403,8 @@ Template:
 <pipeline_name>/
     sub-<label>/
         anat/
-            <source_entities>[_hemi-{L|R}][_space-<space>][_seg-<label>][_res-<label>][_den-<label>]_dseg.{label.gii|dlabel.nii}
+            <source_entities>[_hemi-{L|R}][_space-<space>][_seg-<label>][_den-<label>]_dseg.{label.gii}
+            <source_entities>[_hemi-{L|R}][_space-<space>][_volspace-<space>][_seg-<label>][_res-<label>][_den-<label>]_dseg.{dlabel.nii}
 ```
 
 The [`hemi-<label>`](../appendices/entities.md#hemi) entity is REQUIRED for GIFTI files storing information about

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -431,3 +431,5 @@ volspace:
     has been aligned.
     The `<label>` MUST be taken from one of the modality specific lists in the
     [Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md).
+  type: string
+  format: label

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -422,3 +422,12 @@ tracksys:
     may be longer and more human readable.
   type: string
   format: label
+volspace:
+  name: volspace
+  display_name: Volumetric Space
+  description: |
+    The `volspace-<label>` entity can be used to indicate the spatial reference to which
+    the volumetric component of a combined surface-volume file (for example, a CIFTI file)
+    has been aligned.
+    The `<label>` MUST be taken from one of the modality specific lists in the
+    [Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md).

--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -4,6 +4,7 @@ anat_parametric_volumetric:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -13,6 +14,7 @@ anat_nonparametric_volumetric:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -22,6 +24,7 @@ dwi_volumetric:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -31,6 +34,7 @@ dwi_isotropic:
   entities:
     $ref: rules.files.raw.dwi.isotropic.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -40,6 +44,7 @@ func_volumetric:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -51,6 +56,7 @@ anat_parametric_mask:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -63,6 +69,7 @@ anat_nonparametric_mask:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -75,6 +82,7 @@ dwi_mask:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -87,6 +95,7 @@ func_mask:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -99,6 +108,7 @@ anat_parametric_discrete_segmentation:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -115,6 +125,7 @@ anat_nonparametric_discrete_segmentation:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -131,6 +142,7 @@ func_discrete_segmentation:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -142,6 +154,7 @@ dwi_discrete_segmentation:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -153,6 +166,7 @@ anat_parametric_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -165,6 +179,7 @@ anat_nonparametric_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -177,6 +192,7 @@ func_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -189,6 +205,7 @@ dwi_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -207,6 +224,7 @@ anat_parametic_discrete_surface:
     $ref: rules.files.raw.anat.parametric.entities
     hemisphere: optional
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -224,6 +242,7 @@ anat_nonparametic_discrete_surface:
     $ref: rules.files.raw.anat.nonparametric.entities
     hemisphere: optional
     space: optional
+		volspace: optional
     resolution: optional
     density: optional
     description: optional

--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -4,7 +4,7 @@ anat_parametric_volumetric:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -14,7 +14,7 @@ anat_nonparametric_volumetric:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -24,7 +24,7 @@ dwi_volumetric:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -34,7 +34,7 @@ dwi_isotropic:
   entities:
     $ref: rules.files.raw.dwi.isotropic.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -44,7 +44,7 @@ func_volumetric:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -56,7 +56,7 @@ anat_parametric_mask:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -69,7 +69,7 @@ anat_nonparametric_mask:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -82,7 +82,7 @@ dwi_mask:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -95,7 +95,7 @@ func_mask:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -108,7 +108,7 @@ anat_parametric_discrete_segmentation:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -125,7 +125,7 @@ anat_nonparametric_discrete_segmentation:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -142,7 +142,7 @@ func_discrete_segmentation:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -154,7 +154,7 @@ dwi_discrete_segmentation:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -166,7 +166,7 @@ anat_parametric_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.anat.parametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -179,7 +179,7 @@ anat_nonparametric_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.anat.nonparametric.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -192,7 +192,7 @@ func_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.func.func.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -205,7 +205,7 @@ dwi_probabilistic_segmentation:
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     label: optional
@@ -224,7 +224,7 @@ anat_parametic_discrete_surface:
     $ref: rules.files.raw.anat.parametric.entities
     hemisphere: optional
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional
@@ -242,7 +242,7 @@ anat_nonparametic_discrete_surface:
     $ref: rules.files.raw.anat.nonparametric.entities
     hemisphere: optional
     space: optional
-		volspace: optional
+    volspace: optional
     resolution: optional
     density: optional
     description: optional


### PR DESCRIPTION
This PR adds a `volspace` entity to describe the volumetric space in combined surface-volume derivative files (i.e., CIFTIs). The volspace entity comes from BEP011: Structural derivatives (#518).