### PR TITLE
Add Seyed (Yahya) Shirazi to BIDS Maintainers

### DIFF
--- a/Maintainers_Guide.md
+++ b/Maintainers_Guide.md
@@ -26,6 +26,7 @@ See also: [BIDS governance](https://bids.neuroimaging.io/collaboration/governanc
 | Nell Hardcastle ([@nellh](https://github.com/nellh))                      | 2h/week         |                                       | Jul 2023 |
 | Kimberly Ray ([@KimberlyLRay](https://github.com/KimberlyLRay))           | 1h/week         |                                       | Nov 2022 |
 | Julia-Katharina Pfarr ([@julia-pfarr](https://github.com/julia-pfarr))    | 2h/week         |                                       | Mar 2025 |
+| Seyed (Yahya) Shirazi ([@neuromechanist](https://github.com/neuromechanist)) | 2h/week         | ExG, multimodal recording, events and annotations | Jul 2025 |
 
 In addition to the [BIDS Governance](https://bids.neuroimaging.io/collaboration/governance.html#bids-maintainers-group)
 classification of a maintainer, maintainers may declare a limited scope of responsibility.


### PR DESCRIPTION
## Summary
Adding Seyed (Yahya) Shirazi to the BIDS Maintainers list.

## Details
- **Name**: Seyed (Yahya) Shirazi (@neuromechanist)
- **Time commitment**: 2 hours per week
- **Scope of work**: ExG, multimodal recording, events and annotations
- **Joined**: July 2025

## Reviewers
@ericearl @julia-pfarr @effigies - Please review this addition to the maintainers list.