### PR TITLE
fix(bst): Do not alter logger in library mode, log to stderr not stdout

### DIFF
--- a/tools/schemacode/src/bidsschematools/__main__.py
+++ b/tools/schemacode/src/bidsschematools/__main__.py
@@ -14,7 +14,10 @@ else:
 
 from .rules import regexify_filename_rules
 from .schema import export_schema, load_schema
+from .utils import configure_logger, get_logger
 from .validator import _bidsignore_check
+
+lgr = get_logger()
 
 
 @click.group()
@@ -23,7 +26,7 @@ from .validator import _bidsignore_check
 def cli(verbose, quiet):
     """BIDS Schema Tools"""
     verbose = verbose - quiet
-    logging.getLogger("bidsschematools").setLevel(logging.WARNING - verbose * 10)
+    configure_logger(get_logger(level=logging.WARNING - verbose * 10))
 
 
 @cli.command()
@@ -32,15 +35,14 @@ def cli(verbose, quiet):
 @click.pass_context
 def export(ctx, schema, output):
     """Export BIDS schema to JSON document"""
-    logger = logging.getLogger("bidsschematools")
     schema = load_schema(schema)
     text = export_schema(schema)
     if output == "-":
-        logger.debug("Writing to stdout")
+        lgr.debug("Writing to stdout")
         print(text)
     else:
         output = os.path.abspath(output)
-        logger.debug(f"Writing to {output}")
+        lgr.debug(f"Writing to {output}")
         with open(output, "w") as fobj:
             fobj.write(text)
 
@@ -102,7 +104,6 @@ def pre_receive_hook(schema, input_, output):
 
     This is intended to be used in a git pre-receive hook.
     """
-    logger = logging.getLogger("bidsschematools")
     schema = load_schema(schema)
 
     # Slurp inputs for now; we can think about streaming later
@@ -121,11 +122,9 @@ def pre_receive_hook(schema, input_, output):
         except json.JSONDecodeError:
             fail = True
         if fail or not isinstance(description, dict):
-            logger.critical("Protocol error: invalid JSON in description")
-            logger.critical(
-                "Dataset description must be one JSON object, written to a single line"
-            )
-            logger.critical("Received: %s", description_str)
+            lgr.critical("Protocol error: invalid JSON in description")
+            lgr.critical("Dataset description must be one JSON object, written to a single line")
+            lgr.critical("Received: %s", description_str)
             stream.close()
             sys.exit(2)
     else:
@@ -134,14 +133,14 @@ def pre_receive_hook(schema, input_, output):
         description = {}
 
     dataset_type = description.get("DatasetType", "raw")
-    logger.info("Dataset type: %s", dataset_type)
+    lgr.info("Dataset type: %s", dataset_type)
 
     ignore = []
     for line in stream:
         if line == "0001\n":
             break
         ignore.append(line.strip())
-    logger.info("Ignore patterns found: %d", len(ignore))
+    lgr.info("Ignore patterns found: %d", len(ignore))
 
     all_rules = chain.from_iterable(
         regexify_filename_rules(group, schema, level=2)
@@ -166,7 +165,7 @@ def pre_receive_hook(schema, input_, output):
     with output:
         for filename in stream:
             if not any_files:
-                logger.debug("Validating files, first file: %s", filename)
+                lgr.debug("Validating files, first file: %s", filename)
                 any_files = True
             filename = filename.strip()
             if any(_bidsignore_check(pattern, filename, "") for pattern in ignore):
@@ -178,7 +177,7 @@ def pre_receive_hook(schema, input_, output):
                 valid_files += 1
 
     if valid_files == 0:
-        logger.error("No files to validate")
+        lgr.error("No files to validate")
         rc = 2
 
     stream.close()

--- a/tools/schemacode/src/bidsschematools/utils.py
+++ b/tools/schemacode/src/bidsschematools/utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import sys
 
 from . import data
 
@@ -54,7 +55,7 @@ def configure_logger(lgr):
     """
     if len(lgr.handlers) == 0:
         # add a handler if there isn't one
-        ch = logging.StreamHandler()
+        ch = logging.StreamHandler(stream=sys.stderr)
         lgr.addHandler(ch)
     # Set the formatter for the handlers
     for lh in lgr.handlers:

--- a/tools/schemacode/src/bidsschematools/utils.py
+++ b/tools/schemacode/src/bidsschematools/utils.py
@@ -38,7 +38,7 @@ def get_logger(name=None, level=None):
     """
     logger = logging.getLogger("bidsschematools" + (".%s" % name if name else ""))
     # If explicitly instructed via env var -- set log level
-    if log_level := os.environ.get("BIDS_SCHEMA_LOG_LEVEL", level):
+    if log_level := os.getenv("BIDS_SCHEMA_LOG_LEVEL", level):
         set_logger_level(logger, log_level)
     return logger
 


### PR DESCRIPTION
We tried to upgrade to use recent bidsschematools in dandi-cli (https://github.com/dandi/dandi-cli/pull/1591) but tests started to fail since output was polluted with log messages from bidsschematools, which prompted me to look inside.

I have tried to keep my changes minimal (but did rename `logger` to `lgr` for consistency) and individual commits provide a little more information, but overall point - do not configure logger unless it is an "end user application". And it is typical for logging to just go into stderr to not interfere with potential "useful" output on stdout.