### PR TITLE
fix: Use of min/maxItems in types of ScreenSize/ScreenResolution

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -3238,8 +3238,8 @@ ScreenResolution:
     - type: array
       items:
         type: integer
-        minItems: 2
-        maxItems: 2
+      minItems: 2
+      maxItems: 2
     - type: string
       enum:
         - n/a
@@ -3255,8 +3255,8 @@ ScreenSize:
       items:
         type: number
         unit: m
-        minItems: 2
-        maxItems: 2
+      minItems: 2
+      maxItems: 2
     - type: string
       enum:
         - n/a


### PR DESCRIPTION
Schema error detected by the AJV validator attempting to validate ScreenSize/ScreenResolution in OpenNeuro datasets. Warnings were being emitted that invalidated the JSON output.

Targeting the `maint/1.10.0` branch so this can be fixed and released in schema before the next BIDS release.

xref https://github.com/bids-standard/bids-validator/pull/166