### PR TITLE
Strip possibly present trailing / (os.sep) before adding one

### DIFF
--- a/tools/examplecode/example.py
+++ b/tools/examplecode/example.py
@@ -69,7 +69,7 @@ class _TreeGenerator:
 
         # We are dealing with a directory
         else:
-            self._tree.append(f"{prefix}{connector} {entry}{os.sep}")
+            self._tree.append(f"{prefix}{connector} {entry.rstrip(os.sep)}{os.sep}")
             prefix += (
                 self.PIPE_PREFIX if index != entries_count - 1 else self.SPACE_PREFIX
             )

--- a/tools/examplecode/example.py
+++ b/tools/examplecode/example.py
@@ -7,7 +7,7 @@ on how to use this code.
 
 """
 
-import os
+import posixpath
 
 
 class DirectoryTree:
@@ -69,7 +69,9 @@ class _TreeGenerator:
 
         # We are dealing with a directory
         else:
-            self._tree.append(f"{prefix}{connector} {entry.rstrip(os.sep)}{os.sep}")
+            self._tree.append(
+                f"{prefix}{connector} {entry.rstrip(posixpath.sep)}{posixpath.sep}"
+            )
             prefix += (
                 self.PIPE_PREFIX if index != entries_count - 1 else self.SPACE_PREFIX
             )


### PR DESCRIPTION
Without that users must have trailing / removed, but nobody checks for that etc. So now we have "raw//" etc, e.g. at
https://bids-specification.readthedocs.io/en/latest/derivatives/common-data-types.html#example-use-of-a-descriptionstsv-file

With this change it would make it easier on user and guaranteed to render consistently correctly

- [x] Note also that we use `os.sep` there in the code making rendering dependent on OS on which it is rendered.  I will add commit to change to `posixpath.sep`.