### PR TITLE
[ENH] Specify that dir-<label> should correspond to PhaseEncodingDirection

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -316,6 +316,7 @@ properties:
       - xyzt_units
       - qform_code
       - sform_code
+      - axis_codes
     additionalProperties: false
     properties:
       dim_info:
@@ -404,6 +405,15 @@ properties:
         name: 'sform code'
         description: 'Use of the affine fields.'
         type: integer
+      axis_codes:
+        name: 'axis codes'
+        description: 'Orientation labels indicating primary direction of data axes.'
+        type: array
+        minItems: 3
+        maxItems: 3
+        items:
+          type: string
+          enum: ['R', 'L', 'A', 'P', 'S', 'I']
       mrs:
         name: 'NIfTI-MRS extension'
         description: 'NIfTI-MRS JSON fields'

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -407,7 +407,9 @@ properties:
         type: integer
       axis_codes:
         name: 'axis codes'
-        description: 'Orientation labels indicating primary direction of data axes defined with respect to the object of interest.'
+        description: >
+          Orientation labels indicating primary direction of data axes defined
+          with respect to the object of interest.
         type: array
         minItems: 3
         maxItems: 3

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -407,7 +407,7 @@ properties:
         type: integer
       axis_codes:
         name: 'axis codes'
-        description: 'Orientation labels indicating primary direction of data axes.'
+        description: 'Orientation labels indicating primary direction of data axes defined with respect to the object of interest.'
         type: array
         minItems: 3
         maxItems: 3

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -84,11 +84,16 @@ direction:
     Therefore, if the `dir-<label>` entity is present in a filename,
     `"PhaseEncodingDirection"` MUST be defined in the associated metadata.
 
-    Labels need not follow any particular convention,
-    and JSON metadata MUST take precedence in interpreting an image.
-    Generic labels, such as `dir-reference` and `dir-reversed` avoid any possible inconsistency.
-    `dir-j0` and `dir-j1` can indicate `"PhaseEncodingDirection": "j"` and `"j-"` (or vice versa),
+    Labels need not follow any particular convention and in case of conflict,
+    JSON metadata MUST take precedence in interpreting an image.
+
+    For example, `dir-j0` and `dir-j1` can indicate `"PhaseEncodingDirection": "j"` and `"j-"` (or vice versa),
     identifying the phase-encoding axis while avoiding indicating polarity.
+    However, in case of a dataset indicating `dir-j0` with `"PhaseEncodingDirection": "i"`, the
+    JSON metadata overrides the entity `dir-` setting.
+
+    The use of generic labels, such as `dir-reference` and `dir-reversed`, is RECOMMENDED
+    to avoid any possible inconsistency.
 
     To avoid inconsistency, if the `<label>` is `AP`, `PA`, `LR`, `RL`, `SI`, or `IS`,
     then the `"PhaseEncodingDirection"` SHOULD correspond to the data

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -84,11 +84,17 @@ direction:
     Therefore, if the `dir-<label>` entity is present in a filename,
     `"PhaseEncodingDirection"` MUST be defined in the associated metadata.
 
-    If the `<label>` is `AP`, `PA`, `LR`, `RL`, `SI`, or `IS`,
+    Labels need not follow any particular convention,
+    and JSON metadata MUST take precedence in interpreting an image.
+    Generic labels, such as `dir-reference` and `dir-reversed` avoid any possible inconsistency.
+    `dir-j0` and `dir-j1` can indicate `"PhaseEncodingDirection": "j"` and `"j-"` (or vice versa),
+    identifying the phase-encoding axis while avoiding indicating polarity.
+
+    To avoid inconsistency, if the `<label>` is `AP`, `PA`, `LR`, `RL`, `SI`, or `IS`,
     then the `"PhaseEncodingDirection"` SHOULD correspond to the data
     axis that most closely aligns with the cardinal direction and orientation.
-    For example, `dir-AP` for an image in RAS+ orientation SHOULD have
-    `"PhaseEncodingDirection": "j-"`.
+    For example, `dir-PA` and `dir-AP` for an image in RAS+ orientation SHOULD have
+    `"PhaseEncodingDirection": "j"` and `"j-"`, respectively.
   type: string
   format: label
 echo:

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -83,7 +83,12 @@ direction:
     This entity represents the `"PhaseEncodingDirection"` metadata field.
     Therefore, if the `dir-<label>` entity is present in a filename,
     `"PhaseEncodingDirection"` MUST be defined in the associated metadata.
-    Please note that the `<label>` does not need to match the actual value of the field.
+
+    If the `<label>` is `AP`, `PA`, `LR`, `RL`, `SI`, or `IS`,
+    then the `"PhaseEncodingDirection"` SHOULD correspond to the data
+    axis that most closely aligns with the cardinal direction and orientation.
+    For example, `dir-AP` for an image in RAS+ orientation SHOULD have
+    `"PhaseEncodingDirection": "j-"`.
   type: string
   format: label
 echo:

--- a/src/schema/rules/checks/nifti.yaml
+++ b/src/schema/rules/checks/nifti.yaml
@@ -49,3 +49,18 @@ XformCodes0:
     - nifti_header != null
   checks:
     - nifti_header.qform_code != 0 || nifti_header.sform_code != 0
+
+NiftiPEDir:
+  issue:
+    code: NIFTI_PE_DIRECTION_CONSISTENCY
+    message: |
+      Phase encoding direction is inconsistent with `dir-` entity.
+    level: warning
+  selectors:
+    - type(nifti_header.axis_codes) != "null"
+    - intersects([entities.direction], ["AP", "PA", "RL", "LR", "SI", "IS"])
+    - sidecar.PhaseEncodingDirection
+  checks:
+    - |
+      entities.direction[2 - length(sidecar.PhaseEncodingDirection)]
+      == nifti_header.axis_codes[index(["i", "j", "k"], sidecar.PhaseEncodingDirection[0])]

--- a/src/schema/rules/checks/nifti.yaml
+++ b/src/schema/rules/checks/nifti.yaml
@@ -54,7 +54,8 @@ NiftiPEDir:
   issue:
     code: NIFTI_PE_DIRECTION_CONSISTENCY
     message: |
-      Phase encoding direction is inconsistent with `dir-` entity.
+      The PhaseEncodingDirection and affine orientation indicate
+      that the entity value (one of AP, PA, RL, LR, SI, IS) may be inaccurate.
     level: warning
   selectors:
     - type(nifti_header.axis_codes) != "null"

--- a/tools/schemacode/tests/test_context_types.py
+++ b/tools/schemacode/tests/test_context_types.py
@@ -75,6 +75,7 @@ def test_assignability() -> None:
         xyzt_units=xyzt_units,
         qform_code=1,
         sform_code=1,
+        axis_codes=("L", "P", "S"),
     )
 
     ome: p.Ome = ctx.Ome()


### PR DESCRIPTION
The BIDS convention is to use `dir-{AP,PA,LR,RL}` for phase-encoding directions in MRI filenames, as well as `PhaseEncodingDirection` in JSON sidecars. This duplication has the potential for inconsistency or multiple interpretations of the meaning of AP.

This PR aims to clarify the meaning of `dir-<label>` when its value matches a cardinal axis, and clearly state that this meaning SHOULD be consistent with the `PhaseEncodingDirection`.