### PR TITLE
[INFRA] Fix dicomlookup links, link consistently

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -78,7 +78,7 @@ A guide for using macros can be found at
 
 <sup>2</sup>Conveniently, for Siemens data, this value is easily obtained as
 `1 / (BWPPPE * ReconMatrixPE)`, where BWPPPE is the
-"BandwidthPerPixelPhaseEncode" in DICOM Tag 0019, 1028 and ReconMatrixPE is
+"BandwidthPerPixelPhaseEncode" in [DICOM Tag 0019, 1028](https://dicomlookup.com/dicomtags/(0019,1028)) and ReconMatrixPE is
 the size of the actual reconstructed data in the phase direction (which is NOT
 reflected in a single DICOM Tag for all possible aforementioned scan
 manipulations). See
@@ -944,7 +944,7 @@ accompanied by two ancillary files: `*_asl.json` and `*_aslcontext.tsv`.
 
 The `*_aslcontext.tsv` table consists of a single column of labels identifying the
 `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.
-Volume types are defined in the following table, based on DICOM Tag 0018, 9257 `ASL Context`.
+Volume types are defined in the following table, based on [DICOM Tag 0018, 9257](https://dicomlookup.com/dicomtags/(0018,9257)) `ASL Context`.
 Note that the volume_types `control` and  `label` within BIDS only serve
 to specify the magnetization state of the blood and thus the ASL subtraction order.
 See the [ASL Appendix](../appendices/arterial-spin-labeling.md#which-image-is-control-and-which-is-label)

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -21,7 +21,7 @@ AcquisitionDuration:
   display_name: Acquisition Duration
   description: |
     Duration (in seconds) of volume acquisition.
-    Corresponds to DICOM Tag 0018, 9073 `Acquisition Duration`.
+    Corresponds to [DICOM Tag 0018, 9073](https://dicomlookup.com/dicomtags/(0018,9073)) `Acquisition Duration`.
     This field is mutually exclusive with `"RepetitionTime"`.
   type: number
   exclusiveMinimum: 0
@@ -349,7 +349,7 @@ BolusCutOffDelayTime:
     cut-off saturation pulses.
     For Q2TIPS, only the values for the first and last bolus cut-off saturation
     pulses are provided.
-    Based on DICOM Tag 0018, 925F `ASL Bolus Cut-off Delay Time`.
+    Based on [DICOM Tag 0018, 925F](https://dicomlookup.com/dicomtags/(0018,925F)) `ASL Bolus Cut-off Delay Time`.
   anyOf:
     - type: number
       minimum: 0
@@ -364,14 +364,14 @@ BolusCutOffFlag:
   display_name: Bolus Cut Off Flag
   description: |
     Boolean indicating if a bolus cut-off technique is used.
-    Corresponds to DICOM Tag 0018, 925C `ASL Bolus Cut-off Flag`.
+    Corresponds to [DICOM Tag 0018, 925C](https://dicomlookup.com/dicomtags/(0018,925C)) `ASL Bolus Cut-off Flag`.
   type: boolean
 BolusCutOffTechnique:
   name: BolusCutOffTechnique
   display_name: Bolus Cut Off Technique
   description: |
     Name of the technique used, for example `"Q2TIPS"`, `"QUIPSS"`, `"QUIPSSII"`.
-    Corresponds to DICOM Tag 0018, 925E `ASL Bolus Cut-off Technique`.
+    Corresponds to [DICOM Tag 0018, 925E](https://dicomlookup.com/dicomtags/(0018,925E)) `ASL Bolus Cut-off Technique`.
   type: string
 BrainLocation:
   name: BrainLocation
@@ -429,7 +429,7 @@ ChemicalShiftReference:
   display_name: Chemical Shift Reference
   description: |
     The chemical shift at the transmitter frequency, specified in ppm (for example, `2.68`).
-    Corresponds to DICOM Tag 0018, 9053 `Chemical Shift Reference`.
+    Corresponds to [DICOM Tag 0018, 9053](https://dicomlookup.com/dicomtags/(0018,9053)) `Chemical Shift Reference`.
   type: number
   unit: ppm
 ChunkTransformationMatrix:
@@ -531,7 +531,7 @@ ContrastBolusIngredient:
   display_name: Contrast Bolus Ingredient
   description: |
     Active ingredient of agent.
-    Corresponds to DICOM Tag 0018, 1048 `Contrast/Bolus Ingredient`.
+    Corresponds to [DICOM Tag 0018, 1048](https://dicomlookup.com/dicomtags/(0018,1048)) `Contrast/Bolus Ingredient`.
   type: string
   enum:
     - $ref: objects.enums.IODINE.value
@@ -596,7 +596,7 @@ DeidentificationMethod:
   display_name: Deidentification Method
   description: |
     A description of the mechanism or method used to remove the Patient's identity.
-    Corresponds to DICOM Tag 0012, 0063 `De-identification Method`.
+    Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063)) `De-identification Method`.
   type: array
   items:
     type: string
@@ -605,7 +605,8 @@ DeidentificationMethodCodeSequence:
   display_name: Deidentification Method Code Sequence
   description: |
     A sequence of code objects describing the mechanism or method use to remove the Patient's identity.
-    Corresponds to DICOM Tag 0012, 0064 `De-identification Method Code Sequence`.
+    Corresponds to [DICOM Tag 0012, 0064](https://dicomlookup.com/dicomtags/(0012,0064))
+    `De-identification Method Code Sequence`.
   type: array
   items:
     type: object
@@ -621,25 +622,26 @@ DeidentificationMethodCodeSequence:
         description: |
           An identifier that is unambiguous within the Coding Scheme
           denoted by Coding Scheme Designator and Coding Scheme Version.
-          Corresponds to DICOM Tag 0008, 0100 `Code Value`.
+          Corresponds to [DICOM Tag 0008, 0100](https://dicomlookup.com/dicomtags/(0008,0100)) `Code Value`.
       CodeMeaning:
         name: CodeMeaning
         type: string
         description: |
           Text that has meaning to a human and conveys the meaning of the term
-          Corresponds to DICOM Tag 0008, 0104 `Code Meaning`.
+          Corresponds to [DICOM Tag 0008, 0104](https://dicomlookup.com/dicomtags/(0008,0104)) `Code Meaning`.
       CodingSchemeDesignator:
         name: CodingSchemeDesignator
         type: string
         description: |
           The identifier of the coding scheme in which the coded entry is defined.
-          Corresponds to DICOM Tag 0008, 0102 `Coding Scheme Designator`.
+          Corresponds to [DICOM Tag 0008, 0102](https://dicomlookup.com/dicomtags/(0008,0102))
+          `Coding Scheme Designator`.
       CodingSchemeVersion:
         name: CodingSchemeVersion
         type: string
         description: |
           An identifier of the version of the coding scheme if necessary to resolve ambiguity.
-          Corresponds to DICOM Tag 0008, 0103 `Coding Scheme Version`.
+          Corresponds to [DICOM Tag 0008, 0103](https://dicomlookup.com/dicomtags/(0008,0103)) `Coding Scheme Version`.
 DelayAfterTrigger:
   name: DelayAfterTrigger
   display_name: Delay After Trigger
@@ -808,7 +810,7 @@ DoseCalibrationFactor:
   display_name: Dose Calibration Factor
   description: |
     Multiplication factor used to transform raw data (in counts/sec) to meaningful unit (Bq/ml).
-    Corresponds to DICOM Tag 0054, 1322 `Dose Calibration Factor`.
+    Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322)) `Dose Calibration Factor`.
   type: number
 DwellTime:
   name: DwellTime
@@ -935,7 +937,7 @@ EchoTime:
   display_name: Echo Time
   description: |
     The echo time (TE) for the acquisition, specified in seconds.
-    Corresponds to DICOM Tag 0018, 0081 `Echo Time`
+    Corresponds to [DICOM Tag 0018, 0081](https://dicomlookup.com/dicomtags/(0018,0081)) `Echo Time`
     (please note that the DICOM term is in milliseconds not seconds).
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
@@ -1181,7 +1183,7 @@ FlipAngle:
   display_name: Flip Angle
   description: |
     Flip angle (FA) for the acquisition, specified in degrees.
-    Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
+    Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
     [file collection](SPEC_ROOT/appendices/file-collections.md)
@@ -1203,8 +1205,8 @@ FrameDuration:
   display_name: Frame Duration
   description: |
     Time duration of each frame in default unit seconds.
-    This corresponds to DICOM Tag 0018, 1242 `Actual Frame Duration` converted
-    to seconds.
+    This corresponds to [DICOM Tag 0018, 1242](https://dicomlookup.com/dicomtags/(0018,1242))
+    `Actual Frame Duration` converted to seconds.
   type: array
   items:
     type: number
@@ -1383,7 +1385,8 @@ HardcopyDeviceSoftwareVersion:
   description: |
     Manufacturer's designation of the software of the device that created this
     Hardcopy Image (the printer).
-    Corresponds to DICOM Tag 0018, 101A `Hardcopy Device Software Version`.
+    Corresponds to [DICOM Tag 0018, 101A](https://dicomlookup.com/dicomtags/(0018,101A))
+    `Hardcopy Device Software Version`.
   type: string
 HardwareFilters:
   name: HardwareFilters
@@ -1605,7 +1608,7 @@ InjectedRadioactivity:
     Total amount of radioactivity injected into the patient (for example, `400`).
     For bolus-infusion experiments, this value should be the sum of all injected
     radioactivity originating from both bolus and infusion.
-    Corresponds to DICOM Tag 0018, 1074 `Radionuclide Total Dose`.
+    Corresponds to [DICOM Tag 0018, 1074](https://dicomlookup.com/dicomtags/(0018,1074)) `Radionuclide Total Dose`.
   type: number
 InjectedRadioactivityUnits:
   name: InjectedRadioactivityUnits
@@ -1635,8 +1638,8 @@ InjectionStart:
   description: |
     Time of start of injection with respect to `"TimeZero"` in the default unit
     seconds.
-    This corresponds to DICOM Tag 0018, 1072 `Contrast/Bolus Start Time`
-    converted to seconds relative to `"TimeZero"`.
+    This corresponds to [DICOM Tag 0018, 1072](https://dicomlookup.com/dicomtags/(0018,1072))
+    `Contrast/Bolus Start Time` converted to seconds relative to `"TimeZero"`.
   type: number
   unit: s
 InstitutionAddress:
@@ -1713,7 +1716,7 @@ InversionTime:
     The inversion time (TI) for the acquisition, specified in seconds.
     Inversion time is the time after the middle of inverting RF pulse to middle
     of excitation pulse to detect the amount of longitudinal magnetization.
-    Corresponds to DICOM Tag 0018, 0082 `Inversion Time`
+    Corresponds to [DICOM Tag 0018, 0082](https://dicomlookup.com/dicomtags/(0018,0082)) `Inversion Time`
     (please note that the DICOM term is in milliseconds not seconds).
   type: number
   unit: s
@@ -1752,7 +1755,7 @@ LabelingDuration:
     In case an array of numbers is provided,
     its length should be equal to the number of volumes specified in
     `*_aslcontext.tsv`.
-    Corresponds to DICOM Tag 0018, 9258 `ASL Pulse Train Duration`.
+    Corresponds to [DICOM Tag 0018, 9258](https://dicomlookup.com/dicomtags/(0018,9258)) `ASL Pulse Train Duration`.
   anyOf:
     - type: number
       minimum: 0
@@ -1789,7 +1792,7 @@ LabelingOrientation:
     Orientation of the labeling plane (`(P)CASL`) or slab (`PASL`).
     The direction cosines of a normal vector perpendicular to the ASL labeling
     slab or plane with respect to the patient.
-    Corresponds to DICOM Tag 0018, 9255 `ASL Slab Orientation`.
+    Corresponds to [DICOM Tag 0018, 9255](https://dicomlookup.com/dicomtags/(0018,9255)) `ASL Slab Orientation`.
   type: array
   items:
     type: number
@@ -1851,7 +1854,7 @@ LabelingSlabThickness:
   description: |
     Thickness of the labeling slab in millimeters.
     For non-selective FAIR a zero is entered.
-    Corresponds to DICOM Tag 0018, 9254 `ASL Slab Thickness`.
+    Corresponds to [DICOM Tag 0018, 9254](https://dicomlookup.com/dicomtags/(0018,9254)) `ASL Slab Thickness`.
   type: number
   exclusiveMinimum: 0
   unit: mm
@@ -2003,7 +2006,7 @@ MRAcquisitionType:
   display_name: MR Acquisition Type
   description: |
     Type of sequence readout.
-    Corresponds to DICOM Tag 0018, 0023 `MR Acquisition Type`.
+    Corresponds to [DICOM Tag 0018, 0023](https://dicomlookup.com/dicomtags/(0018,0023)) `MR Acquisition Type`.
   type: string
   enum:
     - $ref: objects.enums.OneD.value
@@ -2014,7 +2017,7 @@ MRTransmitCoilSequence:
   display_name: MR Transmit Coil Sequence
   description: |
     This is a relevant field if a non-standard transmit coil is used.
-    Corresponds to DICOM Tag 0018, 9049 `MR Transmit Coil Sequence`.
+    Corresponds to [DICOM Tag 0018, 9049](https://dicomlookup.com/dicomtags/(0018,9049)) `MR Transmit Coil Sequence`.
   type: string
 MTNumberOfPulses:
   name: MTNumberOfPulses
@@ -2066,14 +2069,14 @@ MTState:
   display_name: MT State
   description: |
     Boolean stating whether the magnetization transfer pulse is applied.
-    Corresponds to DICOM Tag 0018, 9020 `Magnetization Transfer`.
+    Corresponds to [DICOM Tag 0018, 9020](https://dicomlookup.com/dicomtags/(0018,9020)) `Magnetization Transfer`.
   type: boolean
 MagneticFieldStrength:
   name: MagneticFieldStrength
   display_name: Magnetic Field Strength
   description: |
     Nominal field strength of MR magnet in Tesla.
-    Corresponds to DICOM Tag 0018, 0087 `Magnetic Field Strength`.
+    Corresponds to [DICOM Tag 0018, 0087](https://dicomlookup.com/dicomtags/(0018,0087)) `Magnetic Field Strength`.
   type: number
 Magnification:
   name: Magnification
@@ -2209,7 +2212,8 @@ MolarActivity:
   display_name: Molar Activity
   description: |
     Molar activity of compound injected.
-    Corresponds to DICOM Tag 0018, 1077 `Radiopharmaceutical Specific Activity`.
+    Corresponds to [DICOM Tag 0018, 1077](https://dicomlookup.com/dicomtags/(0018,1077))
+    `Radiopharmaceutical Specific Activity`.
   type: number
 MolarActivityMeasTime:
   name: MolarActivityMeasTime
@@ -2473,7 +2477,8 @@ ParallelAcquisitionTechnique:
   display_name: Parallel Acquisition Technique
   description: |
     The type of parallel imaging used (for example `"GRAPPA"`, `"SENSE"`).
-    Corresponds to DICOM Tag 0018, 9078 `Parallel Acquisition Technique`.
+    Corresponds to [DICOM Tag 0018, 9078](https://dicomlookup.com/dicomtags/(0018,9078))
+    `Parallel Acquisition Technique`.
   type: string
 ParallelReductionFactorInPlane:
   name: ParallelReductionFactorInPlane
@@ -2482,7 +2487,8 @@ ParallelReductionFactorInPlane:
     The parallel imaging (for instance, GRAPPA) factor in plane.
     Use the denominator of the fraction of k-space encoded for each slice.
     For example, 2 means half of k-space is encoded.
-    Corresponds to DICOM Tag 0018, 9069 `Parallel Reduction Factor In-plane`.
+    Corresponds to [DICOM Tag 0018, 9069](https://dicomlookup.com/dicomtags/(0018,9069))
+    `Parallel Reduction Factor In-plane`.
   type: number
 ParallelReductionFactorOutOfPlane:
   name: ParallelReductionFactorOutOfPlane
@@ -2494,21 +2500,22 @@ ParallelReductionFactorOutOfPlane:
     Will typically be 1 for 2D sequences, as each slice in a 2D acquisition is usually fully encoded.
     `ParallelReductionFactorOutOfPlane` should not be confused with `MultibandAccelerationFactor`,
     as they imply different methods of accelerating the acquisition.
-    Corresponds to DICOM Tag 0018, 9155 `Parallel Reduction Factor out-of-plane`.
+    Corresponds to [DICOM Tag 0018, 9155](https://dicomlookup.com/dicomtags/(0018,9155))
+    `Parallel Reduction Factor out-of-plane`.
   type: number
 PartialFourier:
   name: PartialFourier
   display_name: Partial Fourier
   description: |
     The fraction of partial Fourier information collected.
-    Corresponds to DICOM Tag 0018, 9081 `Partial Fourier`.
+    Corresponds to [DICOM Tag 0018, 9081](https://dicomlookup.com/dicomtags/(0018,9081)) `Partial Fourier`.
   type: number
 PartialFourierDirection:
   name: PartialFourierDirection
   display_name: Partial Fourier Direction
   description: |
     The direction where only partial Fourier information was collected.
-    Corresponds to DICOM Tag 0018, 9036 `Partial Fourier Direction`.
+    Corresponds to [DICOM Tag 0018, 9036](https://dicomlookup.com/dicomtags/(0018,9036)) `Partial Fourier Direction`.
   type: string
 PharmaceuticalDoseAmount:
   name: PharmaceuticalDoseAmount
@@ -2772,7 +2779,7 @@ ReceiveCoilName:
   display_name: Receive Coil Name
   description: |
     Information describing the receiver coil.
-    Corresponds to DICOM Tag 0018, 1250 `Receive Coil Name`,
+    Corresponds to [DICOM Tag 0018, 1250](https://dicomlookup.com/dicomtags/(0018,1250)) `Receive Coil Name`,
     although not all vendors populate that DICOM Tag,
     in which case this field can be derived from an appropriate
     private DICOM field.
@@ -2976,7 +2983,7 @@ ResonantNucleus:
     The isotope of interest of an MR experiment (for example, `"1H"`, `"13C"`, `"31P"`).
     For multi-nuclei experiments such as <sup>1</sup>H-[<sup>13</sup>C] MR,
     an array can be used: `["1H", "13C"]`.
-    Corresponds to DICOM Tag 0018, 9100 `Resonant Nucleus`.
+    Corresponds to [DICOM Tag 0018, 9100](https://dicomlookup.com/dicomtags/(0018,9100)) `Resonant Nucleus`.
   type: array
   items:
     type: string
@@ -3165,7 +3172,7 @@ ScanOptions:
   display_name: Scan Options
   description: |
     Parameters of ScanningSequence.
-    Corresponds to DICOM Tag 0018, 0022 `Scan Options`.
+    Corresponds to [DICOM Tag 0018, 0022](https://dicomlookup.com/dicomtags/(0018,0022)) `Scan Options`.
   anyOf:
     - type: string
     - type: array
@@ -3183,7 +3190,7 @@ ScanningSequence:
   display_name: Scanning Sequence
   description: |
     Description of the type of data acquired.
-    Corresponds to DICOM Tag 0018, 0020 `Scanning Sequence`.
+    Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020)) `Scanning Sequence`.
   anyOf:
     - type: string
     - type: array
@@ -3265,14 +3272,14 @@ SequenceName:
   display_name: Sequence Name
   description: |
     Manufacturer's designation of the sequence name.
-    Corresponds to DICOM Tag 0018, 0024 `Sequence Name`.
+    Corresponds to [DICOM Tag 0018, 0024](https://dicomlookup.com/dicomtags/(0018,0024)) `Sequence Name`.
   type: string
 SequenceVariant:
   name: SequenceVariant
   display_name: Sequence Variant
   description: |
     Variant of the ScanningSequence.
-    Corresponds to DICOM Tag 0018, 0021 `Sequence Variant`.
+    Corresponds to [DICOM Tag 0018, 0021](https://dicomlookup.com/dicomtags/(0018,0021)) `Sequence Variant`.
   anyOf:
     - type: string
     - type: array
@@ -3525,7 +3532,7 @@ SpectralWidth:
   display_name: Spectral Width
   description: |
     The spectral bandwidth of the MR signal that is sampled, specified in Hz.
-    Corresponds to DICOM Tag 0018, 9052 `Spectral Width`.
+    Corresponds to [DICOM Tag 0018, 9052](https://dicomlookup.com/dicomtags/(0018,9052)) `Spectral Width`.
   type: number
   unit: Hz
 SpectrometerFrequency:
@@ -3842,7 +3849,7 @@ VascularCrushing:
   display_name: Vascular Crushing
   description: |
     Boolean indicating if Vascular Crushing is used.
-    Corresponds to DICOM Tag 0018, 9259 `ASL Crusher Flag`.
+    Corresponds to [DICOM Tag 0018, 9259](https://dicomlookup.com/dicomtags/(0018,9259)) `ASL Crusher Flag`.
   type: boolean
 VascularCrushingVENC:
   name: VascularCrushingVENC
@@ -3852,7 +3859,7 @@ VascularCrushingVENC:
     Specify either one number for the total time-series, or provide an array of
     numbers, for example when using QUASAR, using the value zero to identify
     volumes for which `VascularCrushing` was turned off.
-    Corresponds to DICOM Tag 0018, 925A `ASL Crusher Flow Limit`.
+    Corresponds to [DICOM Tag 0018, 925A](https://dicomlookup.com/dicomtags/(0018,925A)) `ASL Crusher Flow Limit`.
   anyOf:
     - type: number
       unit: cm/s

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2899,10 +2899,10 @@ RepetitionTime:
     and the beginning of acquisition of the volume following it (TR).
     When used in the context of functional acquisitions this parameter best
     corresponds to
-    [DICOM Tag 0020, 0110](http://dicomlookup.com/dicomtags/(0020,0110)):
+    [DICOM Tag 0020, 0110](https://dicomlookup.com/dicomtags/(0020,0110)):
     the "time delta between images in a
     dynamic of functional set of images" but may also be found in
-    [DICOM Tag 0018, 0080](http://dicomlookup.com/dicomtags/(0018,0080)):
+    [DICOM Tag 0018, 0080](https://dicomlookup.com/dicomtags/(0018,0080)):
     "the period of time in msec between the beginning
     of a pulse sequence and the beginning of the succeeding
     (essentially identical) pulse sequence".
@@ -2919,7 +2919,7 @@ RepetitionTimeExcitation:
   display_name: Repetition Time Excitation
   description: |
     The interval, in seconds, between two successive excitations.
-    [DICOM Tag 0018, 0080](http://dicomlookup.com/dicomtags/(0018,0080))
+    [DICOM Tag 0018, 0080](https://dicomlookup.com/dicomtags/(0018,0080))
     best refers to this parameter.
     This field may be used together with the `"RepetitionTimePreparation"` for
     certain use cases, such as

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -47,7 +47,7 @@ ASLFlipAngleNiftiLength:
     message: |
       The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
+      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
       The data type array provides a value for each volume in a 4D dataset and should only be used when the
@@ -70,7 +70,7 @@ ASLFlipAngleASLContextLength:
       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
       associated 'aslcontext.tsv'.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`.
+      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
       The data type array provides a value for each volume in a 4D dataset and should only be used when the volume

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -13,19 +13,24 @@ MRIHardware:
   fields:
     Manufacturer:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070)) `Manufacturer`.
     ManufacturersModelName:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090)) `Manufacturers Model Name`.
     DeviceSerialNumber:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0018, 1000 `DeviceSerialNumber`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 1000](https://dicomlookup.com/dicomtags/(0018,1000)) `DeviceSerialNumber`.
     StationName:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 1010 `Station Name`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 1010](https://dicomlookup.com/dicomtags/(0008,1010)) `Station Name`.
     SoftwareVersions:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0018, 1020 `Software Versions`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 1020](https://dicomlookup.com/dicomtags/(0018,1020)) `Software Versions`.
     HardcopyDeviceSoftwareVersion: deprecated
     MagneticFieldStrength:
       level: recommended
@@ -62,7 +67,8 @@ MRISample:
   fields:
     BodyPart:
       level: optional
-      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
 
@@ -87,7 +93,8 @@ MRISequenceSpecifics:
         echo EPI"`.
     ScanningSequence:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0018, 0020 `Scanning Sequence`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020)) `Scanning Sequence`.
     SequenceVariant: recommended
     ScanOptions: recommended
     SequenceName: recommended
