### PR TITLE
Add 1PE to complement 2PE (microscopy)

### DIFF
--- a/src/modality-specific-files/microscopy.md
+++ b/src/modality-specific-files/microscopy.md
@@ -28,7 +28,7 @@ and a guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
 {{ MACROS___make_filename_template("raw", datatypes=["micr"], suffixes=["TEM", "SEM", "uCT", "BF", "DF",
-"PC", "DIC", "FLUO", "CONF", "PLI", "CARS", "2PE", "MPE", "SR", "NLO", "OCT", "SPIM", "XPCT"], n_dupes_to_combine=4) }}
+"PC", "DIC", "FLUO", "CONF", "PLI", "CARS", "1PE", "2PE", "MPE", "SR", "NLO", "OCT", "SPIM", "XPCT"], n_dupes_to_combine=4) }}
 
 Microscopy data MUST be stored in the `micr` directory.
 
@@ -82,6 +82,7 @@ and a guide for using macros can be found at
          "CONF",
          "PLI",
          "CARS",
+         "1PE",
          "2PE",
          "MPE",
          "SR",

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -1,6 +1,11 @@
 ---
 # This file defines valid BIDS file suffixes.
 # For rules regarding how suffixes relate to datatypes, see files in `rules/files/raw/`.
+OnePE:
+  value: 1PE
+  display_name: 1-photon excitation microscopy
+  description: |
+    1-photon excitation microscopy imaging data
 TwoPE:
   value: 2PE
   display_name: 2-photon excitation microscopy

--- a/src/schema/rules/files/raw/micr.yaml
+++ b/src/schema/rules/files/raw/micr.yaml
@@ -12,6 +12,7 @@ microscopy:
     - CONF
     - PLI
     - CARS
+    - 1PE
     - 2PE
     - MPE
     - SR


### PR DESCRIPTION
https://blog.biodock.ai/one-vs-two-photon-microscopy/ seems to provide a nice comparison between one- and two-photon microscopy. Also
https://www.gophotonics.com/community/what-are-single-photon-and-two-photon-excitation provides another comparison and uses "excitation" consistently between them.

Note that there is also already "FLUO" suffix for "Fluorescence microscopy" in general, of which both 1PE and 2PE and likely MPE (multi-photon) mechanisms are, so unclear when FLUO to be used, but I guess 2PE, MPE and now 1PE should be RECOMMENDED to be used in favor of FLUO as more specific

Some related references:
- https://github.com/bids-standard/bids-specification/pull/1632

ping @bids-standard/bep031 @bendichter 