### PR TITLE
[FIX] schemapath resolution in dev mode install of bidsschematools

### DIFF
--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -224,7 +224,13 @@ def load_schema(schema_path=None):
 
     # JSON file: just load it
     if schema_path.is_file():
-        return Namespace.from_json(schema_path.read_text())
+        content = schema_path.read_text()
+
+        # Bug in Windows dev mode; 'symlink' style to schema directory does not automatically resolve
+        if content[:3] == "../":
+            schema_path = (Path(__file__) / content).resolve()
+        else:
+            return Namespace.from_json(jsonstr=content)
 
     # YAML directory: load, dereference and set versions
     schema = Namespace.from_directory(schema_path)


### PR DESCRIPTION
I ran into some issues when trying to achieve a local dev install to thoroughly test the `bep032` branch on some real datasets

Investigation revealed that this file: https://github.com/bids-standard/bids-specification/blob/9540a823ed70fa65dcf914e992adabd11c7285fc/tools/schemacode/src/bidsschematools/data/schema, which effectively seems to be a symlink, was being passed diectly into the `Namespace.from_json` as a raw string, instead of being recognized as a path to a directory

This small fix resolved my problems and allowed local installation to occur smoothly as expected

Speculation: possibly related to #2120? A collaborator (@yarikoptic) who showed me how to do this weeks ago was able to do it themselves without any issues

### TODO
- [ ] Add self to contributing
- [ ] Increment patch version