@@ -325,7 +332,7 @@ MRIFlipAngleLookLockerTrue:
           You should define 'FlipAngle' for this file, in
           case of a LookLocker acquisition. 'FlipAngle' is the
           flip angle (FA) for the acquisition, specified in degrees.
-          Corresponds to: DICOM Tag 0018, 1314 `Flip Angle`. The data
+          Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`. The data
           type number may apply to files from any MRI modality concerned
           with a single value for this field, or to the files in a file
           collection where the value of this field is iterated using the
@@ -371,13 +378,17 @@ MRIInstitutionInformation:
   fields:
     InstitutionName:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080)) `InstitutionName`.
     InstitutionAddress:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081)) `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 1040](https://dicomlookup.com/dicomtags/(0008,1040))
+        `Institutional Department Name`.
 
 DeidentificationMethod:
   selectors:
@@ -386,7 +397,10 @@ DeidentificationMethod:
   fields:
     DeidentificationMethod:
       level: optional
-      description_addendum: Corresponds to DICOM Tag 0012, 0063 `De-identification Method`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063)) `De-identification Method`.
     DeidentificationMethodCodeSequence:
       level: optional
-      description_addendum: Corresponds to DICOM Tag 0012, 0064 `De-identification Method Code Sequence`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0012, 0064](https://dicomlookup.com/dicomtags/(0012,0064))
+        `De-identification Method Code Sequence`.

--- a/src/schema/rules/sidecars/mrs.yaml
+++ b/src/schema/rules/sidecars/mrs.yaml
@@ -39,7 +39,8 @@ MRSSample:
     BodyPart:
       level: optional
       level_addendum: required if `voi` entity is present
-      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
     BodyPartDetails:
       level: optional
       level_addendum: required if `voi` entity is present

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -7,18 +7,21 @@ PETHardware:
   fields:
     Manufacturer:
       level: required
-      description_addendum: Corresponds to DICOM Tag 0008, 0070 `Manufacturer`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070)) `Manufacturer`.
     ManufacturersModelName:
       level: required
