### PR TITLE
Add "directories" description for "study" DatasetType and add "docs" where was missing

### DIFF
--- a/src/schema/rules/directories.yaml
+++ b/src/schema/rules/directories.yaml
@@ -1,5 +1,5 @@
 ---
-# This file defines layouts of directories.
+# This file defines layouts of directories for each DatasetType
 #
 # A layout defines a collection of directory specifiers.
 # Each specifier has a naming convention, requirement level, opacity, and subdirectories.
@@ -16,10 +16,50 @@
 # The special "root" specifier describes the root of the dataset and only defines subdirectories.
 # No naming convention applies, and the requirement level and opacity would be superfluous.
 #
+study:
+  root:
+    subdirs:
+      - code
+      - docs
+      - derivatives
+      - logs
+      - phenotype
+      - sourcedata
+      - stimuli
+  code:
+    name: code
+    level: optional
+    opaque: true
+  docs:
+    name: docs
+    level: optional
+    opaque: true
+  derivatives:
+    name: derivatives
+    level: optional
+    opaque: true
+  logs:
+    name: logs
+    level: optional
+    opaque: true
+  phenotype:
+    name: phenotype
+    level: optional
+    opaque: false
+  sourcedata:
+    name: sourcedata
+    level: optional
+    opaque: true
+  stimuli:
+    name: stimuli
+    level: optional
+    opaque: true
+
 raw:
   root:
     subdirs:
       - code
+      - docs
       - derivatives
       - logs
       - phenotype
@@ -77,6 +117,7 @@ derivative:
   root:
     subdirs:
       - code
+      - docs
       - derivatives
       - logs
       - phenotype
@@ -85,6 +126,10 @@ derivative:
       - subject
   code:
     name: code
+    level: optional
+    opaque: true
+  docs:
+    name: docs
     level: optional
     opaque: true
   derivatives:


### PR DESCRIPTION
Apparently I have missed this file entirely whenever I was preparing

-  https://github.com/bids-standard/bids-specification/pull/1972 (study DatasetType)

and also due to all the duplication we (I) missed that docs was not listed among "root.subdirs" or not listed at all.

This would provide a fix, but I wonder if we could/should make it so we could avoid duplication altogether.  As I have argued in #1972 I feel that "study" is the base dataset type and next ones just add potentially more to them.  So may be we could come up with some more compact representation here... but not in this PR
