### PR TITLE
Remove reference to dicm2nii altogether and point to page with more converters

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -462,7 +462,8 @@ indicated with "**Corresponds to** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
 When harmonization has been deemed necessary, this is indicated in the
 BIDS term description with "**Based on** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
 Extraction of BIDS compatible metadata can be performed using
-DICOM to NIfTI converters such as [dcm2niix](https://github.com/rordenlab/dcm2niix).
+[DICOM to NIfTI converters](https://bids.neuroimaging.io/tools/converters.html)
+such as [dcm2niix](https://github.com/rordenlab/dcm2niix).
 The [BIDS-validator](https://github.com/bids-standard/bids-validator)
 will check for conflicts between the JSON file and the data recorded in the
 NIfTI header.

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -461,9 +461,9 @@ Where possible, DICOM Tags are adopted directly as BIDS metadata terms and
 indicated with "**Corresponds to** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
 When harmonization has been deemed necessary, this is indicated in the
 BIDS term description with "**Based on** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
-Extraction of BIDS compatible metadata can be performed using [dcm2niix](https://github.com/rordenlab/dcm2niix)
-and [dicm2nii](https://www.mathworks.com/matlabcentral/fileexchange/42997-xiangruili-dicm2nii)
-DICOM to NIfTI converters. The [BIDS-validator](https://github.com/bids-standard/bids-validator)
+Extraction of BIDS compatible metadata can be performed using
+DICOM to NIfTI converters such as [dcm2niix](https://github.com/rordenlab/dcm2niix).
+The [BIDS-validator](https://github.com/bids-standard/bids-validator)
 will check for conflicts between the JSON file and the data recorded in the
 NIfTI header.
 


### PR DESCRIPTION
links checker started to fail, and I see

    ❯ wget -S https://www.mathworks.com/matlabcentral/fileexchange/42997-xiangruili-dicm2nii
    --2025-05-21 16:18:06--  https://www.mathworks.com/matlabcentral/fileexchange/42997-xiangruili-dicm2nii
    Resolving www.mathworks.com (www.mathworks.com)... 23.197.176.176
    Connecting to www.mathworks.com (www.mathworks.com)|23.197.176.176|:443... connected.
    HTTP request sent, awaiting response...
      HTTP/1.1 503 Service Unavailable

and in the browser I see "no healthy upstream" for that URL.

https://github.com/xiangruili/dicm2nii was indeed last updated 9 months ago and overall IMHO just a very basic (no unittests etc) project.  I think standard should not promote/point to tools which are not developed with active participation in the project. dcm2niix is actively developed in sync and participation in BIDS, so IMHO worth leaving in.