### PR TITLE
chore(schematools): Add configuration for bump-my-version

### DIFF
--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -102,6 +102,7 @@ markers = [
 ]
 minversion = "6.0"
 xfail_strict = true
+
 [tool.coverage]
 
 [tool.coverage.paths]

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -102,6 +102,7 @@ markers = [
 ]
 minversion = "6.0"
 xfail_strict = true
+[tool.coverage]
 
 [tool.coverage.paths]
 source = [

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -112,10 +112,25 @@ source = [
 [tool.coverage.run]
 parallel = true
 
-[tool.bumpver]
+[tool.bumpversion]
 current_version = "1.1.0-dev"
-version_pattern = "MAJOR.MINOR.PATCH[-TAG]"
-commit = false
+parse = """(?x)
+    (?P<major>[0-9]+)
+    \\.(?P<minor>[0-9]+)
+    \\.(?P<patch>[0-9]+)
+    (?:-(?P<pre_label>dev))?
+"""
+serialize = ["{major}.{minor}.{patch}-{pre_label}", "{major}.{minor}.{patch}"]
+commit = true
+message = "chore: Bump schema package to {new_version}"
+# Use --tag on releases
+tag = false
+tag_name = "schema-{new_version}"
+tag_message = "Schema release {new_version}"
 
-[tool.bumpver.file_patterns]
-"src/bidsschematools/data/schema/SCHEMA_VERSION" = ['{version}']
+[tool.bumpversion.parts.pre_label]
+values = ["dev", "final"]
+optional_value = "final"
+
+[[tool.bumpversion.files]]
+filename = "../../src/schema/SCHEMA_VERSION"

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -112,6 +112,13 @@ source = [
 [tool.coverage.run]
 parallel = true
 
+# Release process:
+# cd tools/schemacode
+# uvx bump-my-version bump pre_label --tag
+# [inspect result]
+# git push upstream <current-branch> --tags
+# uvx bump-my-version bump <patch|minor|major>
+# git push upstream <current-branch>
 [tool.bumpversion]
 current_version = "1.1.0-dev"
 parse = """(?x)


### PR DESCRIPTION
It turns out that the tool [bump-my-version](https://callowayproject.github.io/bump-my-version/) can handle our tagging strategy for the bidsschematools. Here is a configuration that captures the workflow I've been doing by hand.

I did recently add `tool.bumpver`, but it couldn't handle tags due to the need for a `schema-` prefix.

I added the release process in a comment, but I'm happy to update a doc if there is one.