### PR TITLE
[BF]: use web archive link for now gone behind login page about fieldmaps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
                 --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
                 --ignore-url 'https://www.incf.org' \
                 --ignore-url 'https://dicomlookup.com/dicomtags/.*' \
+                --ignore-url 'https://www.instagram.com/bidsstandard/' \
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -82,7 +82,7 @@ A guide for using macros can be found at
 the size of the actual reconstructed data in the phase direction (which is NOT
 reflected in a single DICOM Tag for all possible aforementioned scan
 manipulations). See
-[Acquiring and using field maps - LCNI](https://lcni.uoregon.edu/wiki/acquiring-and-using-field-maps/)
+[Acquiring and using field maps - LCNI](https://web.archive.org/web/20240709020334/https://lcni.uoregon.edu/wiki/acquiring-and-using-field-maps/)
 and [TotalReadoutTime - dcm\_qa](https://github.com/neurolabusc/dcm_qa/tree/master/In/TotalReadoutTime).
 
 <sup>3</sup>We use the time between the center of the first "effective" echo


### PR DESCRIPTION
ATM we have CI red because of

```
...

URL        `https://lcni.uoregon.edu/wiki/acquiring-and-using-field-maps/'
Name       `Acquiring and using field maps - LCNI'
Parent URL file:///home/circleci/project/site/modality-specific-files/magnetic-resonance-imaging-data.html, line 2908, col 1
Real URL   https://blogs.uoregon.edu/lcni/wp-login.php?privacy=1&redirect_to=https%3A%2F%2Fblogs.uoregon.edu%2Flcni%2Fwiki%2Facquiring-and-using-field-maps%2F%2F
Check time 0.804 seconds
Warning    [http-redirected] Redirected to
           `https://blogs.uoregon.edu/lcni/wp-login.php?privacy=1&redirect_to=https%3A%2F%2Fblogs.uoregon.edu%2Flcni%2Fwiki%2Facquiring-and-using-field-maps%2F%2F'
           status: 302 Found.
Result     Valid: 200 OK
 1 thread active,    12 links queued, 1154 links in 1168 URLs checked, runtime 1 minute, 1 seconds

Statistics:
Downloaded: 3.37MB.
Content types: 0 image, 229 text, 0 video, 0 audio, 10 application, 0 mail and 928 other.
URL lengths: min=17, max=150, avg=57.

That's it. 1167 links in 1168 URLs checked. 1 warning found. 0 errors found.
Stopped checking at 2025-05-06 21:57:11+000 (1 minute, 6 seconds)

Exited with code exit status 1
```

hopefully this would address it and makes CI green again