### PR TITLE
[ENH] Update AcquisitionDuration definition to match DICOM, define FrameAcquisitionDuration for sparse sequences

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -600,13 +600,13 @@ to be populated for functional sequences. Note that all these options can be
 used for non sparse sequences but that only options B, D and E are valid for
 sparse sequences.
 
-|          | **`RepetitionTime`** | **`SliceTiming`** | **`AcquisitionDuration`** | **`DelayTime`** | **`VolumeTiming`** |
-| -------- | -------------------- | ----------------- | ------------------------- | --------------- | ------------------ |
-| option A | \[ X ]               |                   | \[ ]                      |                 | \[ ]               |
-| option B | \[ ]                 | \[ X ]            |                           | \[ ]            | \[ X ]             |
-| option C | \[ ]                 |                   | \[ X ]                    | \[ ]            | \[ X ]             |
-| option D | \[ X ]               | \[ X ]            | \[ ]                      |                 | \[ ]               |
-| option E | \[ X ]               |                   | \[ ]                      | \[ X ]          | \[ ]               |
+|          | **`RepetitionTime`** | **`SliceTiming`** | **`FrameAcquisitionDuration`** | **`DelayTime`** | **`VolumeTiming`** |
+| -------- | -------------------- | ----------------- | ------------------------------ | --------------- | ------------------ |
+| option A | \[ X ]               |                   | \[ ]                           |                 | \[ ]               |
+| option B | \[ ]                 | \[ X ]            |                                | \[ ]            | \[ X ]             |
+| option C | \[ ]                 |                   | \[ X ]                         | \[ ]            | \[ X ]             |
+| option D | \[ X ]               | \[ X ]            | \[ ]                           |                 | \[ ]               |
+| option E | \[ X ]               |                   | \[ ]                           | \[ X ]          | \[ ]               |
 
 **Legend**
 

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1197,6 +1197,15 @@ FlipAngle:
         unit: degree
         exclusiveMinimum: 0
         maximum: 360
+FrameAcquisitionDuration:
+  name: AcquisitionDuration
+  display_name: Acquisition Duration
+  description: |
+    Duration (in seconds) of volume acquisition.
+    Corresponds to DICOM Tag 0018, 9220 `Frame Acquisition Duration`.
+  type: number
+  exclusiveMinimum: 0
+  unit: s
 FrameDuration:
   name: FrameDuration
   display_name: Frame Duration

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -20,9 +20,8 @@ AcquisitionDuration:
   name: AcquisitionDuration
   display_name: Acquisition Duration
   description: |
-    Duration (in seconds) of volume acquisition.
+    Duration (in seconds) of scan acquisition, including all volumes for multi-volume scans.
     Corresponds to DICOM Tag 0018, 9073 `Acquisition Duration`.
-    This field is mutually exclusive with `"RepetitionTime"`.
   type: number
   exclusiveMinimum: 0
   unit: s

--- a/src/schema/rules/checks/func.yaml
+++ b/src/schema/rules/checks/func.yaml
@@ -94,18 +94,18 @@ VolumeTimingRepetitionTimeMutex:
   checks:
     - type(sidecar.RepetitionTime) == "null"
 
-RepetitionTimeAcquisitionDurationMutex:
+RepetitionTimeFrameAcquisitionDurationMutex:
   issue:
     code: REPETITION_TIME_AND_ACQUISITION_DURATION_MUTUALLY_EXCLUSIVE
     message: |
-      The fields 'RepetitionTime' and 'AcquisitionDuration' for this file are mutually exclusive.
+      The fields 'RepetitionTime' and 'FrameAcquisitionDuration' for this file are mutually exclusive.
       To specify acquisition duration, use 'SliceTiming' or 'DelayTime'
-      (RepetitionTime - AcquisitionDuration).
+      (RepetitionTime - FrameAcquisitionDuration).
     level: error
   selectors:
     - type(nifti_header) != "null"
     - intersects([suffix], ["asl", "bold"])
-    - type(sidecar.AcquisitionDuration) != "null"
+    - type(sidecar.FrameAcquisitionDuration) != "null"
   checks:
     - type(sidecar.RepetitionTime) == "null"
 
