### PR TITLE
fix(schema): Update microscopy pixel size checks to account for error and OME convention

### DIFF
--- a/src/schema/rules/checks/micr.yaml
+++ b/src/schema/rules/checks/micr.yaml
@@ -12,15 +12,32 @@ PixelSizeInconsistent:
     - sidecar.PixelSize != null
     - sidecar.PixelSizeUnits != null
   checks:
+    # Note that OME-XML uses µm for microns and BIDS uses um
+    # Accept an error up to .001 of the BIDS unit, to account for floating point error
     - |
-      ome.PhysicalSizeX * 10 ** (-3 * index(["mm", "um", "nm"], ome.PhysicalSizeXUnit))
-      == sidecar.PixelSize[0] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      ome.PhysicalSizeX * 10 ** (-3 * index(["mm", "µm", "nm"], ome.PhysicalSizeXUnit))
+      - sidecar.PixelSize[0] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      < 0.001 * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
     - |
-      ome.PhysicalSizeY * 10 ** (-3 * index(["mm", "um", "nm"], ome.PhysicalSizeYUnit))
-      == sidecar.PixelSize[1] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      sidecar.PixelSize[0] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      - ome.PhysicalSizeX * 10 ** (-3 * index(["mm", "µm", "nm"], ome.PhysicalSizeXUnit))
+      < 0.001 * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
     - |
-      ome.PhysicalSizeZ * 10 ** (-3 * index(["mm", "um", "nm"], ome.PhysicalSizeZUnit))
-      == sidecar.PixelSize[2] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      ome.PhysicalSizeY * 10 ** (-3 * index(["mm", "µm", "nm"], ome.PhysicalSizeYUnit))
+      - sidecar.PixelSize[1] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      < 0.001 * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+    - |
+      sidecar.PixelSize[1] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      - ome.PhysicalSizeY * 10 ** (-3 * index(["mm", "µm", "nm"], ome.PhysicalSizeYUnit))
+      < 0.001 * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+    - |
+      ome.PhysicalSizeZ * 10 ** (-3 * index(["mm", "µm", "nm"], ome.PhysicalSizeZUnit))
+      - sidecar.PixelSize[2] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      < 0.001 * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+    - |
+      sidecar.PixelSize[2] * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
+      - ome.PhysicalSizeZ * 10 ** (-3 * index(["mm", "µm", "nm"], ome.PhysicalSizeZUnit))
+      < 0.001 * 10 ** (-3 * index(["mm", "um", "nm"], sidecar.PixelSizeUnits))
 
 # 227
 InconsistentTiffExtension:


### PR DESCRIPTION
@Remi-Gau's fix of our typo'd metadata field revealed an error in the PixelSizeInconsistent check. The main error is that OME-XML uses µm instead of um. I went ahead and also permitted some error to account for inconsistent serialization/floating point error.