### PR TITLE
[ENH] Allow LICENSE files to have .txt, .md, or .rst extensions

### DIFF
--- a/src/modality-agnostic-files.md
+++ b/src/modality-agnostic-files.md
@@ -8,7 +8,7 @@ Templates:
 -   `README[.md|.rst|.txt]`
 -   `CITATION.cff`
 -   `CHANGES`
--   `LICENSE`
+-   `LICENSE[.md|.rst|.txt]`
 
 ### `dataset_description.json`
 

--- a/src/schema/objects/files.yaml
+++ b/src/schema/objects/files.yaml
@@ -27,7 +27,10 @@ LICENSE:
     A `LICENSE` file MAY be provided in addition to the short specification of the
     used license in the `dataset_description.json` `"License"` field.
     The `"License"` field and `LICENSE` file MUST correspond.
-    The `LICENSE` file MUST be either in ASCII or UTF-8 encoding.
+    The `LICENSE` file MUST be either in ASCII or UTF-8 encoding and MAY have one of the extensions:
+    `.md` ([Markdown](https://www.markdownguide.org/)),
+    `.rst` ([reStructuredText](https://docutils.sourceforge.io/rst.html)),
+    or `.txt`.
 README:
   display_name: README
   file_type: regular

--- a/src/schema/rules/files/common/core.yaml
+++ b/src/schema/rules/files/common/core.yaml
@@ -21,7 +21,12 @@ CHANGES:
   path: CHANGES
 LICENSE:
   level: optional
-  path: LICENSE
+  stem: LICENSE
+  extensions:
+    - ''
+    - .md
+    - .rst
+    - .txt
 genetic_info:
   level: optional
   path: genetic_info.json


### PR DESCRIPTION
Allow extension for the LICENSE file: #2021 
