### PR TITLE
Revert "[ENH] Specify the naming of scanner-generated TRACE and ADC volumes"

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -660,18 +660,13 @@ The definitions of these fields can be found in
 and a guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
-{{ MACROS___make_suffix_table(["dwi", "sbref"]) }}
-
-Additionally, the following suffixes are used for scanner-generated images:
-
-<!--
-This block generates a suffix table.
-The definitions of these fields can be found in
-  src/schema/rules/files/raw
-and a guide for using macros can be found at
- https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
--->
-{{ MACROS___make_suffix_table(["ADC", "TRACE"]) }}
+{{ MACROS___make_suffix_table(
+      [
+         "dwi",
+         "sbref",
+      ]
+   )
+}}
 
 <!--
 This block generates a filename templates.
@@ -699,13 +694,6 @@ In such a case, two files could have the following names:
 `sub-01_acq-singleband_dwi.nii.gz` and `sub-01_acq-multiband_dwi.nii.gz`.
 The user is free to choose any other label than `singleband` and
 `multiband`, as long as they are consistent across subjects and sessions.
-
-Scanner-generated TRACE and ADC volumes MAY be included using the
-`TRACE` and `ADC` suffixes.
-If TRACE or ADC volume filenames match a diffusion series with all applicable entities,
-such volumes SHOULD be computed from that series.
-Otherwise, some entity, such as [`acq-<label>`](../appendices/entities.md#acq),
-SHOULD be used to indicate that the files are unrelated.
 
 ### REQUIRED gradient orientation information
 

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -6,11 +6,6 @@ TwoPE:
   display_name: 2-photon excitation microscopy
   description: |
     2-photon excitation microscopy imaging data
-ADC:
-  value: ADC
-  display_name: Apparent diffusion coefficient (ADC)
-  description:
-    Apparent diffusion coefficient (ADC) map
 BF:
   value: BF
   display_name: Bright-field microscopy
@@ -465,11 +460,6 @@ TEM:
   display_name: Transmission electron microscopy
   description: |
     Transmission electron microscopy imaging data
-TRACE:
-  value: TRACE
-  display_name: Trace diffusion weighted image
-  description: |
-    Diffusion images proportional to the trace of the diffusion tensor
 UNIT1:
   value: UNIT1
   display_name: Homogeneous (flat) T1-weighted MP2RAGE image

--- a/src/schema/rules/files/deriv/imaging.yaml
+++ b/src/schema/rules/files/deriv/imaging.yaml
@@ -26,15 +26,6 @@ dwi_volumetric:
     density: optional
     description: optional
 
-dwi_isotropic:
-  $ref: rules.files.raw.dwi.isotropic
-  entities:
-    $ref: rules.files.raw.dwi.isotropic.entities
-    space: optional
-    resolution: optional
-    density: optional
-    description: optional
-
 func_volumetric:
   $ref: rules.files.raw.func.func
   entities:

--- a/src/schema/rules/files/raw/dwi.yaml
+++ b/src/schema/rules/files/raw/dwi.yaml
@@ -38,23 +38,3 @@ sbref:
     run: optional
     part: optional
     chunk: optional
-
-# Common scanner-generated derivatives need raw names
-isotropic:
-  suffixes:
-    - ADC
-    - TRACE
-  extensions:
-    - .nii.gz
-    - .nii
-    - .json
-  datatypes:
-    - dwi
-  entities:
-    subject: required
-    session: optional
-    acquisition: optional
-    reconstruction: optional
-    direction: optional
-    run: optional
-    chunk: optional


### PR DESCRIPTION
Reverts bids-standard/bids-specification#1725 because there is an intent to replace it with https://github.com/bids-standard/bids-specification/pull/1864.

If #1864 is not accepted in time for 1.10.0, then this will be merged so that it can come in a later release without backwards compatibility issues.