### PR TITLE
[FIX] refactor: update SpectrometerFrequency type to support both number and array formats

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -3605,10 +3605,13 @@ SpectrometerFrequency:
     to the resonant frequency of <sup>1</sup>H.
     For multi-nuclei experiments such as <sup>1</sup>H-[<sup>13</sup>C] MR at 3T,
     an array can be used: `[127.731, 32.125]`.
-  type: array
-  items:
-    type: number
-    unit: MHz
+  anyOf:
+    - type: number
+      unit: MHz
+    - type: array
+      items:
+        type: number
+        unit: MHz
 SpoilingGradientDuration:
   name: SpoilingGradientDuration
   display_name: Spoiling Gradient Duration


### PR DESCRIPTION
Noticed that SpectrometerFrequency required an array. Should allow either a number (most common case) or an array of numbers.