### PR TITLE
Event onsets SHOULD NOT be negative or extremely large

### DIFF
--- a/src/schema/rules/checks/events.yaml
+++ b/src/schema/rules/checks/events.yaml
@@ -44,9 +44,9 @@ SortedOnsets:
     # n/a values will likely cause false alarms if encountered. Consider alternatives.
     - allequal(sorted(columns.onset, "numeric"), columns.onset)
 
-ImplausibleNegativeEventOnset:
+SuspiciousNegativeEventOnset:
   issue:
-    code: IMPLAUSIBLE_NEGATIVE_EVENT_ONSET
+    code: SUSPICIOUS_NEGATIVE_EVENT_ONSET
     message: |
       Event onsets were found more than 60s before the start of recording, indicated by negative values.
       If this is not a mistake, remove or consider an alternative method of representing these events.
@@ -57,9 +57,9 @@ ImplausibleNegativeEventOnset:
   checks:
     - min(columns.onset) >= -60
 
-ImplausiblePositiveEventOnset:
+SuspiciousPositiveEventOnset:
   issue:
-    code: IMPLAUSIBLE_POSITIVE_EVENT_ONSET
+    code: SUSPICIOUS_POSITIVE_EVENT_ONSET
     message: |
       Event onsets were found more than a month after the start of recording.
       If this is not a mistake, remove or consider an alternative method of representing these events.


### PR DESCRIPTION
I found not a single openneuro datasets with negative onsets.

    smaug:/mnt/datasets/datalad/crawl/openneuro
    *$> for ds in ds*; do git grep '^ *-' '**_events.tsv' | head ; done

But ATM we are looking at a dataset with some buggy _events.tsv which has huge negative values sorted within onsets column.  I think in general/theory in some .1% of the cases there could be point to have onsets with negative onsets, e.g. due to desire to encode some preparatory to the data scanning activities  (e.g. during dummy scans etc).  So for those -- it would be nice to have a dedicated ERROR code to ignore/overwrite.  But in general, it just signals a problem with the file and thus IMHO should be an ERROR.

TODOs (@effigies @rwblair @tsalo - please guide)

- [x] how to handle `n/a` values there? (should be ok)
- [ ] how/where to add a test?