### PR TITLE
fix: Update datetime definition/regex to match specification

### DIFF
--- a/src/schema/objects/formats.yaml
+++ b/src/schema/objects/formats.yaml
@@ -70,9 +70,18 @@ datetime:
   display_name: Datetime
   description: |
     A datetime in the form `"YYYY-MM-DDThh:mm:ss[.000000][Z]"`,
-    where [.000000] is an optional subsecond resolution between 1 and 6 decimal points,
-    and [Z] is an optional, valid timezone code.
-  pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2}T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9](\.[0-9]{1,6})?([A-Z]{2,4})?'
+    where `[.000000]` is an optional subsecond resolution between 1 and 6 decimal points,
+    and `[Z]` is an optional literal character `Z` that indicates
+    Coordinated Universal Time (UTC).
+  pattern: "\
+    [0-9]{4}\
+    -(?:0[1-9]|1[0-2])\
+    -(?:0[1-9]|[12][0-9]|3[01])\
+    T(?:2[0-3]|[01][0-9])\
+    :[0-5][0-9]\
+    :(?:[0-5][0-9]|60)\
+    (?:\\.[0-9]{1,6})?\
+    Z?"
 file_relative:
   display_name: Path relative to the parent file
   description: |

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2899,10 +2899,10 @@ RepetitionTime:
     and the beginning of acquisition of the volume following it (TR).
     When used in the context of functional acquisitions this parameter best
     corresponds to
-    [DICOM Tag 0020, 0110](http://dicomlookup.com/dicomtags/(0020,0110)):
+    [DICOM Tag 0020, 0110](https://dicomlookup.com/dicomtags/(0020,0110)):
     the "time delta between images in a
     dynamic of functional set of images" but may also be found in
-    [DICOM Tag 0018, 0080](http://dicomlookup.com/dicomtags/(0018,0080)):
+    [DICOM Tag 0018, 0080](https://dicomlookup.com/dicomtags/(0018,0080)):
     "the period of time in msec between the beginning
     of a pulse sequence and the beginning of the succeeding
     (essentially identical) pulse sequence".
@@ -2919,7 +2919,7 @@ RepetitionTimeExcitation:
   display_name: Repetition Time Excitation
   description: |
     The interval, in seconds, between two successive excitations.
-    [DICOM Tag 0018, 0080](http://dicomlookup.com/dicomtags/(0018,0080))
+    [DICOM Tag 0018, 0080](https://dicomlookup.com/dicomtags/(0018,0080))
     best refers to this parameter.
     This field may be used together with the `"RepetitionTimePreparation"` for
     certain use cases, such as

--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -85,8 +85,8 @@ def test_formats(schema_obj):
             "2022-01-05T13:16:30",
             "2022-01-05T13:16:30.5",  # subsecond resolution is allowed
             "2022-01-05T13:16:30.000005",  # up to 6 decimal points
-            "2022-01-05T13:16:30UTC",  # timezones are allowed
-            "2022-01-05T13:16:30.05UTC",
+            "2022-01-05T13:16:30Z",  # UTC indicator is allowed
+            "2022-01-05T13:16:30.05Z",
         ],
         "time": [
             "13:16:30",
@@ -133,7 +133,7 @@ def test_formats(schema_obj):
         ],
         "datetime": [
             "2022-01-05T13:16:30.1000005",  # too many decimal points
-            "2022-01-05T13:16:30U",  # time zone too short
+            "2022-01-05T13:16:30U",  # Only Z is permitted
             "2022-01-05T13:16:30UTCUTC",  # time zone too long
             "2022-01-05T34:10:10",  # invalid time
         ],


### PR DESCRIPTION
As noted in #1968 and https://github.com/bids-standard/bids-validator/issues/131, we fail to validate timestamps with the `Z`, but instead permit arbitrary 2-4 character upper-case strings. This goes against what the spec actually says.

This PR narrowly brings the schema into line with the text of BIDS 1.10.0. In #2001, I propose permitting the full range of RFC3339 values to handle needs for non-zero offsets.