### PR TITLE
[ENH] Formalize presence of optional docs/ folder

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -392,6 +392,7 @@ Derivatives can be stored/distributed in two ways:
     that were used to generate the derivatives.
     Likewise, any code used to generate the derivatives from the source data
     MAY be included in the `code/` subdirectory.
+    Extra documentation (and relevant images) MAY be included in the `docs/` subdirectory.
     Logs from running the code or other commands MAY be stored under `logs/` subdirectory.
 
     Example of a derivative dataset including the raw dataset as source:

--- a/src/schema/rules/directories.yaml
+++ b/src/schema/rules/directories.yaml
@@ -34,6 +34,10 @@ raw:
     name: derivatives
     level: optional
     opaque: true
+  docs:
+    name: docs
+    level: optional
+    opaque: true
   logs:
     name: logs
     level: optional

--- a/src/schema/rules/files/common/core.yaml
+++ b/src/schema/rules/files/common/core.yaml
@@ -36,6 +36,9 @@ code:
 derivatives:
   level: optional
   path: derivatives
+docs:
+  level: optional
+  path: docs
 logs:
   level: optional
   path: logs


### PR DESCRIPTION
Inspired by the success of the
https://github.com/bids-standard/bids-specification/pull/1962 adding formalization of `logs/` folder, and triggered by the use-case in DANDI https://github.com/dandi/dandi-docs/pull/200 seeking to add more elaborate descriptions to the README (or more specifically README.md), I would like to propose adding any extra documentation and associated artwork (images, videos, etc) under `docs/` folder.  I do not think it is worth breaking down more (as videos/) etc, since it could confuse with data types (videos of behavior or alike).

Not sure if we would want to formalize inner structure anyhow. We could potentially recommend using `docs/images/` subfolder for images.

Then README.md on top level could potentially use those images via references to `docs/` paths.

This would provide further improvement for establishing 
- #1972 