### PR TITLE
[FIX] Update BIDS Starter Kit links in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,8 @@ nav:
           - Cross modality correspondence: appendices/cross-modality-correspondence.md
       - Changelog: CHANGES.md
   - The BIDS Starter Kit:
-      - Website: https://bids-standard.github.io/bids-starter-kit/
-      - Tutorials: https://bids-standard.github.io/bids-starter-kit/tutorials/tutorials.html
+      - Website: https://bids.neuroimaging.io/getting_started/
+      - Tutorials: https://bids.neuroimaging.io/getting_started/tutorials/
       - GitHub repository: https://github.com/bids-standard/bids-starter-kit
 theme:
   name: material


### PR DESCRIPTION
Changed the BIDS Starter Kit website and tutorials URLs in mkdocs.yml to point to bids.neuroimaging.io instead of bids-standard.github.io.