### PR TITLE
[INFRA] Ignore www.incf.org link check.. unlikely to go away (hopefully)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,11 @@ jobs:
               # failures for local file:/// -- yoh found no better way,
               linkchecker -t 1 --check-extern \
                 --ignore-url 'file:///.*' \
-                --ignore-url 'https://fonts.gstatic.com' \
-                --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
-                --ignore-url 'https://github.com/[^/]*' \
-                --ignore-url 'https://doi.org/.*' \
                 --ignore-url 'https://bids-specification.readthedocs.io/en/stable/.*' \
+                --ignore-url 'https://doi.org/.*' \
+                --ignore-url 'https://fonts.gstatic.com' \
+                --ignore-url 'https://github.com/[^/]*' \
+                --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
                 --ignore-url 'https://www.incf.org' \
                 ~/project/site/*html ~/project/site/*/*.html
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
                 --ignore-url 'https://github.com/[^/]*' \
                 --ignore-url 'https://doi.org/.*' \
                 --ignore-url 'https://bids-specification.readthedocs.io/en/stable/.*' \
+                --ignore-url 'https://www.incf.org' \
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"


### PR DESCRIPTION
Currently check fails

    URL        `https://www.incf.org/'
    Name       `INCF'
    Parent URL file:///home/circleci/project/site/introduction.html, line 1795, col 2
    Real URL   https://www.incf.org/
    Check time 0.084 seconds
    Result     Error: SSLError: HTTPSConnectionPool(host='www.incf.org', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certifica...

possibly due to outdated collection of root certificates in the env where testing?

dunno, but we better address it since it brings overall CI to red quite often, causing fatigue and increasing likeliness to skip important issues.

edit: also sorted lines there for consistency etc