### PR TITLE
[ENH] Allow MED format for iEEG data (`*_ieeg.medd/`)

### DIFF
--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -38,6 +38,7 @@ stored in one of the following formats:
 | [EEGLAB](https://sccn.ucsd.edu/eeglab/index.php)                          | `.set`, `.fdt`           | The format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab/index.php). Each recording consists of a `.set` file with an OPTIONAL `.fdt` file.             |
 | [Neurodata Without Borders](https://nwb-schema.readthedocs.io/en/latest/) | `.nwb`                   | Each recording consists of a single `.nwb` file.                                                                                                                           |
 | [MEF3](https://osf.io/e3sf9/)                                             | `.mefd`                  | Each recording consists of a `.mefd` directory.                                                                                                                            |
+| [MED](https://medformat.org/)                                             | `.medd`                  | Each recording consists of a `.medd` directory.                                                                                                                            |
 
 It is RECOMMENDED to use the European data format, or the BrainVision data
 format. It is furthermore discouraged to use the other accepted formats over

--- a/src/schema/objects/extensions.yaml
+++ b/src/schema/objects/extensions.yaml
@@ -153,6 +153,14 @@ md:
   display_name: Markdown
   description: |
     A Markdown file.
+medd:
+  value: .medd/
+  display_name: Multiscale Electrophysiology Data Format
+  description: |
+    A directory in the [MED](https://medformat.org/) format.
+    Successor to the MEF 3.0 format.
+
+    Each recording consists of a `.medd` directory.
 mefd:
   value: .mefd/
   display_name: Multiscale Electrophysiology File Format Version 3.0

--- a/src/schema/rules/files/raw/ieeg.yaml
+++ b/src/schema/rules/files/raw/ieeg.yaml
@@ -3,6 +3,7 @@ ieeg:
   suffixes:
     - ieeg
   extensions:
+    - .medd/
     - .mefd/
     - .json
     - .edf


### PR DESCRIPTION
Added MED format

- closes #1931 
