### PR TITLE
[SCHEMA] Fixes identified from reviewing OpenNeuro errors

### DIFF
--- a/src/schema/rules/checks/mri.yaml
+++ b/src/schema/rules/checks/mri.yaml
@@ -109,7 +109,7 @@ BolusCutOffDelayTimeNotMonotonicallyIncreasing:
     level: error
   selectors:
     - modality == "mri"
-    - sidecar.BolusCutOffDelayTime != null
+    - type(sidecar.BolusCutOffDelayTime) == 'array'
   checks:
     - allequal(sorted(sidecar.BolusCutOffDelayTime), sidecar.BolusCutOffDelayTime)
 

--- a/src/schema/rules/sidecars/entity_rules.yaml
+++ b/src/schema/rules/sidecars/entity_rules.yaml
@@ -10,7 +10,7 @@
 EntitiesTaskMetadata:
   selectors:
     - '"task" in entities'
-    - suffix != 'events'
+    - '!intersects([suffix], ["events", "channels", "markers"])'
   fields:
     TaskName: recommended
 

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -195,8 +195,9 @@ PhaseEncodingDirectionRec:
 
 PhaseEncodingDirectionReq:
   selectors:
-    - modality == "mri"
+    - datatype == "fmap"
     - suffix == "epi"
+    - match(extension, "^\.nii(\.gz)?$")
   fields:
     PhaseEncodingDirection:
       level: required
@@ -244,6 +245,7 @@ SliceTimingMRI:
   selectors:
     - modality == "mri"
     - sidecar.MRAcquisitionType == "2D"
+    - match(extension, "^\.nii(\.gz)?$")
   fields:
     SliceTiming:
       level: recommended
@@ -257,6 +259,7 @@ SliceTimingASL:
     - datatype == "perf"
     - intersects([suffix], ["asl", "m0scan"])
     - sidecar.MRAcquisitionType == "2D"
+    - match(extension, "^\.nii(\.gz)?$")
   fields:
     SliceTiming:
       level: required
@@ -288,6 +291,7 @@ MRIFlipAngleLookLockerFalse:
   selectors:
     - modality == "mri"
     - sidecar.LookLocker != true
+    - match(extension, "^\.nii(\.gz)?$")
   fields:
     FlipAngle:
       level: recommended
@@ -304,6 +308,7 @@ MRIFlipAngleLookLockerTrue:
   selectors:
     - modality == "mri"
     - sidecar.LookLocker == true
+    - match(extension, "^\.nii(\.gz)?$")
   fields:
     FlipAngle:
       level: required
@@ -377,6 +382,7 @@ MRIInstitutionInformation:
 DeidentificationMethod:
   selectors:
     - intersects([modality], ["mri", "pet"])
+    - match(extension, "^\.nii(\.gz)?$")
   fields:
     DeidentificationMethod:
       level: optional


### PR DESCRIPTION
Starting with a trigger-happy `BOLUS_CUT_OFF_DELAY_TIME_NOT_MONOTONICALLY_INCREASING`.

Fixes https://github.com/bids-standard/bids-validator/issues/2128.