### PR TITLE
Add an empty line in hope to get table rendered properly in "Ordering ..." section

### DIFF
--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -999,6 +999,7 @@ EventsMissing:
 ### One-off rules
 
 -   `rules.modalities` - The keys in this file are the modalities, the values objects with the following field:
+
     | Field       | Description                           |
     | ----------- | ------------------------------------- |
     | `datatypes` | List of datatypes mapping to modality |


### PR DESCRIPTION
Looks like some table ordering is a bit mixed up in

https://bids-specification.readthedocs.io/en/latest/schema/#ordering-rules

![Image](https://github.com/user-attachments/assets/f1beb4e3-91ce-4a12-a644-70c6616f750c)


TODO
- [x] check rendering if fixed

looks now with the fix:

![image](https://github.com/user-attachments/assets/20b3d7ea-69a7-4006-86a0-a7374720d113)

