### PR TITLE
[ENH] Accept UTC offsets in datetimes

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -1014,16 +1014,15 @@ For additional rules, see below:
 Describing dates and timestamps:
 
 -   Date time information MUST be expressed in the following format
-    `YYYY-MM-DDThh:mm:ss[.000000][Z]` (year, month, day, hour (24h), minute,
-    second, optional fractional seconds, and optional UTC time indicator).
+    `YYYY-MM-DDThh:mm:ss[.000000][Z|+hh:mm|-hh:mm]` (year, month, day, hour (24h),
+    minute, second, optional fractional seconds, and optional time offset).
     This is almost equivalent to the [RFC3339](https://tools.ietf.org/html/rfc3339)
-    "date-time" format, with the exception that UTC indicator `Z` is optional and
-    non-zero UTC offsets are not indicated.
-    If `Z` is not indicated, time zone is always assumed to be the local time of the
-    dataset viewer.
+    "date-time" format, with the exception that UTC offsets are OPTIONAL.
+    If no time offset is indicated,
+    time zone is always assumed to be the local time of the dataset viewer.
     No specific precision is required for fractional seconds, but the precision
     SHOULD be consistent across the dataset.
-    For example `2009-06-15T13:45:30`.
+    For example `2009-06-15T13:45:30+01:00`.
 
 -   Time stamp information MUST be expressed in the following format:
     `hh:mm:ss[.000000]`

--- a/src/schema/objects/formats.yaml
+++ b/src/schema/objects/formats.yaml
@@ -69,10 +69,24 @@ date:
 datetime:
   display_name: Datetime
   description: |
-    A datetime in the form `"YYYY-MM-DDThh:mm:ss[.000000][Z]"`,
-    where [.000000] is an optional subsecond resolution between 1 and 6 decimal points,
-    and [Z] is an optional, valid timezone code.
-  pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2}T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9](\.[0-9]{1,6})?([A-Z]{2,4})?'
+    An [RFC 3339](https://doi.org/10.17487/RFC3339) timestamp, with OPTIONAL time offset.
+    Datetimes take the form `"YYYY-MM-DDThh:mm:ss[.000000][Z|+hh:mm|-hh:mm]"`,
+    where `[.000000]` is an OPTIONAL subsecond resolution between 1 and 6 decimal points,
+    and `[Z|+hh:mm|-hh:mm]` is a time offset.
+    The character `Z` indicates Coordinated Universal Time (UTC),
+    or else an integral number of minutes may be specified.
+
+    For simplicity, this format validates RFC3339-invalid dates such as 2024-02-31,
+    but implementations SHOULD error on non-existent dates and times.
+  pattern: "\
+    [0-9]{4}\
+    -(?:0[1-9]|1[0-2])\
+    -(?:0[1-9]|[12][0-9]|3[01])\
+    T(?:2[0-3]|[01][0-9])\
+    :[0-5][0-9]\
+    :(?:[0-5][0-9]|60)\
+    (?:\\.[0-9]{1,6})?\
+    (?:Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?"
 file_relative:
   display_name: Path relative to the parent file
   description: |

--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -85,8 +85,10 @@ def test_formats(schema_obj):
             "2022-01-05T13:16:30",
             "2022-01-05T13:16:30.5",  # subsecond resolution is allowed
             "2022-01-05T13:16:30.000005",  # up to 6 decimal points
-            "2022-01-05T13:16:30UTC",  # timezones are allowed
-            "2022-01-05T13:16:30.05UTC",
+            "2022-01-05T13:16:30Z",  # UTC indicator is allowed
+            "2022-01-05T13:16:30.05Z",
+            "2022-01-05T13:16:30+01:00",  # integral offsets are allowed
+            "2022-01-05T13:16:30-05:00",
         ],
         "time": [
             "13:16:30",


### PR DESCRIPTION
As discussed in #1968, non-UTC timezones can be useful for coordinating acquisitions across time zones. The spec currently adopts RFC3339 with the exception that nonzero UTC offsets are not permitted, and the `Z` offset is optional to allow indicating local time.

For backwards compatibility, I propose allowing the offsets to remain optional, but permitting the full range of RFC3339 offsets.

Separately, the current regular expression does not express the current rule, so I will open another PR against the maintenance branch for that.