### PR TITLE
[ENH] Allow datacite.yml in dataset root

### DIFF
--- a/src/modality-agnostic-files/dataset-description.md
+++ b/src/modality-agnostic-files/dataset-description.md
@@ -5,6 +5,7 @@ Templates:
 -   `dataset_description.json`
 -   `README[.md|.rst|.txt]`
 -   `CITATION.cff`
+-   `datacite.yml`
 -   `CHANGES`
 -   `LICENSE[.md|.rst|.txt]`
 
@@ -155,7 +156,24 @@ A guide for using macros can be found at
 -->
 {{ MACROS___render_text("objects.files.README.description") }}
 
-## `CITATION.cff`
+## Structured citation files
+
+BIDS permits structured citation files that may improve interoperability with
+dataset indexing utilities or afford higher precision than fields in
+`dataset_description.json`.
+
+If these files are used, fields that provide information that is redundant with
+`dataset_description.json` fields SHOULD be preferred to those in `dataset_description.json`.
+
+To avoid inconsistency, metadata present in one of the following files SHOULD NOT be
+be included in `dataset_description.json`, with the exception of `Name` and
+`DatasetDOI`, to ensure that tools that are only aware of `dataset_description.json`
+can generate references to the dataset.
+
+In particular, if a structured citation file is present,
+the `"Authors"` field of `dataset_description.json` MUST be omitted.
+
+### `CITATION.cff`
 
 <!-- This block generates a file tree.
 A guide for using macros can be found at
@@ -163,17 +181,21 @@ A guide for using macros can be found at
 -->
 {{ MACROS___render_text("objects.files.CITATION.description") }}
 
-For most redundant fields between `CITATION.cff` and `dataset_description.json`,
-the `CITATION.cff` SHOULD take precedence.
-To avoid inconsistency, metadata present in `CITATION.cff` SHOULD NOT be
-be included in `dataset_description.json`, with the exception of `Name` and
-`DatasetDOI`, to ensure that `CITATION.cff`-unaware tools can generate
-references to the dataset.
-In particular, if `CITATION.cff` is present,
-the `"Authors"` field of `dataset_description.json` MUST be omitted,
-and the `"HowToAcknowledge"`, `"License"` and `"ReferencesAndLinks"` SHOULD be omitted
+If `CITATION.cff` is present,
+the `"HowToAcknowledge"`, `"License"` and `"ReferencesAndLinks"` SHOULD be omitted
 in favor of the `CITATION.cff` fields `message`/`preferred-citation`, `license` and
 `references`.
+
+### `datacite.yml`
+
+<!-- This block generates a file tree.
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___render_text("objects.files.datacite.description") }}
+
+If `datacite.yml` is present, the `"License"` SHOULD be omitted
+in favor of the `datacite.yml` field `rightsList`.
 
 ## `CHANGES`
 

--- a/src/schema/objects/files.yaml
+++ b/src/schema/objects/files.yaml
@@ -49,6 +49,16 @@ README:
     even if the used format is not rendered.
     A guideline for creating a good `README` file can be found in the
     [bids-starter-kit](https://github.com/bids-standard/bids-starter-kit/tree/main/templates/).
+datacite:
+  display_name: datacite.yml
+  file_type: regular
+  description: |
+    A description of the citation information for the dataset, following the
+    [DataCite Metadata Schema v4](https://schema.datacite.org/meta/kernel-4/)
+    (or higher) schema.
+    This file permits more detailed and structured descriptions than
+    [dataset_description.json](SPEC_ROOT/glossary.md#dataset_description-files),
+    suitable for submission to DataCite to generate a DOI.
 dataset_description:
   display_name: Dataset Description
   file_type: regular

--- a/src/schema/rules/checks/dataset.yaml
+++ b/src/schema/rules/checks/dataset.yaml
@@ -89,12 +89,24 @@ SingleSourceAuthors:
     code: AUTHORS_AND_CITATION_FILE_MUTUALLY_EXCLUSIVE
     level: error
     message: |
-      'CITATION.cff' file found. The "Authors" field of 'dataset_description.json'
+      {path} file found. The "Authors" field of 'dataset_description.json'
       must be removed to avoid inconsistency.
   selectors:
-    - path == '/CITATION.cff'
+    - intersects([path], ['/CITATION.cff', '/datacite.yml'])
   checks:
     - '!("Authors" in dataset.dataset_description)'
+
+SingleSourceDataciteFields:
+  issue:
+    code: SINGLE_SOURCE_CITATION_FIELDS
+    level: warning
+    message: |
+      datacite.yml file found. The "License" field of 'dataset_description.json'
+      should be removed to avoid inconsistency.
+  selectors:
+    - path == '/datacite.yml'
+  checks:
+    - '!("License" in dataset.dataset_description)'
 
 SingleSourceCitationFields:
   issue:

--- a/src/schema/rules/files/common/core.yaml
+++ b/src/schema/rules/files/common/core.yaml
@@ -8,6 +8,9 @@ dataset_description:
 CITATION:
   level: optional
   path: CITATION.cff
+datacite:
+  level: optional
+  path: datacite.yml
 README:
   level: recommended
   stem: README

--- a/src/schema/rules/json/dataset.yaml
+++ b/src/schema/rules/json/dataset.yaml
@@ -10,10 +10,12 @@ dataset_description:
       level: optional
       level_addendum: required if [BIDS URIs](SPEC_ROOT/common-principles.md#bids-uri) are used
     DatasetType: recommended
-    License: recommended
+    License:
+      level: optional
+      level_addendum: recommended if neither `CITATION.cff` nor `datacite.yml` is present
     Authors:
       level: optional
-      level_addendum: recommended if `CITATION.cff` is not present
+      level_addendum: recommended if neither `CITATION.cff` nor `datacite.yml` is present
     Keywords: optional
     Acknowledgements: optional
     HowToAcknowledge: optional
@@ -28,7 +30,9 @@ dataset_authors:
   selectors:
     - path == "/dataset_description.json"
     - '!exists("CITATION.cff", "dataset")'
+    - '!exists("datacite.yml", "dataset")'
   fields:
+    License: recommended
     Authors:
       level: recommended
       issue:


### PR DESCRIPTION
The DataCite Metadata Schema (https://schema.datacite.org/meta/kernel-4/) is a fairly comprehensive structure for describing citable datasets, including [contributors](https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/contributor/) (including [organizations](https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/contributor/#a-nametype) and contributor [roles](https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/contributor/#a-contributortype)), [funders](https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/fundingreference/), [licenses](https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/rights/) and [abstracts](https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/description/).

The DataCite Metadata Working Group publish [XSD](https://schema.datacite.org/meta/kernel-4.6/metadata.xsd) and Invenio hosts JSON-Schema translations at https://github.com/inveniosoftware/datacite/tree/master/datacite/schemas.

Following the lead of CITATION.cff, we would use YAML, a superset of JSON that is interpreted as a JSON-compatible object.

I would propose that we add the Invenio JSON-Schema documents to the [jsr:@bids/schema](https://jsr.io/@bids/schema/) package, similar to https://jsr.io/@bids/schema/1.1.0/citation/schema.json.

Closes #1955.

TODO:

* [x] Add schema checks for MUST/SHOULD statements.
* [ ] Recommend against having both CITATION.cff and datacite.yml? They could get out-of-sync, but if someone was syncing them, it might make the dataset legible to more tools.