### PR TITLE
[ENH] Provide baseline definition for behavioral files

### DIFF
--- a/src/modality-specific-files/behavioral-experiments.md
+++ b/src/modality-specific-files/behavioral-experiments.md
@@ -30,6 +30,16 @@ that do not include the mandatory `onset` and `duration` columns
 MAY be included,
 but MUST be labeled `_beh.tsv` rather than `_events.tsv`.
 
+The following OPTIONAL columns are pre-defined for behavioral data files:
+
+<!-- This block generates a columns table.
+The definitions of these fields can be found in
+  src/schema/rules/tabular_data/*.yaml
+and a guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_columns_table("task.Behavioral") }}
+
 ## Sidecar JSON (`*_beh.json`)
 
 In addition to the metadata that is either:

--- a/src/schema/rules/tabular_data/task.yaml
+++ b/src/schema/rules/tabular_data/task.yaml
@@ -19,3 +19,13 @@ TaskEvents:
   initial_columns:
     - onset
     - duration
+
+Behavioral:
+  selectors:
+    - suffix == "beh"
+  columns:
+    trial_type: optional
+    response_time: optional
+    HED: optional
+    stim_file: optional
+  additional_columns: allowed


### PR DESCRIPTION
Part two of resolving https://github.com/bids-standard/bids-validator/issues/1376. Also provides a starting point for behavioral files, instead of being purely free-form. If someone's going to use columns that are defined for `events.tsv`, they should mean the same thing in `beh.tsv`.