### PR TITLE
[FIX] Remove incorrect DICOM correspondence of PartialFourier

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2508,7 +2508,6 @@ PartialFourier:
   display_name: Partial Fourier
   description: |
     The fraction of partial Fourier information collected.
-    Corresponds to [DICOM Tag 0018, 9081](https://dicomlookup.com/dicomtags/(0018,9081)) `Partial Fourier`.
   type: number
 PartialFourierDirection:
   name: PartialFourierDirection


### PR DESCRIPTION
The DICOM tag (0018,9081) is a boolean value, not a partial Fourier fraction.

This implements a discussion between @agahkarakuzu and @neurolabusc in https://github.com/bids-standard/bep001/issues/85.

Closes gh-2110.