### PR TITLE
Update current BIDS maintainers list

### DIFF
--- a/Maintainers_Guide.md
+++ b/Maintainers_Guide.md
@@ -15,7 +15,6 @@ See also: [BIDS governance](https://bids.neuroimaging.io/collaboration/governanc
 
 | Name                                                                         | Time commitment | Scope                                 | Joined   |
 | ---------------------------------------------------------------------------- | --------------- | ------------------------------------- | -------- |
-| Stefan Appelhoff ([@sappelhoff](https://github.com/sappelhoff))              | 1h/week         |                                       | Mar 2020 |
 | Chris Markiewicz ([@effigies](https://github.com/effigies))                  | 5h/week         |                                       | Mar 2020 |
 | Ross Blair ([@rwblair](https://github.com/rwblair))                          |                 | Maintainer of the bids-validator      | Mar 2020 |
 | Taylor Salo ([@tsalo](https://github.com/tsalo))                             | 3h/week         | MRI                                   | Sep 2020 |
@@ -48,6 +47,7 @@ See also: [BIDS governance](https://bids.neuroimaging.io/collaboration/governanc
 | Name                                                                           | Duration            |
 | ------------------------------------------------------------------------------ | ------------------- |
 | Franklin Feingold ([@franklin-feingold](https://github.com/franklin-feingold)) | Mar 2020 - Jul 2022 |
+| Stefan Appelhoff ([@sappelhoff](https://github.com/sappelhoff))                | Mar 2020 - Aug 2025 |
 
 ## Why become a maintainer?
 


### PR DESCRIPTION
Hi all,

with new priorities that came up for me, I have over the past year not been having enough time to make meaningful contributions to BIDS as a maintainer. Therefore, I would like to move my name from active to past BIDS maintainers.

That is the only change though -- as before I will still be available and involved in the project when needed, and/or when I find capacity to pick up tasks.

xref https://github.com/bids-standard/bids-website/commit/a84fa60634a441f41c3edade5a021bc4de749350