-      description_addendum: Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090)) `Manufacturers Model Name`.
     Units:
       level: required
       description_addendum: |
         SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL").
-        Corresponds to DICOM Tag 0054, 1001 `Units`.
+        Corresponds to [DICOM Tag 0054, 1001](https://dicomlookup.com/dicomtags/(0054,1001)) `Units`.
     BodyPart:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
 
 PETInstitutionInformation:
   selectors:
@@ -27,13 +30,17 @@ PETInstitutionInformation:
   fields:
     InstitutionName:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 0080 `InstitutionName`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080)) `InstitutionName`.
     InstitutionAddress:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081)) `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 1040](https://dicomlookup.com/dicomtags/(0008,1040))
+        `Institutional Department Name`.
 
 PETSample:
   selectors:
@@ -42,7 +49,8 @@ PETSample:
   fields:
     BodyPart:
       level: optional
-      description_addendum: Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
 
@@ -114,10 +122,12 @@ PETPharmaceuticals:
   fields:
     PharmaceuticalName:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 0034 `Intervention Drug Name`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0034](https://dicomlookup.com/dicomtags/(0008,0034)) `Intervention Drug Name`.
     PharmaceuticalDoseAmount:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0008, 0028 `Intervention Drug Dose`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0028](https://dicomlookup.com/dicomtags/(0008,0028)) `Intervention Drug Dose`.
     PharmaceuticalDoseUnits: recommended
     PharmaceuticalDoseRegimen: recommended
     PharmaceuticalDoseTime:
@@ -136,17 +146,20 @@ PETTime:
     ScanStart: required
     InjectionStart:
       level: required
-      description_addendum: Corresponds to DICOM Tag 0018, 1072 `Radiopharmaceutical Start Time`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0018, 1072](https://dicomlookup.com/dicomtags/(0018,1072))
+        `Radiopharmaceutical Start Time`.
     FrameTimesStart: required
     FrameDuration: required
     InjectionEnd:
       level: recommended
       description_addendum: |
-        Corresponds to DICOM Tag 0018, 1073 `Radiopharmaceutical Stop Time`
-        converted to seconds relative to TimeZero.
+        Corresponds to [DICOM Tag 0018, 1073](https://dicomlookup.com/dicomtags/(0018,1073))
+        `Radiopharmaceutical Stop Time` converted to seconds relative to TimeZero.
     ScanDate:
       level: deprecated
-      description_addendum: Corresponds to DICOM Tag 0008, 0022 `Acquisition Date`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0008, 0022](https://dicomlookup.com/dicomtags/(0008,0022)) `Acquisition Date`.
 
 PETReconstruction:
   selectors:
@@ -158,40 +171,57 @@ PETReconstruction:
     ImageDecayCorrectionTime: required
     ReconMethodName:
       level: required
-      description_addendum: This partly matches the DICOM Tag 0054, 1103 `Reconstruction Method`.
+      description_addendum: |
+        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        `Reconstruction Method`.
     ReconMethodParameterLabels:
       level: required
-      description_addendum: This partly matches the DICOM Tag 0054, 1103 `Reconstruction Method`.
+      description_addendum: |
+        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        `Reconstruction Method`.
     ReconMethodParameterUnits:
       level: recommended
       level_addendum: required if `ReconMethodParameterLabels` does not contain `"none"`
-      description_addendum: This partly matches the DICOM Tag 0054, 1103 `Reconstruction Method`.
+      description_addendum: |
+        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        `Reconstruction Method`.
     ReconMethodParameterValues:
       level: recommended
       level_addendum: required if `ReconMethodParameterLabels` does not contain `"none"`
-      description_addendum: This partly matches the DICOM Tag 0054, 1103 `Reconstruction Method`.
+      description_addendum: |
+        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        `Reconstruction Method`.
     ReconFilterType:
       level: required
-      description_addendum: This partly matches the DICOM Tag 0018, 1210 `Convolution Kernel`.
+      description_addendum: |
+        This partly matches the [DICOM Tag 0018, 1210](https://dicomlookup.com/dicomtags/(0018,1210))
+        `Convolution Kernel`.
     ReconFilterSize:
       level: recommended
       level_addendum: required if `ReconFilterType` is not `"none"`
-      description_addendum: This partly matches the DICOM Tag 0018, 1210 `Convolution Kernel`.
+      description_addendum: |
+        This partly matches the [DICOM Tag 0018, 1210](https://dicomlookup.com/dicomtags/(0018,1210))
+        `Convolution Kernel`.
     AttenuationCorrection:
       level: required
-      description_addendum: This corresponds to DICOM Tag 0054, 1101 `Attenuation Correction Method`.
+      description_addendum: |
+        This corresponds to [DICOM Tag 0054, 1101](https://dicomlookup.com/dicomtags/(0054,1101))
+        `Attenuation Correction Method`.
     ReconMethodImplementationVersion: recommended
     AttenuationCorrectionMethodReference: recommended
     ScaleFactor: recommended
     ScatterFraction:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0054, 1323 `Scatter Fraction Factor`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0054, 1323](https://dicomlookup.com/dicomtags/(0054,1323)) `Scatter Fraction Factor`.
     DecayCorrectionFactor:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0054, 1321 `Decay Factor`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0054, 1321](https://dicomlookup.com/dicomtags/(0054,1321)) `Decay Factor`.
     DoseCalibrationFactor:
       level: recommended
-      description_addendum: Corresponds to DICOM Tag 0054, 1322 `Dose Calibration Factor`.
+      description_addendum: |
+        Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322)) `Dose Calibration Factor`.
     PromptRate: recommended
     SinglesRate: recommended
     RandomRate: recommended


### PR DESCRIPTION
Should fix failing link checks. Then semi-automatically added links to all DICOM tags following the pattern `DICOM Tag \d{4}, \d{4}`. Adjusted newlines when necessary, but did not aim for beauty.