### PR TITLE
Temporarily disable dicomlookup urls check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
                 --ignore-url 'https://github.com/[^/]*' \
                 --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
                 --ignore-url 'https://www.incf.org' \
+                --ignore-url 'https://dicomlookup.com/dicomtags/.*' \
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"


### PR DESCRIPTION
We know they are broken:

- https://github.com/bids-standard/bids-specification/issues/2068 
 
and there is no immediate fix. This should disable them, until we resolve them, and do not miss some other broken urls interim (e.g. while reviewing https://github.com/bids-standard/bids-specification/pull/2064 by @Remi-Gau ).
