### PR TITLE
feat(schema): Rewrite PHENOTYPE_SUBJECTS_MISSING to run on each phenotype file

### DIFF
--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -80,11 +80,6 @@ properties:
             type: array
             items:
               type: string
-          phenotype:
-            description: 'The union of participant_id columns in phenotype files'
-            type: array
-            items:
-              type: string
   subject:
     description: 'Properties and contents of the current subject'
     type: object
@@ -106,11 +101,6 @@ properties:
               type: string
           session_id:
             description: 'The session_id column of sessions.tsv'
-            type: array
-            items:
-              type: string
-          phenotype:
-            description: 'The union of session_id columns in phenotype files'
             type: array
             items:
               type: string

--- a/src/schema/rules/checks/dataset.yaml
+++ b/src/schema/rules/checks/dataset.yaml
@@ -30,24 +30,6 @@ ParticipantIDMismatch:
         sorted(dataset.subjects.sub_dirs)
       )
 
-# 51
-PhenotypeSubjectsMissing:
-  issue:
-    code: PHENOTYPE_SUBJECTS_MISSING
-    message: |
-      A phenotype/ .tsv file lists subjects that were not found in
-      the participant_id column found in the participants.tsv file.
-    level: error
-  selectors:
-    - path == '/participants.tsv'
-    - type(dataset.subjects.phenotype) != 'null'
-  checks:
-    - |
-      allequal(
-        sorted(intersects(columns.participant_id, dataset.subjects.phenotype)),
-        sorted(dataset.subjects.phenotype)
-      )
-
 # 214
 SamplesTSVMissing:
   issue:

--- a/src/schema/rules/checks/phenotype.yaml
+++ b/src/schema/rules/checks/phenotype.yaml
@@ -1,0 +1,21 @@
+# Rules for phenotype files
+---
+
+# 51
+PhenotypeSubjectsMissing:
+  issue:
+    code: PHENOTYPE_SUBJECTS_MISSING
+    message: |
+      A phenotype/ .tsv file lists subjects that were not found in
+      the participant_id column found in the participants.tsv file.
+    level: error
+  selectors:
+    - datatype == 'phenotype'
+    - suffix == '.tsv'
+    - type(dataset.subjects.participant_id) != 'null'
+  checks:
+    - |
+      allequal(
+        sorted(intersects(columns.participant_id, dataset.subjects.participant_id)),
+        sorted(dataset.subjects.participant_id)
+      )


### PR DESCRIPTION
This builds on and takes advantage of #2050 to select phenotype files and compare the `participant_id` column to the dataset-global `dataset.subjects.participant_id`, which is populated from `participants.tsv`.

This does two things for validation implementations:

1) It allows the specific phenotype file with extra participants to be identified, since the phenotype participants are not collapsed into one superset.
2) It allows us to avoid calculating the union at validator startup, which could be potentially costly for files with many phenotype files, as well as avoid loading each phenotype file twice (or hold a long-lived cache of all phenotype data).

Note that #2050 is not strictly required in order to use this check, as validating phenotype file names already requires us to have it as a pseudo-datatype. I do think a second use case (with more expected from BEP36) justifies moving this from implementation detail to official spec language.