### PR TITLE
[ENH] Allow direction entity in MESE files

### DIFF
--- a/src/schema/rules/files/deriv/preprocessed_data.yaml
+++ b/src/schema/rules/files/deriv/preprocessed_data.yaml
@@ -26,12 +26,21 @@ anat_defacemask_common:
     space: optional
     description: optional
 
-anat_multiecho_common:
+anat_megre_common:
   selectors:
     - dataset.dataset_description.DatasetType == 'derivative'
-  $ref: rules.files.raw.anat.multiecho
+  $ref: rules.files.raw.anat.megre
   entities:
-    $ref: rules.files.raw.anat.multiecho.entities
+    $ref: rules.files.raw.anat.megre.entities
+    space: optional
+    description: optional
+
+anat_mese_common:
+  selectors:
+    - dataset.dataset_description.DatasetType == 'derivative'
+  $ref: rules.files.raw.anat.mese
+  entities:
+    $ref: rules.files.raw.anat.mese.entities
     space: optional
     description: optional
 

--- a/src/schema/rules/files/raw/anat.yaml
+++ b/src/schema/rules/files/raw/anat.yaml
@@ -85,10 +85,30 @@ defacemask:
     modality: optional
     chunk: optional
 
-multiecho:
+megre:
+  suffixes:
+    - MEGRE
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  datatypes:
+    - anat
+  entities:
+    subject: required
+    session: optional
+    task: optional
+    acquisition: optional
+    ceagent: optional
+    reconstruction: optional
+    run: optional
+    echo: required
+    part: optional
+    chunk: optional
+
+mese:
   suffixes:
     - MESE
-    - MEGRE
   extensions:
     - .nii.gz
     - .nii

--- a/src/schema/rules/files/raw/anat.yaml
+++ b/src/schema/rules/files/raw/anat.yaml
@@ -26,7 +26,6 @@ nonparametric:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     echo: optional
     part: optional
@@ -63,7 +62,6 @@ parametric:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     chunk: optional
 
@@ -83,7 +81,6 @@ defacemask:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     modality: optional
     chunk: optional
@@ -127,7 +124,6 @@ multiflip:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     echo: optional
     flip: required
@@ -150,7 +146,6 @@ multiinversion:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     inversion: required
     part: optional
@@ -172,7 +167,6 @@ mp2rage:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     echo: optional
     flip: optional
@@ -197,7 +191,6 @@ vfamt:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     echo: optional
     flip: required
@@ -221,7 +214,6 @@ mtr:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
-    direction: optional
     run: optional
     mtransfer: required
     part: optional

--- a/src/schema/rules/files/raw/anat.yaml
+++ b/src/schema/rules/files/raw/anat.yaml
@@ -26,6 +26,7 @@ nonparametric:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     echo: optional
     part: optional
@@ -62,6 +63,7 @@ parametric:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     chunk: optional
 
@@ -81,6 +83,7 @@ defacemask:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     modality: optional
     chunk: optional
@@ -102,6 +105,7 @@ multiecho:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     echo: required
     part: optional
@@ -123,6 +127,7 @@ multiflip:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     echo: optional
     flip: required
@@ -145,6 +150,7 @@ multiinversion:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     inversion: required
     part: optional
@@ -166,6 +172,7 @@ mp2rage:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     echo: optional
     flip: optional
@@ -190,6 +197,7 @@ vfamt:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     echo: optional
     flip: required
@@ -213,6 +221,7 @@ mtr:
     acquisition: optional
     ceagent: optional
     reconstruction: optional
+    direction: optional
     run: optional
     mtransfer: required
     part: optional


### PR DESCRIPTION
Closes none.

Changes proposed:
- Split MESE and MEGRE suffix entity sets.
- Add optional direction entity to the raw MESE anatomical suffix.