### PR TITLE
[SCHEMA] Add v1.10.0 to known BIDS versions list

### DIFF
--- a/src/schema/meta/versions.yaml
+++ b/src/schema/meta/versions.yaml
@@ -1,5 +1,6 @@
 ---
 # A list of released BIDS versions as of the next schema release
+- '1.10.0'
 - '1.9.0'
 - '1.8.0'
 - '1.7.0'


### PR DESCRIPTION
This PR adds BIDS version 1.10.0 to `src/schema/meta/versions.yaml` to address the following bug:

The `bids-validator` throws an `UNKNOWN_BIDS_VERSION` warning for datasets with `"BIDSVersion" : "1.10.0"`