### PR TITLE
[SCHEMA] Allow physio files for anat datatype

### DIFF
--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -46,6 +46,7 @@ timeseries__mri_no_task:
     - .tsv.gz
     - .json
   datatypes:
+    - anat
     - dwi
     - perf
   entities:
@@ -100,6 +101,24 @@ events__mrs:
     reconstruction: optional
     nucleus: optional
     volume: optional
+
+timeseries__anat:
+  $ref: rules.files.raw.task.timeseries
+  datatypes:
+    - anat
+  entities:
+    $ref: rules.files.raw.task.timeseries.entities
+    subject: required
+    session: optional
+    task: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    run: optional
+    echo: optional
+    part: optional
+    chunk: optional
+
 
 timeseries__func:
   $ref: rules.files.raw.task.timeseries

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -110,7 +110,6 @@ timeseries__anat:
     $ref: rules.files.raw.task.timeseries.entities
     ceagent: optional
     reconstruction: optional
-    run: optional
     echo: optional
     part: optional
     chunk: optional

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -108,10 +108,6 @@ timeseries__anat:
     - anat
   entities:
     $ref: rules.files.raw.task.timeseries.entities
-    subject: required
-    session: optional
-    task: optional
-    acquisition: optional
     ceagent: optional
     reconstruction: optional
     run: optional

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -46,7 +46,6 @@ timeseries__mri_no_task:
     - .tsv.gz
     - .json
   datatypes:
-    - anat
     - dwi
     - perf
   entities:

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -113,7 +113,6 @@ timeseries__anat:
     part: optional
     chunk: optional
 
-
 timeseries__func:
   $ref: rules.files.raw.task.timeseries
   datatypes:


### PR DESCRIPTION
Issue outlined in bids-standard/bids-validator#2164

This would fail to cover echo, part, and chunk entities which are legal for anatomical images and so too would be legal in the physio filenames.