### PR TITLE
[FIX] Permitting `desc` for channels and events

### DIFF
--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -94,7 +94,7 @@ channels_coordsystem_common:
     description: optional
 
 channels_coordsystem__eeg_common:
-  $ref: rules.files.raw.channels.coordsystem___eeg
+  $ref: rules.files.raw.channels.coordsystem__eeg
   entities:
     $ref: rules.files.raw.channels.coordsystem__eeg.entities
     description: optional

--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -69,19 +69,19 @@ beh_noncontinuous_common:
     space: optional
     description: optional
 
-channels_channel_common:
+channels_channels_common:
   $ref: rules.files.raw.channels.channels
   entities:
     $ref: rrules.files.raw.channels.channels.entities
     description: optional
 
-channels_channel__meg_common:
+channels_channels__meg_common:
   $ref: rules.files.raw.channels.channels__meg
   entities:
     $ref: rrules.files.raw.channels.channels__meg.entities
     description: optional
 
-channels_channel__motion_common:
+channels_channels__motion_common:
   $ref: rules.files.raw.channels.channels__motion
   entities:
     $ref: rrules.files.raw.channels.channels__motion.entities

--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -277,3 +277,9 @@ pet_blood_common:
     $ref: rules.files.raw.pet.blood.entities
     space: optional
     description: optional
+
+task_events_common:
+  $ref: rules.files.raw.task.events
+  entities:
+    $ref: rrules.files.raw.task.events.entities
+    description: optional

--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -72,49 +72,49 @@ beh_noncontinuous_common:
 channels_channels_common:
   $ref: rules.files.raw.channels.channels
   entities:
-    $ref: rrules.files.raw.channels.channels.entities
+    $ref: rules.files.raw.channels.channels.entities
     description: optional
 
 channels_channels__meg_common:
   $ref: rules.files.raw.channels.channels__meg
   entities:
-    $ref: rrules.files.raw.channels.channels__meg.entities
+    $ref: rules.files.raw.channels.channels__meg.entities
     description: optional
 
 channels_channels__motion_common:
   $ref: rules.files.raw.channels.channels__motion
   entities:
-    $ref: rrules.files.raw.channels.channels__motion.entities
+    $ref: rules.files.raw.channels.channels__motion.entities
     description: optional
 
 channels_coordsystem_common:
   $ref: rules.files.raw.channels.coordsystem
   entities:
-    $ref: rrules.files.raw.channels.coordsystem.entities
+    $ref: rules.files.raw.channels.coordsystem.entities
     description: optional
 
 channels_coordsystem__eeg_common:
   $ref: rules.files.raw.channels.coordsystem___eeg
   entities:
-    $ref: rrules.files.raw.channels.coordsystem__eeg.entities
+    $ref: rules.files.raw.channels.coordsystem__eeg.entities
     description: optional
 
 channels_electrodes_common:
   $ref: rules.files.raw.channels.electrodes
   entities:
-    $ref: rrules.files.raw.channels.electrodes.entities
+    $ref: rules.files.raw.channels.electrodes.entities
     description: optional
 
 channels_electrodes__meg_common:
   $ref: rules.files.raw.channels.electrodes__meg
   entities:
-    $ref: rrules.files.raw.channels.electrodes__meg.entities
+    $ref: rules.files.raw.channels.electrodes__meg.entities
     description: optional
 
 channels_electrodes_optodes_common:
   $ref: rules.files.raw.channels.optodes
   entities:
-    $ref: rrules.files.raw.channels.optodes.entities
+    $ref: rules.files.raw.channels.optodes.entities
     description: optional
 
 dwi_dwi_common:
@@ -281,5 +281,5 @@ pet_blood_common:
 task_events_common:
   $ref: rules.files.raw.task.events
   entities:
-    $ref: rrules.files.raw.task.events.entities
+    $ref: rules.files.raw.task.events.entities
     description: optional

--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -75,6 +75,48 @@ channels_channel_common:
     $ref: rrules.files.raw.channels.channels.entities
     description: optional
 
+channels_channel__meg_common:
+  $ref: rules.files.raw.channels.channels__meg
+  entities:
+    $ref: rrules.files.raw.channels.channels__meg.entities
+    description: optional
+
+channels_channel__motion_common:
+  $ref: rules.files.raw.channels.channels__motion
+  entities:
+    $ref: rrules.files.raw.channels.channels__motion.entities
+    description: optional
+
+channels_coordsystem_common:
+  $ref: rules.files.raw.channels.coordsystem
+  entities:
+    $ref: rrules.files.raw.channels.coordsystem.entities
+    description: optional
+
+channels_coordsystem__eeg_common:
+  $ref: rules.files.raw.channels.coordsystem___eeg
+  entities:
+    $ref: rrules.files.raw.channels.coordsystem__eeg.entities
+    description: optional
+
+channels_electrodes_common:
+  $ref: rules.files.raw.channels.electrodes
+  entities:
+    $ref: rrules.files.raw.channels.electrodes.entities
+    description: optional
+
+channels_electrodes__meg_common:
+  $ref: rules.files.raw.channels.electrodes__meg
+  entities:
+    $ref: rrules.files.raw.channels.electrodes__meg.entities
+    description: optional
+
+channels_electrodes_optodes_common:
+  $ref: rules.files.raw.channels.optodes
+  entities:
+    $ref: rrules.files.raw.channels.optodes.entities
+    description: optional
+
 dwi_dwi_common:
   $ref: rules.files.raw.dwi.dwi
   entities:

--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -69,17 +69,17 @@ beh_noncontinuous_common:
     space: optional
     description: optional
 
+channels_channel_common:
+  $ref: rules.files.raw.channels.channels
+  entities:
+    $ref: rrules.files.raw.channels.channels.entities
+    description: optional
+
 dwi_dwi_common:
   $ref: rules.files.raw.dwi.dwi
   entities:
     $ref: rules.files.raw.dwi.dwi.entities
     space: optional
-    description: optional
-
-channels_channel_common:
-  $ref: rules.files.raw.channels.channels
-  entities:
-    $ref: rrules.files.raw.channels.channels.entities
     description: optional
 
 dwi_sbref_common:

--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -76,6 +76,12 @@ dwi_dwi_common:
     space: optional
     description: optional
 
+channels_channel_common:
+  $ref: rules.files.raw.channels.channels
+  entities:
+    $ref: rrules.files.raw.channels.channels.entities
+    description: optional
+
 dwi_sbref_common:
   $ref: rules.files.raw.dwi.sbref
   entities:


### PR DESCRIPTION
Fixes #2029, to accommodate the `desc` entity (based on the current [derivative specifications](https://bids-specification.readthedocs.io/en/stable/derivatives/introduction.html#file-naming-conventions), for **channels**, **electrodes**, **coordsystem** and **events** files.

I was not sure if adding `description` to `channels.channel` would be inherited to other special cases, such as `channels.channels__motion`, so I explicitly included those in the schema as well.

@effigies, I appreciate your insights.