### PR TITLE
[ENH] Allow additional columns if defined for various TSV files

### DIFF
--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -650,7 +650,8 @@
               "additionalProperties": false
             },
             "additional_columns": {
-              "type": "string"
+              "type": "string",
+              "enum": ["allowed", "allowed_if_defined", "not_allowed", "n/a"]
             },
             "index_columns": { "type": "array", "items": { "type": "string" } },
             "initial_columns": {
@@ -658,7 +659,7 @@
               "items": { "type": "string" }
             }
           },
-          "required": ["selectors", "columns"],
+          "required": ["selectors", "columns", "additional_columns"],
           "additionalProperties": false
         }
       }

--- a/src/schema/rules/tabular_data/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/tabular_data/derivatives/common_derivatives.yaml
@@ -10,6 +10,7 @@ SegmentationLookup:
     color: optional
     mapping: optional
   index_columns: [index]
+  additional_columns: allowed
 
 Descriptions:
   selectors:

--- a/src/schema/rules/tabular_data/pet.yaml
+++ b/src/schema/rules/tabular_data/pet.yaml
@@ -21,6 +21,7 @@ Blood:
     whole_blood_radioactivity:
       level: optional
       level_addendum: required if `WholeBloodAvail` is `true`
+  additional_columns: allowed
 
 BloodPlasma:
   selectors:
@@ -30,6 +31,7 @@ BloodPlasma:
     - sidecar.PlasmaAvail == true
   columns:
     plasma_radioactivity: required
+  additional_columns: n/a
 
 BloodMetabolite:
   selectors:
@@ -40,6 +42,7 @@ BloodMetabolite:
   columns:
     metabolite_parent_fraction: required
     metabolite_polar_fraction: recommended
+  additional_columns: n/a
 
 BloodMetaboliteCorrection:
   selectors:
@@ -49,6 +52,7 @@ BloodMetaboliteCorrection:
     - sidecar.MetaboliteRecoveryCorrectionApplied == true
   columns:
     hplc_recovery_fractions: required
+  additional_columns: n/a
 
 BloodWholeBlood:
   selectors:
@@ -58,3 +62,4 @@ BloodWholeBlood:
     - sidecar.WholeBloodAvail == true
   columns:
     whole_blood_radioactivity: required
+  additional_columns: n/a

--- a/src/schema/rules/tabular_data/pet.yaml
+++ b/src/schema/rules/tabular_data/pet.yaml
@@ -4,6 +4,7 @@ Blood:
     - datatype == "pet"
     - suffix == "blood"
     - extension == ".tsv"
+  initial_columns: [time]
   columns:
     time: required
     plasma_radioactivity:


### PR DESCRIPTION
Several table definitions were missing an indication of whether additional columns were allowed, which defaults to `not_allowed`. This PR updates the metaschema to require the field to be explicit, and sets its value to `allowed_if_defined` for all cases that were missing.

cc @melanieganz @CPernet @mnoergaard for your thoughts on the PET cases. This is strictly speaking a relaxation, but IMO if people provide definitions, that's good?

Closes #1993.