### PR TITLE
Defaced derivative example should be in a pipeline subdirectory

### DIFF
--- a/src/derivatives/introduction.md
+++ b/src/derivatives/introduction.md
@@ -15,7 +15,7 @@ Examples:
 A defaced T1w image would typically be made during the curation process and is thus under raw
 
 ```Text
-sourcedata/defaced/sub-01/anat/sub-01_T1w.nii.gz
+sourcedata/pre-deface/sub-01/anat/sub-01_T1w.nii.gz
 sub-01/anat/sub-01_T1w.nii.gz
 ```
 

--- a/src/derivatives/introduction.md
+++ b/src/derivatives/introduction.md
@@ -15,7 +15,7 @@ Examples:
 A defaced T1w image would typically be made during the curation process and is thus under raw
 
 ```Text
-sourcedata/private/sub-01/anat/sub-01_T1w.nii.gz
+sourcedata/defaced/sub-01/anat/sub-01_T1w.nii.gz
 sub-01/anat/sub-01_T1w.nii.gz
 ```
 
@@ -23,7 +23,7 @@ A defaced T1w image could also, in theory, be derived from a BIDS dataset and wo
 
 ```Text
 sub-01/anat/sub-01_T1w.nii.gz
-derivatives/sub-01/anat/sub-01_desc-defaced_T1w.nii.gz
+derivatives/defaced/sub-01/anat/sub-01_desc-defaced_T1w.nii.gz
 ```
 
 ## Derivatives storage and directory structure


### PR DESCRIPTION
The [derivatives introduction](https://bids-specification.readthedocs.io/en/stable/derivatives/introduction.html) demonstrates a defaced T1w file as `derivatives/sub-01/sub-01_desc-defaced_T1w.nii`, which places it directly under the derivatives folder.  According to [this](https://bids-specification.readthedocs.io/en/stable/common-principles.html#storage-of-derived-datasets) it should however be in a subfolder corresponding to the pipeline name, so a directory name like `derivatives/<pipeline>/sub-01/sub-01_desc-defaced_T1w.nii`.

I named the pipeline "defaced" and inserted it in the example file path. I also renamed the `sourcedata/private` directory into `sourcedata/defaced`. 

Closes #2134.