### PR TITLE
rf(schemacode): Update packaging, minimum Python, resource loading

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
             python-version: 3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+src/schema.json
+
 site/
 .DS_Store
 .idea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,7 @@ repos:
       - id: mypy
         # Sync with project.optional-dependencies.typing
         additional_dependencies:
+          - acres
           - click
           - markdown-it-py
           - pandas-stubs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,6 @@ repos:
         additional_dependencies:
           - click
           - markdown-it-py
-          - importlib_resources
           - pandas-stubs
           - pyparsing
           - pytest

--- a/tools/schemacode/MANIFEST.in
+++ b/tools/schemacode/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include tests *

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -9,11 +9,10 @@ authors = [{name = "bids-standard developers"}]
 maintainers = [{name = "bids-standard developers", email = "bids.maintenance@gmail.com"}]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "click",
     "pyyaml",
-    'importlib_resources; python_version < "3.9"',
     "jsonschema",
 ]
 classifiers = [
@@ -21,10 +20,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
 

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -1,34 +1,94 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "bidsschematools"
+description = "Python tools for working with the BIDS schema."
+authors = [{name = "bids-standard developers"}]
+maintainers = [{name = "bids-standard developers", email = "bids.maintenance@gmail.com"}]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "click",
+    "pyyaml",
+    'importlib_resources; python_version < "3.9"',
+    "jsonschema",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+doc = [
+    "sphinx>=1.5.3",
+    "sphinx_rtd_theme",
+]
+render = [
+    "tabulate",
+    "pandas",
+    "markdown-it-py",
+]
+expressions = ["pyparsing"]
+tests = [
+    "codecov",
+    "coverage[toml]",
+    "flake8",
+    "flake8-black",
+    "flake8-isort",
+    "pytest",
+    "pytest-cov",
+]
+all = [
+    "bidsschematools[doc,render,tests,expressions]",
+]
+
+[project.scripts]
+bst = "bidsschematools.__main__:cli"
+
+[project.urls]
+Homepage = "https://github.com/bids-standard/bids-specification"
+
+[tool.setuptools.package-data]
+bidsschematools = [
+    "data/metaschema.json",
+    "data/schema.json",
+    "data/schema/BIDS_VERSION",
+    "data/schema/SCHEMA_VERSION",
+    "data/schema/**/*.yaml",
+    "tests/data/*",
+]
+
+[tool.setuptools.dynamic]
+version = {file = ["src/bidsschematools/data/schema/SCHEMA_VERSION"]}
 
 [tool.black]
 line-length = 99
-target-version = ['py37']
 include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.github
-    | \.hg
-    | \.pytest_cache
-    | _build
-    | build
-    | dist
-  )/
-)
-'''
 
 [tool.isort]
 profile = "black"
 multi_line_output = 3
 
 [tool.pytest.ini_options]
+addopts = "-ra --strict-markers --strict-config"
+log_cli = true
+log_cli_level = "INFO"
 markers = [
   "validate_schema: tests that validate the schema itself",
 ]
+minversion = "6.0"
+xfail_strict = true
+
 
 [tool.coverage.paths]
 source = [

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "acres",
     "click",
     "pyyaml",
-    "jsonschema",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -30,6 +29,9 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+validation = [
+    "jsonschema",
+]
 doc = [
     "sphinx>=1.5.3",
     "sphinx_rtd_theme",
@@ -41,6 +43,7 @@ render = [
 ]
 expressions = ["pyparsing"]
 tests = [
+    "bidsschematools[validation,render,expressions]",
     "codecov",
     "coverage[toml]",
     "flake8",
@@ -50,7 +53,7 @@ tests = [
     "pytest-cov",
 ]
 all = [
-    "bidsschematools[doc,render,tests,expressions]",
+    "bidsschematools[doc,tests]",
 ]
 
 [project.scripts]

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -11,6 +11,7 @@ license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
+    "acres",
     "click",
     "pyyaml",
     "jsonschema",

--- a/tools/schemacode/setup.cfg
+++ b/tools/schemacode/setup.cfg
@@ -1,68 +1,3 @@
-[metadata]
-name = bidsschematools
-version = file:src/bidsschematools/data/schema/SCHEMA_VERSION
-url = https://github.com/bids-standard/bids-specification
-author = bids-standard developers
-author_email = bids.maintenance@gmail.com
-description = Python tools for working with the BIDS schema.
-long_description = file:README.md
-long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
-license = MIT
-classifiers =
-    Development Status :: 4 - Beta
-    Intended Audience :: Science/Research
-    Topic :: Scientific/Engineering :: Information Analysis
-    License :: OSI Approved :: MIT License
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-
-[options]
-python_requires = >=3.8
-install_requires =
-    click
-    pyyaml
-    importlib_resources; python_version < "3.9"
-    jsonschema
-zip_safe = false
-
-[options.extras_require]
-doc =
-    sphinx>=1.5.3
-    sphinx_rtd_theme
-render =
-    tabulate
-    pandas
-    markdown-it-py
-expressions =
-    pyparsing
-tests =
-    codecov
-    coverage[toml]
-    flake8
-    flake8-black
-    flake8-isort
-    pytest
-    pytest-cov
-all =
-    %(doc)s
-    %(render)s
-    %(tests)s
-    %(expressions)s
-
-[options.package_data]
-bidsschematools =
-    data/metaschema.json
-    data/schema/BIDS_VERSION
-    data/schema/SCHEMA_VERSION
-    data/schema/**/*.yaml
-    tests/data/*
-
-[options.entry_points]
-console_scripts =
-    bst=bidsschematools.__main__:cli
-
 [flake8]
 max-line-length = 99
 exclude = *build/
@@ -70,6 +5,3 @@ ignore = E203,E402,E722,W503
 per-file-ignores =
     */__init__.py : F401
 docstring-convention = numpy
-
-[tool:pytest]
-log_cli = true

--- a/tools/schemacode/src/bidsschematools/__init__.py
+++ b/tools/schemacode/src/bidsschematools/__init__.py
@@ -11,16 +11,16 @@ __all__ = ("__version__", "__bids_version__")
 
 
 def __getattr__(attr):
-    from .data import load_resource
+    from .data import load
 
     if attr == "__version__":
         global __version__
-        __version__ = load_resource("schema/SCHEMA_VERSION").read_text().strip()
+        __version__ = load.readable("schema/SCHEMA_VERSION").read_text().strip()
         __version__.__doc__ = "Schema version"
         return __version__
     elif attr == "__bids_version__":
         global __bids_version__
-        __bids_version__ = load_resource("schema/BIDS_VERSION").read_text().strip()
+        __bids_version__ = load.readable("schema/BIDS_VERSION").read_text().strip()
         __bids_version__.__doc__ = "BIDS specification version"
         return __bids_version__
 

--- a/tools/schemacode/src/bidsschematools/__init__.py
+++ b/tools/schemacode/src/bidsschematools/__init__.py
@@ -4,24 +4,32 @@
 .. autodata:: __bids_version__
 """
 
-global __version__
-global __bids_version__
+__version__: str
+__bids_version__: str
 
 __all__ = ("__version__", "__bids_version__")
 
 
-def __getattr__(attr):
+def __getattr__(attr: str) -> str:
+    """Lazily load the schema version and BIDS version from the filesystem."""
+    from typing import TypeVar
+
     from .data import load
 
-    if attr == "__version__":
-        global __version__
-        __version__ = load.readable("schema/SCHEMA_VERSION").read_text().strip()
-        __version__.__doc__ = "Schema version"
-        return __version__
-    elif attr == "__bids_version__":
-        global __bids_version__
-        __bids_version__ = load.readable("schema/BIDS_VERSION").read_text().strip()
-        __bids_version__.__doc__ = "BIDS specification version"
-        return __bids_version__
+    T = TypeVar("T")
+
+    def document(obj: T, docstring: str) -> T:
+        tp = type(obj)
+        return type(tp.__name__, (tp,), {"__doc__": docstring})(obj)
+
+    versions = {
+        "__version__": ("schema/SCHEMA_VERSION", "Schema version"),
+        "__bids_version__": ("schema/BIDS_VERSION", "BIDS specification version"),
+    }
+
+    if attr in versions:
+        resource, docstring = versions[attr]
+        globals()[attr] = document(load.readable(resource).read_text().strip(), docstring)
+        return globals()[attr]
 
     raise AttributeError(f"module {__spec__.name!r} has no attribute {attr!r}")

--- a/tools/schemacode/src/bidsschematools/__init__.py
+++ b/tools/schemacode/src/bidsschematools/__init__.py
@@ -4,15 +4,24 @@
 .. autodata:: __bids_version__
 """
 
-try:  # Prefer backport to leave consistency to dependency spec
-    from importlib_resources import files
-except ImportError:
-    from importlib.resources import files  # type: ignore
+global __version__
+global __bids_version__
 
-version_file = files("bidsschematools.data") / "schema" / "SCHEMA_VERSION"
-__version__ = version_file.read_text().strip()
-"Schema version"
+__all__ = ("__version__", "__bids_version__")
 
-bids_version_file = files("bidsschematools.data") / "schema" / "BIDS_VERSION"
-__bids_version__ = bids_version_file.read_text().strip()
-"BIDS specification version"
+
+def __getattr__(attr):
+    from .data import load_resource
+
+    if attr == "__version__":
+        global __version__
+        __version__ = load_resource("schema/SCHEMA_VERSION").read_text().strip()
+        __version__.__doc__ = "Schema version"
+        return __version__
+    elif attr == "__bids_version__":
+        global __bids_version__
+        __bids_version__ = load_resource("schema/BIDS_VERSION").read_text().strip()
+        __bids_version__.__doc__ = "BIDS specification version"
+        return __bids_version__
+
+    raise AttributeError(f"module {__spec__.name!r} has no attribute {attr!r}")

--- a/tools/schemacode/src/bidsschematools/__main__.py
+++ b/tools/schemacode/src/bidsschematools/__main__.py
@@ -7,7 +7,6 @@ from itertools import chain
 
 import click
 
-from .data import load_resource
 from .rules import regexify_filename_rules
 from .schema import export_schema, load_schema
 from .utils import configure_logger, get_logger
@@ -48,7 +47,9 @@ def export(ctx, schema, output):
 @click.pass_context
 def export_metaschema(ctx, output):
     """Export BIDS schema to JSON document"""
-    metaschema = load_resource("metaschema.json").read_text()
+    from .data import load
+
+    metaschema = load.readable("metaschema.json").read_text()
     if output == "-":
         print(metaschema, end="")
     else:

--- a/tools/schemacode/src/bidsschematools/__main__.py
+++ b/tools/schemacode/src/bidsschematools/__main__.py
@@ -7,11 +7,7 @@ from itertools import chain
 
 import click
 
-if sys.version_info < (3, 9):
-    from importlib_resources import files
-else:
-    from importlib.resources import files
-
+from .data import load_resource
 from .rules import regexify_filename_rules
 from .schema import export_schema, load_schema
 from .utils import configure_logger, get_logger
@@ -52,7 +48,7 @@ def export(ctx, schema, output):
 @click.pass_context
 def export_metaschema(ctx, output):
     """Export BIDS schema to JSON document"""
-    metaschema = files("bidsschematools.data").joinpath("metaschema.json").read_text()
+    metaschema = load_resource("metaschema.json").read_text()
     if output == "-":
         print(metaschema, end="")
     else:

--- a/tools/schemacode/src/bidsschematools/conftest.py
+++ b/tools/schemacode/src/bidsschematools/conftest.py
@@ -2,8 +2,11 @@ import logging
 import tempfile
 from pathlib import Path
 from subprocess import run
+from typing import Generator
 
 import pytest
+
+from . import data
 
 lgr = logging.getLogger()
 
@@ -90,12 +93,10 @@ def get_gitrepo_fixture(url, whitelist):
 
 
 @pytest.fixture(scope="session")
-def schema_dir():
+def schema_dir() -> Generator[str, None, None]:
     """Path to the schema housed in the bids-specification repo."""
-    from bidsschematools import utils
-
-    bids_schema = utils.get_bundled_schema_path()
-    return bids_schema
+    with data.load.as_path("schema") as schema_path:
+        yield str(schema_path)
 
 
 @pytest.fixture(scope="session")

--- a/tools/schemacode/src/bidsschematools/data/__init__.py
+++ b/tools/schemacode/src/bidsschematools/data/__init__.py
@@ -6,20 +6,11 @@
 import atexit
 import os
 from contextlib import ExitStack
-from functools import cached_property
+from functools import cache, cached_property
+from importlib.resources import as_file, files
 from pathlib import Path
 from types import ModuleType
 from typing import Union
-
-try:
-    from functools import cache
-except ImportError:  # PY38
-    from functools import lru_cache as cache
-
-try:  # Prefer backport to leave consistency to dependency spec
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files  # type: ignore
 
 __all__ = ["load_resource"]
 

--- a/tools/schemacode/src/bidsschematools/data/__init__.py
+++ b/tools/schemacode/src/bidsschematools/data/__init__.py
@@ -1,91 +1,14 @@
 """Module containing data files, including the schema source files
 
-.. autofunction:: load_resource
+.. autofunction:: load
+
+.. automethod:: load.readable
+
+.. automethod:: load.as_path
+
+.. automethod:: load.cached
 """
 
-import atexit
-import os
-from contextlib import ExitStack
-from functools import cache, cached_property
-from importlib.resources import as_file, files
-from pathlib import Path
-from types import ModuleType
-from typing import Union
+from acres import Loader
 
-__all__ = ["load_resource"]
-
-
-class Loader:
-    """A loader for package files relative to a module
-
-    This class wraps :mod:`importlib.resources` to provide a getter
-    function with an interpreter-lifetime scope. For typical packages
-    it simply passes through filesystem paths as :class:`~pathlib.Path`
-    objects. For zipped distributions, it will unpack the files into
-    a temporary directory that is cleaned up on interpreter exit.
-
-    This loader accepts a fully-qualified module name or a module
-    object.
-
-    Expected usage::
-
-        '''Data package
-
-        .. autofunction:: load_data
-        '''
-
-        from bidsschematools.data import Loader
-
-        load_data = Loader(__package__)
-
-    :class:`~Loader` objects implement the :func:`callable` interface
-    and generate a docstring, and are intended to be treated and documented
-    as functions.
-    """
-
-    def __init__(self, anchor: Union[str, ModuleType]):
-        self._anchor = anchor
-        self.files = files(anchor)
-        self.exit_stack = ExitStack()
-        atexit.register(self.exit_stack.close)
-        # Allow class to have a different docstring from instances
-        self.__doc__ = self._doc
-
-    @cached_property
-    def _doc(self):
-        """Construct docstring for instances
-
-        Lists the public top-level paths inside the location, where
-        non-public means has a `.` or `_` prefix or is a 'tests'
-        directory.
-        """
-        top_level = sorted(
-            os.path.relpath(p, self.files) + "/"[: p.is_dir()]
-            for p in self.files.iterdir()
-            if p.name[0] not in (".", "_") and p.name != "tests"
-        )
-        doclines = [
-            f"Load package files relative to ``{self._anchor}``.",
-            "",
-            "This package contains the following (top-level) files/directories:",
-            "",
-            *(f"* ``{path}``" for path in top_level),
-        ]
-
-        return "\n".join(doclines)
-
-    @cache
-    def __call__(self, *segments) -> Path:
-        """Ensure data is available as a :class:`~pathlib.Path`.
-
-        Any temporary files that are created remain available throughout
-        the duration of the program, and are deleted when Python exits.
-
-        Results are cached so that multiple calls do not unpack the same
-        data multiple times, but the cache is sensitive to the specific
-        argument(s) passed.
-        """
-        return self.exit_stack.enter_context(as_file(self.files.joinpath(*segments)))
-
-
-load_resource = Loader(__package__)
+load = Loader(__spec__.name)

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -8,8 +8,6 @@ from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from functools import lru_cache
 
-from jsonschema import ValidationError, validate
-
 from . import __bids_version__, __version__, data, utils
 from .types import Namespace
 
@@ -292,6 +290,14 @@ def filter_schema(schema, **kwargs):
 
 def validate_schema(schema: Namespace):
     """Validate a schema against the BIDS metaschema."""
+    try:
+        from jsonschema import ValidationError, validate
+    except ImportError as e:
+        raise RuntimeError(
+            "The `jsonschema` package is required to validate schemas. "
+            "Please install it with `pip install jsonschema`."
+        ) from e
+
     from .data import load
 
     metaschema = json.loads(load.readable("metaschema.json").read_text())

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -3,7 +3,6 @@
 import json
 import os
 import re
-import sys
 import tempfile
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
@@ -11,12 +10,8 @@ from functools import lru_cache
 
 from jsonschema import ValidationError, validate
 
-if sys.version_info < (3, 9):
-    from importlib_resources import files
-else:
-    from importlib.resources import files
-
 from . import __bids_version__, __version__, utils
+from .data import load_resource
 from .types import Namespace
 
 lgr = utils.get_logger()
@@ -298,7 +293,7 @@ def filter_schema(schema, **kwargs):
 
 def validate_schema(schema: Namespace):
     """Validate a schema against the BIDS metaschema."""
-    metaschema = json.loads(files("bidsschematools.data").joinpath("metaschema.json").read_text())
+    metaschema = json.loads(load_resource("metaschema.json").read_text())
 
     # validate is put in this try/except clause because the error is sometimes too long to
     # print in the terminal

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -10,8 +10,7 @@ from functools import lru_cache
 
 from jsonschema import ValidationError, validate
 
-from . import __bids_version__, __version__, utils
-from .data import load_resource
+from . import __bids_version__, __version__, data, utils
 from .types import Namespace
 
 lgr = utils.get_logger()
@@ -204,7 +203,7 @@ def load_schema(schema_path=None):
     This function is cached, so it will only be called once per schema path.
     """
     if schema_path is None:
-        schema_path = utils.get_bundled_schema_path()
+        schema_path = data.load.readable("schema")
         lgr.info("No schema path specified, defaulting to the bundled schema, `%s`.", schema_path)
     schema = Namespace.from_directory(schema_path)
     if not schema.objects:
@@ -293,7 +292,9 @@ def filter_schema(schema, **kwargs):
 
 def validate_schema(schema: Namespace):
     """Validate a schema against the BIDS metaschema."""
-    metaschema = json.loads(load_resource("metaschema.json").read_text())
+    from .data import load
+
+    metaschema = json.loads(load.readable("metaschema.json").read_text())
 
     # validate is put in this try/except clause because the error is sometimes too long to
     # print in the terminal

--- a/tools/schemacode/src/bidsschematools/tests/data/__init__.py
+++ b/tools/schemacode/src/bidsschematools/tests/data/__init__.py
@@ -1,10 +1,16 @@
 """Test data module
 
 .. autofunction:: load_test_data
+
+.. automethod:: load_test_data.readable
+
+.. automethod:: load_test_data.as_path
+
+.. automethod:: load_test_data.cached
 """
 
-from ...data import Loader
+from acres import Loader
 
 __all__ = ("load_test_data",)
 
-load_test_data = Loader(__package__)
+load_test_data = Loader(__spec__.name)

--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -8,12 +8,12 @@ from jsonschema.exceptions import ValidationError
 
 from bidsschematools import __bids_version__, schema, types
 
-from ..data import load_resource
+from ..data import load
 
 
 def test__get_bids_version(tmp_path):
     # Is the version being read in correctly?
-    schema_path = str(load_resource("schema"))
+    schema_path = str(load("schema"))
     bids_version = schema._get_bids_version(schema_path)
     assert bids_version == __bids_version__
 

--- a/tools/schemacode/src/bidsschematools/tests/test_validator.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_validator.py
@@ -6,7 +6,7 @@ import pytest
 from bidsschematools.conftest import BIDS_ERROR_SELECTION, BIDS_SELECTION
 from bidsschematools.validator import select_schema_path, validate_bids
 
-from ..data import load_resource
+from ..data import load
 from .data import load_test_data
 
 
@@ -155,9 +155,8 @@ def test_validate_bids(bids_examples, tmp_path):
     assert len(result["path_tracking"]) == 0
 
     # Is the schema version recorded correctly?
-    schema_path = load_resource("schema")
-    with open(os.path.join(schema_path, "BIDS_VERSION")) as f:
-        expected_version = f.readline().rstrip()
+    schema_path = load.readable("schema")
+    expected_version = schema_path.joinpath("BIDS_VERSION").read_text().rstrip()
     assert result["bids_version"] == expected_version
 
 
@@ -279,9 +278,7 @@ def test_bids_schema_versioncheck(monkeypatch):
     """Test incompatible version."""
     import bidsschematools as bst
 
-    from ..utils import get_bundled_schema_path
-
-    schema_dir = get_bundled_schema_path()
+    schema_dir = bst.data.load.readable("schema")
     assert bst.validator._bids_schema_versioncheck(schema_dir)
     monkeypatch.setattr(bst, "__version__", "99.99.99")
     assert not bst.validator._bids_schema_versioncheck(schema_dir)

--- a/tools/schemacode/src/bidsschematools/types/namespace.py
+++ b/tools/schemacode/src/bidsschematools/types/namespace.py
@@ -258,7 +258,9 @@ class Namespace(MutableMapping):
     @classmethod
     def from_directory(cls, path, fmt="yaml"):
         if fmt == "yaml":
-            return cls.build(_read_yaml_dir(Path(path)))
+            if isinstance(path, str):
+                path = Path(path)
+            return cls.build(_read_yaml_dir(path))
         raise NotImplementedError(f"Unknown format: {fmt}")
 
     def to_json(self, **kwargs) -> str:

--- a/tools/schemacode/src/bidsschematools/validator.py
+++ b/tools/schemacode/src/bidsschematools/validator.py
@@ -41,10 +41,12 @@ def _bids_schema_versioncheck(schema_dir, compatibility=VALIDATOR_SCHEMA_COMPATI
     if compatibility not in ("major", "minor"):
         raise ValueError("Schema compatibility needs to be set to either “major” or “minor”.")
 
-    schema_version_file = os.path.join(schema_dir, "SCHEMA_VERSION")
+    if isinstance(schema_dir, str):
+        schema_dir = Path(schema_dir)
+
+    schema_version_file = schema_dir.joinpath("SCHEMA_VERSION")
     try:
-        with open(schema_version_file, "r") as f:
-            schema_version = f.readlines()[0].strip()
+        schema_version = schema_version_file.read_text().strip()
     except FileNotFoundError:
         lgr.warning(
             "The selected schema directory, `%s`, does not contain a SCHEMA_VERSION file. "
@@ -311,8 +313,7 @@ def select_schema_path(
     (2) a concatenation of `bids_reference_root` the detected version specification
         inside the BIDS root directory, if such a directory is provided and the BIDS version
         schema is compatible with the validator.
-    (3) `None`, expanded to the bundled schema supplied with the validator by
-        `bst.utils.get_bundled_schema_path`.
+    (3) `None`, expanded to the bundled schema.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR is some house-keeping before some larger changes I would like to make to the bidsschematools package. Those changes include switching to PDM for writing build hooks to install a compiled JSON schema in the package. To do that, we need to switch to pyproject.toml, at which point we should probably drop Python 3.8 support and use the [acres](https://pypi.org/project/acres/) package to abstract away `importlib_resources`.