@@ -114,7 +114,7 @@ VolumeTimingDelayTimeMutex:
     code: VOLUME_TIMING_AND_DELAY_TIME_MUTUALLY_EXCLUSIVE
     message: |
       The fields 'VolumeTiming' and 'DelayTime' for this file are mutually exclusive.
-      To specify acquisition duration, use 'AcquisitionDuration' or 'SliceTiming'.
+      To specify acquisition duration, use 'FrameAcquisitionDuration' or 'SliceTiming'.
     level: error
   selectors:
     - type(nifti_header) != "null"
@@ -123,15 +123,15 @@ VolumeTimingDelayTimeMutex:
   checks:
     - type(sidecar.DelayTime) == "null"
 
-VolumeTimingMissingAcquisitionDuration:
+VolumeTimingMissingFrameAcquisitionDuration:
   issue:
     code: VOLUME_TIMING_MISSING_ACQUISITION_DURATION
     message: |
-      The field 'VolumeTiming' requires 'AcquisitionDuration' or 'SliceTiming' to be defined.
+      The field 'VolumeTiming' requires 'FrameAcquisitionDuration' or 'SliceTiming' to be defined.
     level: error
   selectors:
     - type(nifti_header) != "null"
     - intersects([suffix], ["asl", "bold"])
     - type(sidecar.VolumeTiming) != "null"
   checks:
-    - '"SliceTiming" in sidecar || "AcquisitionDuration" in sidecar'
+    - '"SliceTiming" in sidecar || "FrameAcquisitionDuration" in sidecar'

--- a/src/schema/rules/sidecars/func.yaml
+++ b/src/schema/rules/sidecars/func.yaml
@@ -44,7 +44,7 @@ MRIFuncVolumeTiming:
       description_addendum: |
         This field is mutually exclusive with `"DelayTime"`.
         If defined, this requires acquisition time (TA) be defined via either
-        `"SliceTiming"` or `"AcquisitionDuration"`.
+        `"SliceTiming"` or `"FrameAcquisitionDuration"`.
 
 # Timing Parameters
 MRIFuncTimingParameters:
@@ -56,7 +56,7 @@ MRIFuncTimingParameters:
     NumberOfVolumesDiscardedByScanner: recommended
     NumberOfVolumesDiscardedByUser: recommended
     DelayTime: recommended
-    AcquisitionDuration:
+    FrameAcquisitionDuration:
       level: recommended
       level_addendum: |
         required for sequences that are described with the `VolumeTiming`

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -232,6 +232,7 @@ MRITimingParameters:
         or variable echo time fMRI sequences.
     InversionTime: recommended
     DwellTime: recommended
+    AcquisitionDuration: optional
 
 EchoTimeRequiredASL:
   selectors:


### PR DESCRIPTION
This PR brings the AcquisitionDuration definition in line with DICOM and separates it from checks for sparse sequence descriptions. We already narrowed the AcquisitionDuration mutual exclusion rules to only apply to BOLD and ASL data.

This defines `FrameAcquisitionDuration`, which corresponds to [DICOM tag 0018, 9220](https://dicom.innolitics.com/ciods/enhanced-mr-image/enhanced-mr-image/00189220).

@neurolabusc I wonder if this tag is used in any of your QA datasets yet?
@Lestropie Are you okay with deferring a CT-applicable definition to when CT data is accepted in BIDS? As noted in https://github.com/bids-standard/bids-specification/issues/1906#issuecomment-2436578444, we do have mechanisms in the schema to provide multiple definitions for terms that are used in multiple contexts.

Closes #1906.

----

I would *also* like to relax the mutual exclusion constraints that are indicated in [Task Imaging Data - Timing Parameters](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#timing-parameters_1):

![image](https://github.com/user-attachments/assets/d4e75bae-ea23-4659-9b5d-d932f649d709)

Given that `RepetitionTime`, `SliceTiming` and `FrameAcquisitionDuration` could all be present in the DICOM metadata, I think a better check would be for consistency among these, instead of enforcing mutual exclusion. `DelayTime` and `VolumeTiming` cannot be derived from DICOM tags (I don't think), so I would be okay with continuing to validate mutual exclusion or to validate consistency.

`RepetitionTime` and `VolumeTiming` need to remain mutually exclusive, as they are distinct ways of declaring the onsets of each volume.

I am happy to enact this change in this PR or another, if people agree that it's worth doing.