### PR TITLE
feat(cli): Add tool for filename validation for use in pre-receive hooks

### DIFF
--- a/tools/schemacode/bidsschematools/__main__.py
+++ b/tools/schemacode/bidsschematools/__main__.py
@@ -18,9 +18,11 @@ from .validator import _bidsignore_check
 
 @click.group()
 @click.option("-v", "--verbose", count=True)
-def cli(verbose):
+@click.option("-q", "--quiet", count=True)
+def cli(verbose, quiet):
     """BIDS Schema Tools"""
-    logging.getLogger("bidsschematools").setLevel(logging.INFO - verbose * 10)
+    verbose = verbose - quiet
+    logging.getLogger("bidsschematools").setLevel(logging.WARNING - verbose * 10)
 
 
 @cli.command()

--- a/tools/schemacode/bidsschematools/__main__.py
+++ b/tools/schemacode/bidsschematools/__main__.py
@@ -136,10 +136,13 @@ def pre_receive_hook(schema, input_, output):
     dataset_type = description.get("DatasetType", "raw")
     logger.info("Dataset type: %s", dataset_type)
 
-    ignore = [line.strip() for line in stream if line != "0001\n"]
+    ignore = []
+    for line in stream:
+        if line == "0001\n":
+            break
+        ignore.append(line.strip())
     logger.info("Ignore patterns found: %d", len(ignore))
 
-    schema = load_schema(schema)
     all_rules = chain.from_iterable(
         regexify_filename_rules(group, schema, level=2)
         for group in (schema.rules.files.common, schema.rules.files.raw)

--- a/tools/schemacode/bidsschematools/__main__.py
+++ b/tools/schemacode/bidsschematools/__main__.py
@@ -1,6 +1,8 @@
 import logging
 import os
+import re
 import sys
+from itertools import chain
 
 import click
 
@@ -9,8 +11,9 @@ if sys.version_info < (3, 9):
 else:
     from importlib.resources import files
 
-
+from .rules import regexify_filename_rules
 from .schema import export_schema, load_schema
+from .validator import _bidsignore_check
 
 
 @click.group()
@@ -51,6 +54,63 @@ def export_metaschema(ctx, output):
         output = os.path.abspath(output)
         with open(output, "w") as fobj:
             fobj.write(metaschema)
+
+
+@cli.command("pre-receive-hook")
+@click.option("--schema", "-s", type=click.Path(), help="Path to the BIDS schema")
+@click.option(
+    "--input", "-i", "input_", default="-", type=click.Path(), help="Input file (default: stdin)"
+)
+@click.option(
+    "--output",
+    "-o",
+    "output",
+    default="-",
+    type=click.Path(),
+    help="Output file (default: stdout)",
+)
+def pre_receive_hook(schema, input_, output):
+    """Validate filenames from a list of files against the BIDS schema
+
+    The input should be a list of ignore patterns followed by a line containing
+    "0001" and then a list of filenames. The output will be a list of filenames
+    that do not match the schema.
+
+    This is intended to be used in a git pre-receive hook.
+    """
+    # Slurp inputs for now; we can think about streaming later
+    if input_ == "-":
+        lines = sys.stdin.readlines()
+    else:
+        with open(input_) as fobj:
+            lines = fobj.readlines()
+
+    split = lines.index("0001\n")
+    ignore = [line.rstrip() for line in lines[:split]]
+    filenames = [line.rstrip() for line in lines[split + 1 :]]
+
+    schema = load_schema(schema)
+    all_rules = chain.from_iterable(
+        regexify_filename_rules(group, schema, level=2)
+        for group in (schema.rules.files.common, schema.rules.files.raw)
+    )
+    regexes = [rule["regex"] for rule in all_rules]
+    # XXX Hack for phenotype files - this can be removed once we
+    # have a schema definition for them
+    regexes.append(r"phenotype/.*\.tsv")
+
+    output = sys.stdout if output == "-" else open(output, "w")
+
+    rc = 0
+    with output:
+        for filename in filenames:
+            if any(_bidsignore_check(pattern, filename, "") for pattern in ignore):
+                continue
+            if not any(re.match(regex, filename) for regex in regexes):
+                output.write(f"{filename}\n")
+                rc = 1
+
+    sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/tools/schemacode/bidsschematools/__main__.py
+++ b/tools/schemacode/bidsschematools/__main__.py
@@ -75,9 +75,30 @@ def export_metaschema(ctx, output):
 def pre_receive_hook(schema, input_, output):
     """Validate filenames from a list of files against the BIDS schema
 
-    The input should be a list of ignore patterns followed by a line containing
-    "0001" and then a list of filenames. The output will be a list of filenames
-    that do not match the schema.
+    The expected input takes the following form:
+
+    ```
+    bids-hook-v2
+    {"Name": "My dataset", "BIDSVersion": "1.9.0", "DatasetType": "raw"}
+    ignore-pattern1
+    ...
+    ignore-patternN
+    0001
+    .datalad/config
+    .gitattributes
+    CHANGES
+    README
+    dataset_description.json
+    participants.tsv
+    sub-01/anat/sub-01_T1w.nii.gz
+    ...
+    ```
+
+    The header identifies the protocol version. For protocol ``bids-hook-v2``,
+    the second line MUST be the dataset_description.json file, with any newlines removed.
+    The following lines, up to the line containing "0001", are ignore patterns
+    from the .bidsignore file. The lines following "0001" are the filenames to
+    be validated.
 
     This is intended to be used in a git pre-receive hook.
     """

--- a/tools/schemacode/bidsschematools/__main__.py
+++ b/tools/schemacode/bidsschematools/__main__.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -88,14 +89,30 @@ def pre_receive_hook(schema, input_, output):
             lines = fobj.readlines()
 
     split = lines.index("0001\n")
-    ignore = [line.rstrip() for line in lines[:split]]
+    preamble = [line.rstrip() for line in lines[:split]]
     filenames = [line.rstrip() for line in lines[split + 1 :]]
+    try:
+        split = preamble.index("0000")
+    except ValueError:
+        description = {}
+        ignore = preamble
+    else:
+        description = json.loads("".join(preamble[:split]))
+        ignore = preamble[split + 1 :]
+
+    dataset_type = description.get("DatasetType", "raw")
 
     schema = load_schema(schema)
     all_rules = chain.from_iterable(
         regexify_filename_rules(group, schema, level=2)
         for group in (schema.rules.files.common, schema.rules.files.raw)
     )
+    if dataset_type == "derivative":
+        all_rules = chain(
+            all_rules,
+            regexify_filename_rules(schema.rules.files.derivatives, schema, level=2),
+        )
+
     regexes = [rule["regex"] for rule in all_rules]
     # XXX Hack for phenotype files - this can be removed once we
     # have a schema definition for them

--- a/tools/schemacode/bidsschematools/utils.py
+++ b/tools/schemacode/bidsschematools/utils.py
@@ -29,7 +29,7 @@ def get_logger(name=None):
     logging.Logger
         logger object.
     """
-    return logging.getLogger("bids-schema" + (".%s" % name if name else ""))
+    return logging.getLogger("bidsschematools" + (".%s" % name if name else ""))
 
 
 def set_logger_level(lgr, level):


### PR DESCRIPTION
This is a basic validator that accepts a `.bidsignore` list and a list of files. The use case is to quickly determine if a git push should be accepted by a server.