### PR TITLE
Revert "[ENH] Allow MED format for iEEG data (`*_ieeg.medd/`) (#1956)"

### DIFF
--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -38,7 +38,6 @@ stored in one of the following formats:
 | [EEGLAB](https://sccn.ucsd.edu/eeglab/index.php)                          | `.set`, `.fdt`           | The format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab/index.php). Each recording consists of a `.set` file with an OPTIONAL `.fdt` file.             |
 | [Neurodata Without Borders](https://nwb-schema.readthedocs.io/en/latest/) | `.nwb`                   | Each recording consists of a single `.nwb` file.                                                                                                                           |
 | [MEF3](https://osf.io/e3sf9/)                                             | `.mefd`                  | Each recording consists of a `.mefd` directory.                                                                                                                            |
-| [MED](https://medformat.org/)                                             | `.medd`                  | Each recording consists of a `.medd` directory.                                                                                                                            |
 
 It is RECOMMENDED to use the European data format, or the BrainVision data
 format. It is furthermore discouraged to use the other accepted formats over

--- a/src/schema/objects/extensions.yaml
+++ b/src/schema/objects/extensions.yaml
@@ -153,14 +153,6 @@ md:
   display_name: Markdown
   description: |
     A Markdown file.
-medd:
-  value: .medd/
-  display_name: Multiscale Electrophysiology Data Format
-  description: |
-    A directory in the [MED](https://medformat.org/) format.
-    Successor to the MEF 3.0 format.
-
-    Each recording consists of a `.medd` directory.
 mefd:
   value: .mefd/
   display_name: Multiscale Electrophysiology File Format Version 3.0

--- a/src/schema/rules/files/raw/ieeg.yaml
+++ b/src/schema/rules/files/raw/ieeg.yaml
@@ -3,7 +3,6 @@ ieeg:
   suffixes:
     - ieeg
   extensions:
-    - .medd/
     - .mefd/
     - .json
     - .edf


### PR DESCRIPTION
This reverts commit 436d7cde4c4f5edce4d57085d36ab457e51da6e3.

Adding this format needs additional vetting, per steering group decision.