### PR TITLE
feat: Generate context types from schema

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -57,18 +57,18 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
-            python-version: 3
+            python-version: 3.13
           - os: windows-latest
-            python-version: 3
+            python-version: 3.13
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
+      - name: Set up Python ${{ matrix.python-version }} (uv)
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
+          activate-environment: true
 
       - name: "Display Python version"
         run: python -c "import sys; print(sys.version)"
@@ -81,12 +81,17 @@ jobs:
 
       - name: "Install package"
         run: |
-          pip install $( ls dist/*.whl )[all]
+          uv pip install $( ls dist/*.whl )[all]
 
       - name: "Run tests"
         run: |
           python -m pytest -vs --doctest-modules -m "not validate_schema" \
               --cov-append --cov-report=xml --cov-report=term --cov=src/bidsschematools
+        working-directory: tools/schemacode
+
+      - name: "Validate generated types"
+        run: |
+          uvx --with=. mypy tests
         working-directory: tools/schemacode
 
       - name: Upload artifacts

--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Run schema validation tests
         run: |
-          python -m pytest -vs --doctest-modules -m "not validate_schema" \
+          python -m pytest -vs --doctest-modules -m "validate_schema" \
               --cov-append --cov-report=xml --cov-report=term --cov=src/bidsschematools
         working-directory: tools/schemacode
 

--- a/tools/schemacode/docs/conf.py
+++ b/tools/schemacode/docs/conf.py
@@ -48,13 +48,14 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "tests"]
+exclude_patterns = ["_build"]
 
 
 autosummary_mock_imports = [
     "pytest",
     # Mock internal modules to avoid building docs
     "bidsschematools.conftest",
+    "bidsschematools.tests",
 ]
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/tools/schemacode/pdm_build.py
+++ b/tools/schemacode/pdm_build.py
@@ -24,11 +24,22 @@ def pdm_build_initialize(context):
     schema_json.parent.mkdir(parents=True, exist_ok=True)
     schema_json.write_text(schema.to_json())
 
-    context_py = base_dir / "bidsschematools/types/context.py"
-    context_py.parent.mkdir(parents=True, exist_ok=True)
-    context_py.write_text(generate_module(schema))
+    # Write generated code for types
+    # Limit to wheel to avoid duplication while allowing building
+    # the wheel directly from source
+    if context.target == "wheel":
+        context_py = base_dir / "bidsschematools/types/context.py"
+        context_py.parent.mkdir(parents=True, exist_ok=True)
+        context_py.write_text(generate_module(schema, "dataclasses"))
+
+        protocols_py = base_dir / "bidsschematools/types/protocols.py"
+        protocols_py.parent.mkdir(parents=True, exist_ok=True)
+        protocols_py.write_text(generate_module(schema, "protocol"))
 
 
 def pdm_build_update_files(context, files):
     # Dereference symlinks
     files.update({relpath: path.resolve() for relpath, path in files.items()})
+    # Remove code generator, which is not used once installed
+    if context.target == "wheel":
+        del files["bidsschematools/types/_generator.py"]

--- a/tools/schemacode/pdm_build.py
+++ b/tools/schemacode/pdm_build.py
@@ -3,6 +3,7 @@ import sys
 sys.path.insert(0, "src")
 
 import bidsschematools.schema
+from bidsschematools.types._generator import generate_module
 
 
 def pdm_build_initialize(context):
@@ -22,6 +23,10 @@ def pdm_build_initialize(context):
     schema_json = base_dir / "bidsschematools/data/schema.json"
     schema_json.parent.mkdir(parents=True, exist_ok=True)
     schema_json.write_text(schema.to_json())
+
+    context_py = base_dir / "bidsschematools/types/context.py"
+    context_py.parent.mkdir(parents=True, exist_ok=True)
+    context_py.write_text(generate_module(schema))
 
 
 def pdm_build_update_files(context, files):

--- a/tools/schemacode/src/bidsschematools/types/_generator.py
+++ b/tools/schemacode/src/bidsschematools/types/_generator.py
@@ -1,66 +1,131 @@
+"""BIDS validation context code generator
+
+This module produces source code for BIDS validation context classes.
+The source code can be executed at import time to ensure that classes
+are consistent with the current state of the BIDS schema.
+
+When packaging, calling modules should be replaced with the source code
+they execute, ensuring that the classes are available for static analysis
+and can be compiled to bytecode.
+
+This module can be removed during packaging.
+"""
+
 from __future__ import annotations
 
 import json
+from textwrap import dedent, indent
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Protocol
+
+    class Spec(Protocol):
+        prelude: str
+        class_def: str
+        attr_def: str
+        proto_prefix: str
 
 
-PRELUDE = '''\
-"""BIDS validation context definitions
+def with_indent(spaces: int, /):
+    def decorator(attr):
+        return indent(dedent(attr), " " * spaces)
 
-The classes in this module are used to define the context for BIDS validation.
-The context is a namespace that contains relevant information about the dataset
-as a whole and an individual file to be validated.
+    return decorator
 
-These classes are used to define the structure of the context,
-but they cannot be instantiated directly.
-Conforming subtypes need only match the structure of these classes,
-and do not need to inherit from them.
 
-The classes use ``@property`` decorators to indicate that subtypes need only
-provide read access to the attributes, and may restrict writing, for example,
-when calculating attributes dynamically based on other attributes.
+class ProtocolSpec:
+    prelude = dedent('''\
+    """BIDS validation context definitions
 
-Note that some type checkers will not match classes that use
-:class:`functools.cached_property`.
-To permit this, add the following to your module::
+    The classes in this module are used to define the context for BIDS validation.
+    The context is a namespace that contains relevant information about the dataset
+    as a whole and an individual file to be validated.
 
-    if TYPE_CHECKING:
-        cached_property = property
-    else:
-        from functools import cached_property
+    These classes are used to define the structure of the context,
+    but they cannot be instantiated directly.
+    Conforming subtypes need only match the structure of these classes,
+    and do not need to inherit from them.
+    It is recommended to import this module in an ``if TYPE_CHECKING`` block
+    to avoid import costs.
 
-This module has been auto-generated from the BIDS schema version {version}.
-"""
+    The classes use ``@property`` decorators to indicate that subtypes need only
+    provide read access to the attributes, and may restrict writing, for example,
+    when calculating attributes dynamically based on other attributes.
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
+    Note that some type checkers will not match classes that use
+    :class:`functools.cached_property`.
+    To permit this, add the following to your module::
+
+        if TYPE_CHECKING:
+            cached_property = property
+        else:
+            from functools import cached_property
+
+    This module has been auto-generated from the BIDS schema version {version}.
+    """
+
+    from __future__ import annotations
+
     from collections.abc import Mapping, Sequence
     from typing import Any, Literal, Protocol
-else:
-    Any = object
-    Literal = tuple
-    Mapping = dict
-    Protocol = object
-    Sequence = list
 
-__all__ = {__all__}
+    __all__ = {__all__}
 
 
-'''
+    ''')
 
-CLASS = '''\
-class {name}(Protocol):
-    """{docstring}"""
-'''
-
-ATTR = '''\
-    @property
-    def {name}(self) -> {type}:
+    class_def = dedent('''\
+    class {name}(Protocol):
         """{docstring}"""
-'''
+    ''')
+
+    attr_def = with_indent(4)('''\
+        @property
+        def {name}(self) -> {type}:
+            """{docstring}"""
+    ''')
+
+    proto_prefix = ""
+
+
+class DataclassSpec:
+    prelude = dedent('''\
+    """BIDS validation context dataclasses
+
+    The classes in this module may be used to populate the context for BIDS validation.
+
+    This module has been auto-generated from the BIDS schema version {version}.
+    """
+
+    from __future__ import annotations
+
+    from dataclasses import dataclass
+
+    TYPE_CHECKING = False
+    if TYPE_CHECKING:
+        from collections.abc import Mapping, Sequence
+        from typing import Any, Literal
+
+        from . import protocols as p
+
+    __all__ = {__all__}
+
+
+    ''')
+
+    class_def = dedent('''\
+    @dataclass(slots=True, frozen=True)
+    class {name}:
+        """{docstring}"""
+    ''')
+
+    attr_def = with_indent(4)("""\
+        {name}: {type}{default}
+        #: {docstring}
+    """)
+
+    proto_prefix = "p."
 
 
 def snake_to_pascal(name: str) -> str:
@@ -71,41 +136,68 @@ def create_protocol_source(
     class_name: str,
     properties: dict[str, Any],
     metadata: dict[str, Any],
-    protocols: dict[str, str],
+    template: Spec,
+    classes: dict[str, str],
 ) -> str:
     class_name = snake_to_pascal(class_name)
-    lines = [CLASS.format(name=class_name, docstring=metadata.get("description", "").strip())]
-    for prop_name, prop_info in properties.items():
-        type_, md = typespec_to_source(prop_name, prop_info, protocols)
-        lines.append(
-            ATTR.format(name=prop_name, type=type_, docstring=md.get("description", "").strip())
-        )
+    docstring = f"""\
+{metadata.get("description", "").strip()}
 
-    protocols[class_name] = "\n".join(lines)
+Attributes
+----------
+"""
+
+    required = metadata.get("required", {})
+    optional = [prop for prop in properties if prop not in required]
+
+    lines = []
+    for prop_name in (*required, *optional):
+        prop_info = properties[prop_name]
+        type_, md = typespec_to_source(prop_name, prop_info, template, classes)
+        default = ""
+        if prop_name not in required:
+            type_ = f"{type_} | None"
+            default = " = None"
+        if not type_.startswith(("int", "float", "str", "bool", "Literal", "Sequence", "Mapping")):
+            type_ = f"{template.proto_prefix}{type_}"
+        description = md.get("description", "").strip()
+        lines.append(
+            template.attr_def.format(
+                name=prop_name, type=type_, docstring=description, default=default
+            )
+        )
+        docstring += f"{prop_name}: {type_}\n\t{description}\n"
+
+    lines.insert(0, template.class_def.format(name=class_name, docstring=docstring))
+
+    classes[class_name] = "\n".join(lines)
     return class_name
 
 
 def typespec_to_source(
     name: str,
     typespec: dict[str, Any],
-    protocols: dict[str, str],
+    template: Spec,
+    classes: dict[str, str],
 ) -> tuple[str, dict[str, Any]]:
     """Convert JSON-schema style specification to type and metadata dictionary."""
     tp = typespec.get("type")
     if not tp:
         raise ValueError(f"Invalid typespec: {json.dumps(typespec)}")
-    metadata = {key: typespec[key] for key in ("name", "description") if key in typespec}
+    metadata = {
+        key: typespec[key] for key in ("name", "description", "required") if key in typespec
+    }
     if tp == "object":
         properties = typespec.get("properties")
         if properties:
             type_ = create_protocol_source(
-                name, properties=properties, metadata=metadata, protocols=protocols
+                name, properties=properties, metadata=metadata, template=template, classes=classes
             )
         else:
             type_ = "Mapping[str, Any]"
     elif tp == "array":
         if "items" in typespec:
-            subtype, md = typespec_to_source(name, typespec["items"], protocols=protocols)
+            subtype, md = typespec_to_source(name, typespec["items"], template, classes=classes)
         else:
             subtype = "Any"
         type_ = f"Sequence[{subtype}]"
@@ -120,18 +212,28 @@ def typespec_to_source(
     return type_, metadata
 
 
-def generate_protocols(typespec: dict[str, Any], root_class_name: str) -> dict[str, str]:
+def generate_protocols(
+    typespec: dict[str, Any],
+    root_class_name: str,
+    template: Spec,
+) -> dict[str, str]:
     """Generate protocol definitions from a JSON schema typespec."""
     protocols: dict[str, str] = {}
-    typespec_to_source(root_class_name, typespec, protocols)
+    typespec_to_source(
+        root_class_name,
+        typespec,
+        template=template,
+        classes=protocols,
+    )
     return protocols
 
 
-def generate_module(schema: dict[str, Any]) -> str:
+def generate_module(schema: dict[str, Any], class_type: str) -> str:
     """Generate a context module source code from a BIDS schema.
 
     Returns a tuple containing the module source code and a list of protocol names.
     """
-    protocols = generate_protocols(schema["meta"]["context"], "context")
-    prelude = PRELUDE.format(version=schema["schema_version"], __all__=list(protocols))
+    template: Spec = ProtocolSpec if class_type == "protocol" else DataclassSpec
+    protocols = generate_protocols(schema["meta"]["context"], "context", template)
+    prelude = template.prelude.format(version=schema["schema_version"], __all__=list(protocols))
     return prelude + "\n\n".join(protocols.values())

--- a/tools/schemacode/src/bidsschematools/types/_generator.py
+++ b/tools/schemacode/src/bidsschematools/types/_generator.py
@@ -100,6 +100,7 @@ class DataclassSpec:
 
     from __future__ import annotations
 
+    import sys
     from dataclasses import dataclass
 
     TYPE_CHECKING = False
@@ -109,13 +110,18 @@ class DataclassSpec:
 
         from . import protocols as p
 
+    if sys.version_info >= (3, 10):
+        dc_kwargs = {{"slots": True, "frozen": True}}
+    else:  # PY39
+        dc_kwargs = {{"frozen": True}}
+
     __all__ = {__all__}
 
 
     ''')
 
     class_def = dedent('''\
-    @dataclass(slots=True, frozen=True)
+    @dataclass(**dc_kwargs)
     class {name}:
         """{docstring}"""
     ''')

--- a/tools/schemacode/src/bidsschematools/types/_generator.py
+++ b/tools/schemacode/src/bidsschematools/types/_generator.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
+
+
+PRELUDE = '''\
+"""BIDS validation context definitions
+
+The classes in this module are used to define the context for BIDS validation.
+The context is a namespace that contains relevant information about the dataset
+as a whole and an individual file to be validated.
+
+These classes are used to define the structure of the context,
+but they cannot be instantiated directly.
+Conforming subtypes need only match the structure of these classes,
+and do not need to inherit from them.
+
+The classes use ``@property`` decorators to indicate that subtypes need only
+provide read access to the attributes, and may restrict writing, for example,
+when calculating attributes dynamically based on other attributes.
+
+Note that some type checkers will not match classes that use
+:class:`functools.cached_property`.
+To permit this, add the following to your module::
+
+    if TYPE_CHECKING:
+        cached_property = property
+    else:
+        from functools import cached_property
+
+This module has been auto-generated from the BIDS schema version {version}.
+"""
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any, Literal, Protocol
+else:
+    Any = object
+    Literal = tuple
+    Mapping = dict
+    Protocol = object
+    Sequence = list
+
+__all__ = {__all__}
+
+
+'''
+
+CLASS = '''\
+class {name}(Protocol):
+    """{docstring}"""
+'''
+
+ATTR = '''\
+    @property
+    def {name}(self) -> {type}:
+        """{docstring}"""
+'''
+
+
+def snake_to_pascal(name: str) -> str:
+    return "".join(word.capitalize() for word in name.split("_"))
+
+
+def create_protocol_source(
+    class_name: str,
+    properties: dict[str, Any],
+    metadata: dict[str, Any],
+    protocols: dict[str, str],
+) -> str:
+    class_name = snake_to_pascal(class_name)
+    lines = [CLASS.format(name=class_name, docstring=metadata.get("description", "").strip())]
+    for prop_name, prop_info in properties.items():
+        type_, md = typespec_to_source(prop_name, prop_info, protocols)
+        lines.append(
+            ATTR.format(name=prop_name, type=type_, docstring=md.get("description", "").strip())
+        )
+
+    protocols[class_name] = "\n".join(lines)
+    return class_name
+
+
+def typespec_to_source(
+    name: str,
+    typespec: dict[str, Any],
+    protocols: dict[str, str],
+) -> tuple[str, dict[str, Any]]:
+    """Convert JSON-schema style specification to type and metadata dictionary."""
+    tp = typespec.get("type")
+    if not tp:
+        raise ValueError(f"Invalid typespec: {json.dumps(typespec)}")
+    metadata = {key: typespec[key] for key in ("name", "description") if key in typespec}
+    if tp == "object":
+        properties = typespec.get("properties")
+        if properties:
+            type_ = create_protocol_source(
+                name, properties=properties, metadata=metadata, protocols=protocols
+            )
+        else:
+            type_ = "Mapping[str, Any]"
+    elif tp == "array":
+        if "items" in typespec:
+            subtype, md = typespec_to_source(name, typespec["items"], protocols=protocols)
+        else:
+            subtype = "Any"
+        type_ = f"Sequence[{subtype}]"
+    else:
+        type_ = {
+            "number": "float",
+            "string": "str",
+            "integer": "int",
+        }[tp]
+        if type_ == "str" and "enum" in typespec:
+            type_ = f"Literal[{', '.join(f'{v!r}' for v in typespec['enum'])}]"
+    return type_, metadata
+
+
+def generate_protocols(typespec: dict[str, Any], root_class_name: str) -> dict[str, str]:
+    """Generate protocol definitions from a JSON schema typespec."""
+    protocols: dict[str, str] = {}
+    typespec_to_source(root_class_name, typespec, protocols)
+    return protocols
+
+
+def generate_module(schema: dict[str, Any]) -> str:
+    """Generate a context module source code from a BIDS schema.
+
+    Returns a tuple containing the module source code and a list of protocol names.
+    """
+    protocols = generate_protocols(schema["meta"]["context"], "context")
+    prelude = PRELUDE.format(version=schema["schema_version"], __all__=list(protocols))
+    return prelude + "\n\n".join(protocols.values())

--- a/tools/schemacode/src/bidsschematools/types/_generator.py
+++ b/tools/schemacode/src/bidsschematools/types/_generator.py
@@ -104,11 +104,11 @@ class DataclassSpec:
     from dataclasses import dataclass
 
     TYPE_CHECKING = False
-    if TYPE_CHECKING:
+    if TYPE_CHECKING or "sphinx.ext.autodoc" in sys.modules:
         from collections.abc import Mapping, Sequence
         from typing import Any, Literal
 
-        from . import protocols as p
+        from . import protocols
 
     if sys.version_info >= (3, 10):
         dc_kwargs = {{"slots": True, "frozen": True}}
@@ -131,7 +131,7 @@ class DataclassSpec:
         #: {docstring}
     """)
 
-    proto_prefix = "p."
+    proto_prefix = "protocols."
 
 
 def snake_to_pascal(name: str) -> str:

--- a/tools/schemacode/src/bidsschematools/types/context.py
+++ b/tools/schemacode/src/bidsschematools/types/context.py
@@ -1,0 +1,11 @@
+"""Loader for dynamically-generated context.
+
+This module is accessed when the package is installed in editable mode.
+This source code should not be found in the installed package.
+"""
+
+from ..schema import load_schema
+from ._generator import generate_module
+
+schema = load_schema()
+exec(generate_module(schema), globals())

--- a/tools/schemacode/src/bidsschematools/types/protocols.py
+++ b/tools/schemacode/src/bidsschematools/types/protocols.py
@@ -8,4 +8,4 @@ from ..schema import load_schema
 from ._generator import generate_module
 
 schema = load_schema()
-exec(generate_module(schema, "dataclasses"), globals())
+exec(generate_module(schema, "protocol"), globals())

--- a/tools/schemacode/tests/test_context_types.py
+++ b/tools/schemacode/tests/test_context_types.py
@@ -1,0 +1,9 @@
+from bidsschematools.types import context
+
+
+def test_import():
+    "Verify that the module contains the generated content."
+    assert context.__doc__.splitlines()[0].startswith("BIDS validation context")
+    assert "Context" in context.__all__
+
+    assert isinstance(context.Context, type)

--- a/tools/schemacode/tests/test_context_types.py
+++ b/tools/schemacode/tests/test_context_types.py
@@ -1,9 +1,118 @@
-from bidsschematools.types import context
+from bidsschematools.types import context as ctx
+from bidsschematools.types import protocols as p
 
 
 def test_import():
     "Verify that the module contains the generated content."
-    assert context.__doc__.splitlines()[0].startswith("BIDS validation context")
-    assert "Context" in context.__all__
+    assert ctx.__doc__ is not None
+    assert ctx.__doc__.splitlines()[0].startswith("BIDS validation context")
+    assert "Context" in ctx.__all__
 
-    assert isinstance(context.Context, type)
+    assert isinstance(ctx.Context, type)
+
+
+def test_assignability() -> None:
+    """Verify that dataclass values can be assigned to variables annotated with protocols.
+
+    For pytest, this just checks instantiability.
+    Running mypy with bst installed should check assignability,
+    for example, with::
+
+        uvx --with=. mypy tests
+    """
+    subjects: p.Subjects = ctx.Subjects([])
+    subjects = ctx.Subjects([], [], [])
+
+    dataset: p.Dataset = ctx.Dataset(
+        dataset_description={},
+        tree={},
+        ignored=[],
+        datatypes=[],
+        modalities=[],
+        subjects=subjects,
+    )
+
+    magnitude: p.Magnitude = ctx.Magnitude("path")
+    magnitude1: p.Magnitude1 = ctx.Magnitude1("path")
+    m0scan: p.M0scan = ctx.M0scan("path")
+    bval: p.Bval = ctx.Bval("path", 5, 1, [0, 0, 0, 0, 0])
+    channels: p.Channels = ctx.Channels("path")
+    channels = ctx.Channels("path", ["TYPE"], ["1"], ["SHORT"])
+    events: p.Events = ctx.Events("path", ["0.0", "3.0"])
+    bvec: p.Bvec = ctx.Bvec("path", 5, 3)
+    coordsystem: p.Coordsystem = ctx.Coordsystem("path")
+    aslcontext: p.Aslcontext = ctx.Aslcontext("path", 2, ["label", "control"])
+    associations: p.Associations = ctx.Associations()
+    associations = ctx.Associations(
+        magnitude=magnitude,
+        magnitude1=magnitude1,
+        m0scan=m0scan,
+        bval=bval,
+        channels=channels,
+        events=events,
+        bvec=bvec,
+        coordsystem=coordsystem,
+        aslcontext=aslcontext,
+    )
+
+    gzip: p.Gzip = ctx.Gzip(0)
+    gzip = ctx.Gzip(0, "filename", "comment")
+
+    sessions: p.Sessions = ctx.Sessions([])
+    sessions = ctx.Sessions([], [], [])
+    subject: p.Subject = ctx.Subject(sessions)
+
+    tiff: p.Tiff = ctx.Tiff(0x4D4D)
+
+    dim_info: p.DimInfo = ctx.DimInfo(1, 2, 3)
+    xyzt_units: p.XyztUnits = ctx.XyztUnits("mm", "sec")
+    nifti_header: p.NiftiHeader = ctx.NiftiHeader(
+        dim_info=dim_info,
+        dim=[4, 64, 64, 48, 100, 1, 1, 1],
+        pixdim=[1.0, 1.0, 1.0, 1.0, 1.5, 1.0, 1.0, 1.0],
+        shape=(64, 64, 48, 100),
+        voxel_sizes=(1.0, 1.0, 1.0, 1.5),
+        xyzt_units=xyzt_units,
+        qform_code=1,
+        sform_code=1,
+    )
+
+    ome: p.Ome = ctx.Ome()
+    ome = ctx.Ome(
+        PhysicalSizeX=10,
+        PhysicalSizeY=10,
+        PhysicalSizeZ=10,
+        PhysicalSizeXUnit="um",
+        PhysicalSizeYUnit="um",
+        PhysicalSizeZUnit="um",
+    )
+
+    context: p.Context = ctx.Context(
+        schema={},
+        dataset=dataset,
+        path="path",
+        size=0,
+        sidecar={},
+        associations=associations,
+    )
+    context = ctx.Context(
+        schema={},
+        dataset=dataset,
+        subject=subject,
+        path="path",
+        modality="modality",
+        datatype="datatype",
+        entities={},
+        suffix="suffix",
+        extension=".ext",
+        size=0,
+        sidecar={},
+        associations=associations,
+        gzip=gzip,
+        tiff=tiff,
+        ome=ome,
+        nifti_header=nifti_header,
+        columns={},
+        json={},
+    )
+    assert context.schema == {}  # Use the variable to pacify linters


### PR DESCRIPTION
This PR follows-up #2115 by procedurally generating Python types from the `schema.meta.context` object. This uses [structural subtyping](https://typing.python.org/en/latest/spec/protocol.html#protocols) to allow for a variety of implementations to satisfy type-checkers, while also providing default standard library dataclass implementations.

The dataclass fields are annotated with protocols instead of one another, so that you can flexibly mix-and-match the provided dataclasses and your own classes, for example:

```python
from functools import cached_property
import json

import attrs
from bidsschematools.types import context as ctx

@attrs.define
class Dataset:
    tree: FileTree
    ignored: list[str]

    @cached_property
    def dataset_description(self) -> dict[str, Any]:
        with open(tree['dataset_description.json']) as fobj:
            return json.load(fobj)

    @cached_property
    def modalities(self) -> list[str]:
        ...

    @cached_property
    def datatypes(self) -> list[str]:
        ...

    @cached_property
    def subjects(self) -> ctx.Subjects:
        ...
```

`Dataset` is assignable to a variable annotated as `bidsschematools.types.protocols.Dataset`, but not `bidsschematools.types.context.Dataset`.

Protocols doc: https://bidsschematools--2133.org.readthedocs.build/en/2133/api/bidsschematools.types.protocols.html
Dataclasses doc: https://bidsschematools--2133.org.readthedocs.build/en/2133/api/bidsschematools.types.context.html

As with #2115, the goal here is to remain dynamic in editable installation mode, constructing and `exec`ing the module on-the-fly, while freezing a copy for optimal loading when performing full installations or building packages.