### PR TITLE
[ENH] Do explicitly "allow" for having dotfiles and explicitly ignore them

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -202,6 +202,11 @@ as the labels would collide on a case-insensitive filesystem.
 Additionally, because the suffix `eeg` is defined,
 then the suffix `EEG` will not be added to future versions of the standard.
 
+### Dotfiles
+
+Files and directories starting with a dot (`.`) are reserved for system use and no valid recognized BIDS file or directory can start with a `.`.
+Any file or directory starting with a `.` present in a BIDS dataset is considered hidden and not subject to BIDS validation.
+
 ## Uniqueness of data files
 
 Data files MUST be uniquely identified by BIDS path components

--- a/tools/schemacode/src/bidsschematools/__main__.py
+++ b/tools/schemacode/src/bidsschematools/__main__.py
@@ -169,7 +169,9 @@ def pre_receive_hook(schema, input_, output):
                 logger.debug("Validating files, first file: %s", filename)
                 any_files = True
             filename = filename.strip()
-            if any(_bidsignore_check(pattern, filename, "") for pattern in ignore):
+            if filename.startswith(".") or any(
+                _bidsignore_check(pattern, filename, "") for pattern in ignore
+            ):
                 continue
             if not any(re.match(regex, filename) for regex in regexes):
                 print(filename, file=output)


### PR DESCRIPTION
Up to this point it was up for a validator to "code" that up. E.g. current new deno based validator in
https://github.com/bids-standard/bids-validator/blob/main/src/files/ignore.ts has

    const defaultIgnores = [
      '.git**',
      '.*',
      'sourcedata/',
      ...

thus ignores all dotfiles from validation.  But this is inconsistent e.g.  with shipped in bids-specification schematools treatment, where files in a dotdirectory were reported as "invalid":

	❯ cat /tmp/input.txt | python -m bidsschematools pre-receive-hook
	.datalad/config
	.gitattributes
	sub-01/anat/sub-01_unknown.nii.gz

And as demonstrated above there could be legit "system" dotfiles (VCS related etc) which are part of the folder containing BIDS dataset, I think we should **explicitly** describe position of BIDS in relation to the dotfiles.  As it is pretty much "ignore", that is what this PR is intended to state.

In this PR I also adjusted `pre_receive_hook` to ignore dotfiles. The `find_files` was already ignoring them.