### PR TITLE
[ENH] Formalize presence of optional logs/ folder

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -387,7 +387,7 @@ Derivatives can be stored/distributed in two ways:
     that were used to generate the derivatives.
     Likewise, any code used to generate the derivatives from the source data
     MAY be included in the `code/` subdirectory.
-    Logs from running the code or other commands could be stored under `logs/` subdirectory.
+    Logs from running the code or other commands MAY be stored under `logs/` subdirectory.
 
     Example of a derivative dataset including the raw dataset as source:
 

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -387,6 +387,7 @@ Derivatives can be stored/distributed in two ways:
     that were used to generate the derivatives.
     Likewise, any code used to generate the derivatives from the source data
     MAY be included in the `code/` subdirectory.
+    Logs from running the code or other commands could be stored under `logs/` subdirectory.
 
     Example of a derivative dataset including the raw dataset as source:
 

--- a/src/schema/rules/directories.yaml
+++ b/src/schema/rules/directories.yaml
@@ -21,6 +21,7 @@ raw:
     subdirs:
       - code
       - derivatives
+      - logs
       - phenotype
       - sourcedata
       - stimuli
@@ -31,6 +32,10 @@ raw:
     opaque: true
   derivatives:
     name: derivatives
+    level: optional
+    opaque: true
+  logs:
+    name: logs
     level: optional
     opaque: true
   phenotype:
@@ -69,6 +74,7 @@ derivative:
     subdirs:
       - code
       - derivatives
+      - logs
       - phenotype
       - sourcedata
       - stimuli
@@ -79,6 +85,10 @@ derivative:
     opaque: true
   derivatives:
     name: derivatives
+    level: optional
+    opaque: true
+  logs:
+    name: logs
     level: optional
     opaque: true
   phenotype:

--- a/src/schema/rules/files/common/core.yaml
+++ b/src/schema/rules/files/common/core.yaml
@@ -31,6 +31,9 @@ code:
 derivatives:
   level: optional
   path: derivatives
+logs:
+  level: optional
+  path: logs
 sourcedata:
   level: optional
   path: sourcedata


### PR DESCRIPTION
It is quite often desired to store logs, e.g. simply stdout/stderr from invocation of BIDS converters or other tools which were used to produce/change content in current BIDS datasset.  They quite often provide ultimate provenance information to troubleshoot odd or incorrect results.  But researchers, in my personal opinion, undervalue logs!  But hinting them on "standard" location for them, I think we could inspire more of relevant to dataset provenance metadata being collected and shared.  

TODOs:
- ~~?Danger: might leak sensitive metadata, so may be wording should be adjusted to mention that they should be inspected/sensored? WDYT?~~ I think it is fine/assumed

Shameless plug: consider using con-duct (https://github.com/con/duct) for your "logging needs".

Note that I think that ideally the `logs/` should not include "derivative" data, such as e.g. output of `bids-validator`.  Those outputs should go under `derivatives/bids-validator-{version}/output.json` or alike.  (It might be the only reasonable "derivative" to recommend bundling with any "raw" or derived BIDS dataset).