### PR TITLE
fix(schema): Remove task entity selector for associated events

### DIFF
--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -14,7 +14,6 @@
 ---
 events:
   selectors:
-    - '"task" in entities'
     - extension != '.json'
   target:
     suffix: events


### PR DESCRIPTION
As of #1440, events files are no longer assumed to be associated with task data files (although currently all events files do have a required task entity). This brings `meta.associations.events` into line, so that events files can be found.

This is somewhat abstract and will come at a slight cost to the validator, but other tools using `meta.associations` to find associated files will benefit from removing the restriction.