### PR TITLE
fix(schema): Remove SLICE_TIMING_AND_DURATION_MUTUALLY_EXCLUSIVE

### DIFF
--- a/src/schema/rules/checks/func.yaml
+++ b/src/schema/rules/checks/func.yaml
@@ -117,19 +117,6 @@ VolumeTimingDelayTimeMutex:
   checks:
     - type(sidecar.DelayTime) == "null"
 
-SliceTimingAcquisitionDurationMutex:
-  issue:
-    code: SLICE_TIMING_AND_DURATION_MUTUALLY_EXCLUSIVE
-    message: |
-      'SliceTiming' is defined for this file.
-      Neither 'DelayTime' nor 'AcquisitionDuration' may be defined in addition.
-    level: error
-  selectors:
-    - type(sidecar.SliceTiming) != "null"
-  checks:
-    - type(sidecar.AcquisitionDuration) == "null"
-    - type(sidecar.DelayTime) == "null"
-
 VolumeTimingMissingAcquisitionDuration:
   issue:
     code: VOLUME_TIMING_MISSING_ACQUISITION_DURATION


### PR DESCRIPTION
This rule goes counter to the table in https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#timing-parameters_1.