### PR TITLE
[FIX] Run codespell 2.4.0 throughout fixing few left typos automagically

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 [codespell]
 skip = *.js,*.svg,*.eps,.git,node_modules,env,venv,.mypy_cache,package-lock.json,CITATION.cff,tools/new_contributors.tsv,./tools/schemacode/docs/build,venvs
 ignore-regex = \bHEP\b
-ignore-words-list = fo,te,als,Acknowledgements,acknowledgements,weill,bu,winn,manuel
+ignore-words-list = acknowledgements,als,bu,fo,te,weill,winn
 builtin = clear,rare,en-GB_to_en-US
 # this overloads default dictionaries and I have not yet figured out
 # how to have multiple https://github.com/codespell-project/codespell/issues/2727

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,6 @@
 [codespell]
-skip = *.js,*.svg,*.eps,.git,node_modules,env,venv,.mypy_cache,package-lock.json,CITATION.cff,tools/new_contributors.tsv,./tools/schemacode/docs/build
+skip = *.js,*.svg,*.eps,.git,node_modules,env,venv,.mypy_cache,package-lock.json,CITATION.cff,tools/new_contributors.tsv,./tools/schemacode/docs/build,venvs
+ignore-regex = \bHEP\b
 ignore-words-list = fo,te,als,Acknowledgements,acknowledgements,weill,bu,winn,manuel
 builtin = clear,rare,en-GB_to_en-US
 # this overloads default dictionaries and I have not yet figured out

--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -439,7 +439,7 @@ arrays or objects:
 | `properties`           | The object described has a given set of fields; the values of these fields may be constrained |
 | `additionalProperties` | The object described has constraints on its values, but not the names                         |
 
-### On re-used objects with different definitions
+### On reused objects with different definitions
 
 In a few cases, two objects with the same name appear multiple times in the specification.
 When this happens, it is preferred to find a common definition, and clarify it in the rules (see below).

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -523,7 +523,7 @@ ContinuousHeadLocalization:
   name: ContinuousHeadLocalization
   display_name: Continuous Head Localization
   description: |
-    `true` or `false` value indicating whether continuous head localisation
+    `true` or `false` value indicating whether continuous head localization
     was performed.
   type: boolean
 ContrastBolusIngredient:
@@ -1472,7 +1472,7 @@ HeadCoilFrequency:
   name: HeadCoilFrequency
   display_name: Head Coil Frequency
   description: |
-    List of frequencies (in Hz) used by the head localisation coils
+    List of frequencies (in Hz) used by the head localization coils
     ('HLC' in CTF systems, 'HPI' in Neuromag/Elekta/MEGIN, 'COH' in BTi/4D)
     that track the subject's head position in the MEG helmet
     (for example, `[293, 307, 314, 321]`).
@@ -2133,7 +2133,7 @@ MaxMovement:
   display_name: Max Movement
   description: |
     Maximum head movement (in mm) detected during the recording,
-    as measured by the head localisation coils (for example, `4.8`).
+    as measured by the head localization coils (for example, `4.8`).
   type: number
   unit: mm
 MeasurementToolMetadata:

--- a/tools/schemacode/src/bidsschematools/validator.py
+++ b/tools/schemacode/src/bidsschematools/validator.py
@@ -334,7 +334,7 @@ def select_schema_path(
 
     Notes
     -----
-    * This is a purely aspirational function, and is pre-empted by logic inside
+    * This is a purely aspirational function, and is preempted by logic inside
         `bst.validator.validate_bids()`, and further contingent on better schema stability and
         ongoing work in: https://github.com/bids-standard/bids-schema
     * The default `bids_reference_root` value is based on the FHS and ideally should be enforced.


### PR DESCRIPTION
CI started to error out codespell as I saw in #2032 and it is due to new codespell 2.4.0.

So this PR fixes those detected with codespell 2.4.0 and indeed we had inconsistencies on GB vs US forms for "localization" so it is harmonized now.

I have done `HEP` exclusion via regex which might slow things down but would keep it case specific