### PR TITLE
[FIX] Define a metadata table for TB1EPI

### DIFF
--- a/src/appendices/qmri.md
+++ b/src/appendices/qmri.md
@@ -607,10 +607,15 @@ The nominal FA value of the SE pulse is twice this value.
 Note that the following metadata fields MUST be defined in the accompanying JSON
 files:
 
-| **Field name**     | **Definition**                                                                                                                                 |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TotalReadoutTime` | The effective readout length defined as `EffectiveEchoSpacing * PEReconMatrix`, with `EffectiveEchoSpacing = TrueEchoSpacing / PEacceleration` |
-| `MixingTime`       | Time interval between the SE and STE pulses                                                                                                    |
+<!-- This block generates a metadata table.
+These tables are defined in
+  src/schema/rules/sidecars
+The definitions of the fields specified in these tables may be found in
+  src/schema/objects/metadata.yaml
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_sidecar_table("fmap.TB1EPI") }}
 
 To properly identify constituents of this particular method, values of the `echo`
 entity MUST index the images as follows:

--- a/src/appendices/units.md
+++ b/src/appendices/units.md
@@ -83,30 +83,51 @@ Examples for CMIXF-12 (including the five unicode symbols mentioned above):
 
 ### Multiples
 
-| **Prefix name**                             | **Prefix symbol** | **Factor**      |
-| ------------------------------------------- | ----------------- | --------------- |
-| [deca](https://www.wikiwand.com/en/Deca-)   | da                | 10<sup>1</sup>  |
-| [hecto](https://www.wikiwand.com/en/Hecto-) | h                 | 10<sup>2</sup>  |
-| [kilo](https://www.wikiwand.com/en/Kilo-)   | k                 | 10<sup>3</sup>  |
-| [mega](https://www.wikiwand.com/en/Mega-)   | M                 | 10<sup>6</sup>  |
-| [giga](https://www.wikiwand.com/en/Giga-)   | G                 | 10<sup>9</sup>  |
-| [tera](https://www.wikiwand.com/en/Tera-)   | T                 | 10<sup>12</sup> |
-| [peta](https://www.wikiwand.com/en/Peta-)   | P                 | 10<sup>15</sup> |
-| [exa](https://www.wikiwand.com/en/Exa-)     | E                 | 10<sup>18</sup> |
-| [zetta](https://www.wikiwand.com/en/Zetta-) | Z                 | 10<sup>21</sup> |
-| [yotta](https://www.wikiwand.com/en/Yotta-) | Y                 | 10<sup>24</sup> |
+| **Prefix name** | **Prefix symbol** | **Factor**      |
+| --------------- | ----------------- | --------------- |
+| [deca][]        | da                | 10<sup>1</sup>  |
+| [hecto][]       | h                 | 10<sup>2</sup>  |
+| [kilo][]        | k                 | 10<sup>3</sup>  |
+| [mega][]        | M                 | 10<sup>6</sup>  |
+| [giga][]        | G                 | 10<sup>9</sup>  |
+| [tera][]        | T                 | 10<sup>12</sup> |
+| [peta][]        | P                 | 10<sup>15</sup> |
+| [exa][]         | E                 | 10<sup>18</sup> |
+| [zetta][]       | Z                 | 10<sup>21</sup> |
+| [yotta][]       | Y                 | 10<sup>24</sup> |
 
 ### Submultiples
 
-| **Prefix name**                             | **Prefix symbol** | **Factor**       |
-| ------------------------------------------- | ----------------- | ---------------- |
-| [deci](https://www.wikiwand.com/en/Deci-)   | d                 | 10<sup>-1</sup>  |
-| [centi](https://www.wikiwand.com/en/Centi-) | c                 | 10<sup>-2</sup>  |
-| [milli](https://www.wikiwand.com/en/Milli-) | m                 | 10<sup>-3</sup>  |
-| [micro](https://www.wikiwand.com/en/Micro-) | u                 | 10<sup>-6</sup>  |
-| [nano](https://www.wikiwand.com/en/Nano-)   | n                 | 10<sup>-9</sup>  |
-| [pico](https://www.wikiwand.com/en/Pico-)   | p                 | 10<sup>-12</sup> |
-| [femto](https://www.wikiwand.com/en/Femto-) | f                 | 10<sup>-15</sup> |
-| [atto](https://www.wikiwand.com/en/Atto-)   | a                 | 10<sup>-18</sup> |
-| [zepto](https://www.wikiwand.com/en/Zepto-) | z                 | 10<sup>-21</sup> |
-| [yocto](https://www.wikiwand.com/en/Yocto-) | y                 | 10<sup>-24</sup> |
+| **Prefix name** | **Prefix symbol** | **Factor**       |
+| --------------- | ----------------- | ---------------- |
+| [deci][]        | d                 | 10<sup>-1</sup>  |
+| [centi][]       | c                 | 10<sup>-2</sup>  |
+| [milli][]       | m                 | 10<sup>-3</sup>  |
+| [micro][]       | u                 | 10<sup>-6</sup>  |
+| [nano][]        | n                 | 10<sup>-9</sup>  |
+| [pico][]        | p                 | 10<sup>-12</sup> |
+| [femto][]       | f                 | 10<sup>-15</sup> |
+| [atto][]        | a                 | 10<sup>-18</sup> |
+| [zepto][]       | z                 | 10<sup>-21</sup> |
+| [yocto][]       | y                 | 10<sup>-24</sup> |
+
+[deca]: https://en.wikipedia.org/wiki/Deca-
+[hecto]: https://en.wikipedia.org/wiki/Hecto-
+[kilo]: https://en.wikipedia.org/wiki/Kilo-
+[mega]: https://en.wikipedia.org/wiki/Mega-
+[giga]: https://en.wikipedia.org/wiki/Giga-
+[tera]: https://en.wikipedia.org/wiki/Tera-
+[peta]: https://en.wikipedia.org/wiki/Peta-
+[exa]: https://en.wikipedia.org/wiki/Exa-
+[zetta]: https://en.wikipedia.org/wiki/Zetta-
+[yotta]: https://en.wikipedia.org/wiki/Yotta-
+[deci]: https://en.wikipedia.org/wiki/Deci-
+[centi]: https://en.wikipedia.org/wiki/Centi-
+[milli]: https://en.wikipedia.org/wiki/Milli-
+[micro]: https://en.wikipedia.org/wiki/Micro-
+[nano]: https://en.wikipedia.org/wiki/Nano-
+[pico]: https://en.wikipedia.org/wiki/Pico-
+[femto]: https://en.wikipedia.org/wiki/Femto-
+[atto]: https://en.wikipedia.org/wiki/Atto-
+[zepto]: https://en.wikipedia.org/wiki/Zepto-
+[yocto]: https://en.wikipedia.org/wiki/Yocto-

--- a/src/schema/rules/sidecars/fmap.yaml
+++ b/src/schema/rules/sidecars/fmap.yaml
@@ -69,3 +69,13 @@ MRIFieldmapPepolar:
   fields:
     PhaseEncodingDirection: required
     TotalReadoutTime: required
+
+TB1EPI:
+  selectors:
+    - datatype == "fmap"
+    - suffix == "TB1EPI"
+  fields:
+    EchoTime: required
+    FlipAngle: required
+    TotalReadoutTime: required
+    MixingTime: required


### PR DESCRIPTION
This PR resolves #1351 by drawing the TotalReadoutTime and MixingTime definitions from the schema. I followed the table in https://bids-specification.readthedocs.io/en/latest/appendices/qmri.html#field-maps to determine the required metadata.