### PR TITLE
[SCHEMA] Allow `mod-*` to relate physio data to MRI data in `anat/`

### DIFF
--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -37,6 +37,7 @@ timeseries:
     acquisition: optional
     run: optional
     recording: optional
+    modality: optional
 
 timeseries__mri_no_task:
   suffixes:


### PR DESCRIPTION
`mod` seems to be more appropriate, but was also not yet supported.