### PR TITLE
BF(test): reintroduce import of the load

### DIFF
--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -10,6 +10,8 @@ from jsonschema.exceptions import ValidationError
 
 from bidsschematools import __bids_version__, schema, types
 
+from ..data import load
+
 
 def test__get_bids_version(schema_dir):
     # Is the version being read in correctly?
@@ -372,7 +374,7 @@ def test_valid_schema_with_check_jsonschema(tmp_path, regex_variant):
     using the `check-jsonschema` CLI
     """
     bids_schema = schema.load_schema().to_dict()
-    metaschema_path = str(load("metaschema.json"))
+    metaschema_path = str(load.readable("metaschema.json"))
 
     # Save BIDS schema to a temporary file
     bids_schema_path = tmp_path / "bids_schema.json"


### PR DESCRIPTION
This code seems got broken by #4604.  My semi-blind (did not test locally) attempt to fix

otherwise we have multiple CIs red ATM, e.g.

![image](https://github.com/user-attachments/assets/478786be-f1c2-45e1-af32-a01515daf4bf)

![image](https://github.com/user-attachments/assets/52421ce2-9efb-4603-a947-ccc4b578f468)
