### PR TITLE
[ENH] Clarify that task label is not required to derive from TaskName

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -3753,7 +3753,7 @@ TaskName:
   description: |
     Name of the task.
     No two tasks should have the same name.
-    The task label included in the filename is derived from this `"TaskName"` field
+    The task label included in the filename MAY be derived from this `"TaskName"` field
     by removing all non-alphanumeric or `+` characters (that is, all except those matching `[0-9a-zA-Z+]`),
     and potentially replacing spaces with `+` to ease readability.
     For example `"TaskName"` `"faces n-back"` or `"head nodding"` could correspond to task labels


### PR DESCRIPTION
Following up on decision made in Copenhagen. This "is" was interpreted by some to be a requirement, but this has never been validated, would be breaking to turn into an error, and is impractical to encode in the schema. Rather than contort ourselves to devise a check, it makes more sense to use RFC 2119 language to make clear that this is an optional convention, not a requirement.

Closes #2081.