### PR TITLE
[ENH] Clarify that "raw dataset" source data in example layout is a raw BIDS dataset

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -352,7 +352,7 @@ Derivatives can be stored/distributed in two ways:
     Extra documentation (and relevant images) MAY be included in the `docs/` subdirectory.
     Logs from running the code or other commands MAY be stored under `logs/` subdirectory.
 
-    Example of a derivative dataset including the raw dataset as source:
+    Example of a derivative dataset including the BIDS raw dataset as source:
 
     <!-- This block generates a file tree.
     A guide for using macros can be found at
@@ -367,9 +367,11 @@ Derivatives can be stored/distributed in two ways:
                 "...": "",
             },
             "sourcedata": {
-                "sub-01": {},
-                "sub-02": {},
-                "...": "",
+                "raw": {
+                    "sub-01": {},
+                    "sub-02": {},
+                    "...": "",
+                },
             },
             "sub-01": {},
             "sub-02": {},


### PR DESCRIPTION
and also did not include under "raw" subfolder

attn @nikhil153 since relates to a bit more "involved" discussion/approach of
- https://github.com/bids-standard/bids-specification/pull/2191

edit: continuing on above relation to #2191 -- this + 1 more spot is where might be worth changing "raw" into "bids-raw" or "raw-bids" (under `sourcedata/`) to signal that it is not just "raw" recording of some kind, but rather a raw BIDS dataset.
