### PR TITLE
fix(schema): Quote task in events association

### DIFF
--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -14,7 +14,7 @@
 ---
 events:
   selectors:
-    - 'task in entities'
+    - '"task" in entities'
     - extension != '.json'
   target:
     suffix: events

--- a/src/schema/rules/checks/events.yaml
+++ b/src/schema/rules/checks/events.yaml
@@ -13,7 +13,7 @@ EventsMissing:
     - datatype != "beh"
     - '"task" in entities'
     - '!match(entities.task, "rest")'
-    - '!intersects([suffix], ["events", "beh"])'
+    - '!intersects([suffix], ["events", "beh", "channels", "electrodes", "optodes"])'
     - extension != ".json"
     - datatype != "meg" || entities.subject != "emptyroom" && entities.task != "noise"
   checks:


### PR DESCRIPTION
Addresses https://github.com/bids-standard/bids-validator/issues/213.

The problem was that in `task in entities`, `task` is an identifier instead of a string, so it always evaluated `false`. The other fix helps in cases where, e.g., there is `channels.tsv` but `run-X_events.tsv`, which means that events aren't found by inheritance for those files.