### PR TITLE
fix: Account for NIfTI time units when checking RepetitionTime

### DIFF
--- a/src/schema/rules/checks/func.yaml
+++ b/src/schema/rules/checks/func.yaml
@@ -40,9 +40,17 @@ RepetitionTimeMismatch:
     - type(sidecar.RepetitionTime) != "null"
     - type(nifti_header) != "null"
   checks:
-    # Implement millisecond rounding via AND
-    - sidecar.RepetitionTime - nifti_header.pixdim[4] < 0.001
-    - sidecar.RepetitionTime - nifti_header.pixdim[4] > -0.001
+    # Use index(...) % 3 to treat unknown units like seconds
+    - |
+      nifti_header.pixdim[4]
+        * 10 ** (-3 * (index(["sec", "msec", "usec", "unknown"], nifti_header.xyzt_units.t) % 3))
+      - sidecar.RepetitionTime
+      > -0.001
+    - |
+      nifti_header.pixdim[4]
+        * 10 ** (-3 * (index(["sec", "msec", "usec", "unknown"], nifti_header.xyzt_units.t) % 3))
+      - sidecar.RepetitionTime
+      < 0.001
 
 # 54
 BoldNot4d:


### PR DESCRIPTION
I've run across a BOLD dataset with temporal units set to msec. The RepetitionTime is consistent with pixdim[4], when this is accounted for.

This is an attempt at a rule that will work.