### PR TITLE
Downgrade absence of sub- folders to warning

### DIFF
--- a/src/schema/rules/checks/dataset.yaml
+++ b/src/schema/rules/checks/dataset.yaml
@@ -7,7 +7,7 @@ SubjectFolders:
     code: SUBJECT_FOLDERS
     message: |
       There are no subject directories (labeled "sub-*") in the root of this dataset.
-    level: error
+    level: warning
   selectors:
     - path == '/dataset_description.json'
   checks:


### PR DESCRIPTION
I could be wrong but I think there is no strict and agreed upon requirement to require having sub- subfolders in BIDS specification. Although odd, thus warranting a warning, I think it is not strictly forbidden, and e.g. a BIDS dataset only with stimuli/ or derivatives/ or sourcedata might still be well legit BIDS dataset.

Check was added in b9ea963df27ded2c4363199c4c030c0229f2d1e2 likely just copying from prior node version of bids-validator.  Asking @effigies for setting me straight ;)