### PR TITLE
[SCHEMA] Configure only the bst logger instead of the root logger

### DIFF
--- a/tools/schemacode/src/bidsschematools/render/tables.py
+++ b/tools/schemacode/src/bidsschematools/render/tables.py
@@ -14,9 +14,6 @@ from bidsschematools.schema import BIDSSchemaError, Namespace, filter_schema
 from bidsschematools.utils import get_logger, set_logger_level
 
 lgr = get_logger()
-# Basic settings for output, for now just basic
-set_logger_level(lgr, os.environ.get("BIDS_SCHEMA_LOG_LEVEL", logging.INFO))
-logging.basicConfig(format="%(asctime)-15s [%(levelname)8s] %(message)s")
 
 # Remember to add extension (.html or .md) to the paths when using them.
 ENTITIES_PATH = "SPEC_ROOT/appendices/entities"

--- a/tools/schemacode/src/bidsschematools/render/text.py
+++ b/tools/schemacode/src/bidsschematools/render/text.py
@@ -11,9 +11,6 @@ from bidsschematools.schema import Namespace, filter_schema, load_schema
 from bidsschematools.utils import get_logger, set_logger_level
 
 lgr = get_logger()
-# Basic settings for output, for now just basic
-set_logger_level(lgr, os.environ.get("BIDS_SCHEMA_LOG_LEVEL", logging.INFO))
-logging.basicConfig(format="%(asctime)-15s [%(levelname)8s] %(message)s")
 
 # Remember to add extension (.html or .md) to the paths when using them.
 ENTITIES_PATH = "SPEC_ROOT/appendices/entities"

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -21,10 +21,6 @@ from . import __bids_version__, __version__, utils
 from .types import Namespace
 
 lgr = utils.get_logger()
-# Basic settings for output, for now just basic
-utils.set_logger_level(lgr, os.environ.get("BIDS_SCHEMA_LOG_LEVEL", logging.INFO))
-logging.basicConfig(format="%(asctime)-15s [%(levelname)8s] %(message)s")
-
 
 class BIDSSchemaError(Exception):
     """Errors indicating invalid values in the schema itself"""

--- a/tools/schemacode/src/bidsschematools/utils.py
+++ b/tools/schemacode/src/bidsschematools/utils.py
@@ -34,6 +34,11 @@ def get_logger(name=None):
     # Basic settings for output, for now just basic
     set_logger_level(logger, os.environ.get("BIDS_SCHEMA_LOG_LEVEL", logging.INFO))
     format="%(asctime)-15s [%(levelname)8s] %(message)s"
+    if len(logger.handlers) == 0:
+        # add a handler if there isn't one
+        ch = logging.StreamHandler()
+        logger.addHandler(ch)
+    # Set the formatter for the handlers
     for lh in logger.handlers:
         lh.setFormatter(logging.Formatter(format))
 

--- a/tools/schemacode/src/bidsschematools/utils.py
+++ b/tools/schemacode/src/bidsschematools/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for the bids-specification schema."""
 
 import logging
+import os
 
 from . import data
 
@@ -29,7 +30,15 @@ def get_logger(name=None):
     logging.Logger
         logger object.
     """
-    return logging.getLogger("bidsschematools" + (".%s" % name if name else ""))
+    logger = logging.getLogger("bidsschematools" + (".%s" % name if name else ""))
+    # Basic settings for output, for now just basic
+    set_logger_level(logger, os.environ.get("BIDS_SCHEMA_LOG_LEVEL", logging.INFO))
+    format="%(asctime)-15s [%(levelname)8s] %(message)s"
+    for lh in logger.handlers:
+        lh.setFormatter(logging.Formatter(format))
+
+    return logger
+
 
 
 def set_logger_level(lgr, level):


### PR DESCRIPTION
This PR addresses an issue in which third-party projects using the `bidsschematools` python package might have logging issues.

Currently, the `bidsschematools` package is reconfiguring the python root logger in order to set the format, which also adds a handler to the root logger. This affects pybids, which also affects templateflow and, in consecuence, any other tool using templateflow.

This PR should not create any imcompatibility as it is just a logging reconfiguration and does not modify the schema nor the logic of the code handling the schema.
