### PR TITLE
[SCHEMA] Allow HED has an optional column on selected files

### DIFF
--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -15,6 +15,7 @@ Participants:
     handedness: recommended
     strain: recommended
     strain_rrid: recommended
+    HED: optional
   index_columns: [participant_id]
   additional_columns: allowed
 
@@ -42,6 +43,7 @@ Scans:
       description_addendum: |
         There MUST be exactly one row for each file.
     acq_time__scans: optional
+    HED: optional
   index_columns: [filename]
   additional_columns: allowed
 
@@ -58,5 +60,6 @@ Sessions:
         There MUST be exactly one row for each session.
     acq_time__sessions: optional
     pathology: recommended
+    HED: optional
   index_columns: [session_id]
   additional_columns: allowed


### PR DESCRIPTION
HED used to be allowed in various `.tsv` files including the `participants.tsv`, `scans.tsv`, `sessions.tsv`, and `samples.tsv` as well as the `.tsv` files in the `phenotypes` directory. At some point this became disallowed, and the HED in these files may not be validated. The [`eeg_ds003645s_hed_demo`](https://github.com/bids-standard/bids-examples/tree/master/eeg_ds003645s_hed_demo) dataset in the bids examples illustrates this usage.

This PR modifies the schema to allow them again.  It does not address the `phenotypes` directory, as I am not sure how this should be done.