### PR TITLE
[FIX] Update zenodo DOI from 3686061 to 10175845

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![YouTube Channel Subscribers](https://img.shields.io/youtube/channel/subscribers/UCxZUcYfd_nvIVWAbzRB1tlw)
 [![Mastodon Follow](https://img.shields.io/mastodon/follow/109520103085644521?domain=https%3A%2F%2Ffosstodon.org%2F)](https://fosstodon.org/@bidsstandard)
 [![@BIDSstandard](https://img.shields.io/twitter/follow/bidsstandard.svg?style=social)](https://x.com/BIDSstandard)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3686061.svg)](https://doi.org/10.5281/zenodo.3686061)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10175845.svg)](https://doi.org/10.5281/zenodo.10175845)
 
 <img src="./BIDS_logo/BIDS_logo_white_transparent_background_crop.png#gh-dark-mode-only" alt="bids-logo" width="600"/>
 <img src="./BIDS_logo/BIDS_logo_black_transparent_background_crop.png#gh-light-mode-only" alt="bids-logo" width="600"/>

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -892,7 +892,7 @@ have the form `<scheme>:[//<authority>]<path>[?<query>][#<fragment>]`, as specif
 in [RFC 3986](https://tools.ietf.org/html/rfc3986).
 This applies to URLs and other common URIs, including Digital Object Identifiers (DOIs),
 which may be fully specified as `doi:<path>`,
-for example, [doi:10.5281/zenodo.3686061](https://doi.org/10.5281/zenodo.3686061).
+for example, [doi:10.5281/zenodo.10175845](https://doi.org/10.5281/zenodo.10175845).
 A given resource may have multiple URIs.
 When selecting URIs to add to dataset metadata, it is important to consider
 specificity and persistence.

--- a/src/index.md
+++ b/src/index.md
@@ -14,4 +14,4 @@ own datasets to match the BIDS specification, we recommend exploring the
 Alternatively, to get started please read [the introduction to the specification](introduction.md).
 
 For an overview of the BIDS ecosystem, visit the [BIDS homepage](https://bids.neuroimaging.io).
-The entire specification can also be [downloaded as PDF](https://doi.org/10.5281/zenodo.3686061).
+The entire specification can also be [downloaded as PDF](https://doi.org/10.5281/zenodo.10175845).


### PR DESCRIPTION
The DOI [10.5281/zenodo.3686061](https://doi.org/10.5281/zenodo.3686061) only covers versions <= 1.8.0. For versions >= 1.9.0, the correct record is [10.5281/zenodo.10175845](https://doi.org/10.5281/zenodo.10175845).