### PR TITLE
feat: Define phenotype/*.tsv in schema, add HED to modality agnostic tables

### DIFF
--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -63,3 +63,14 @@ Sessions:
     HED: optional
   index_columns: [session_id]
   additional_columns: allowed
+
+Phenotype:
+  selectors:
+    - datatype == 'phenotype'
+  initial_columns:
+    - participant_id
+  columns:
+    participant_id: required
+    HED: optional
+  index_columns: [participant_id]
+  additional_columns: allowed

--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -15,6 +15,7 @@ Participants:
     handedness: recommended
     strain: recommended
     strain_rrid: recommended
+    HED: optional
   index_columns: [participant_id]
   additional_columns: allowed
 
@@ -42,6 +43,7 @@ Scans:
       description_addendum: |
         There MUST be exactly one row for each file.
     acq_time__scans: optional
+    HED: optional
   index_columns: [filename]
   additional_columns: allowed
 
@@ -58,5 +60,6 @@ Sessions:
         There MUST be exactly one row for each session.
     acq_time__sessions: optional
     pathology: recommended
+    HED: optional
   index_columns: [session_id]
   additional_columns: allowed


### PR DESCRIPTION
Incorporates #2125, and defines `phenotype/*.tsv` files, which are currently unvalidated.

This is targeting the `maint/1.10.0` branch as a schema fixup, not a change to the spec.