### PR TITLE
[INFRA] add GA ID to mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,9 @@ extra:
       link: https://www.instagram.com/bidsstandard/
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/channel/UCxZUcYfd_nvIVWAbzRB1tlw
+  analytics:
+    provider: google
+    property: G-SBWH6YNMPX
 
 extra_javascript:
   - js/jquery-3.6.0.min.js


### PR DESCRIPTION
RTD deprecated google analytics:
https://github.com/readthedocs/readthedocs.org/issues/11707

Added GA id to mkdocs config as per:
https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/