### PR TITLE
DOCS: Fix HED resources link in hierarchical event descriptors documentation

### DIFF
--- a/src/appendices/hed.md
+++ b/src/appendices/hed.md
@@ -14,7 +14,7 @@ Individual terms are comma-separated and may be grouped using parentheses to ind
 association.
 See the [HED Schema Browser](https://www.hedtags.org/display_hed.html)
 to view the HED schema and the
-[HED resources](https://www.hed-resources.org/en/latest/) site for additional information.
+[HED resources](https://www.hedtags.org/hed-resources/) site for additional information.
 
 Starting with HED version 8.0.0, HED allows users to annotate using individual
 terms or partial paths in the HED vocabulary (for example, `Red` or `Visual-presentation`)


### PR DESCRIPTION
<img width="1364" height="598" alt="image" src="https://github.com/user-attachments/assets/ed9abea5-182e-4c03-ac8a-a943b2a27ea4" />

https://github.com/hed-standard/hed-resources/commit/3b3461009d2db6de8d45f40a97d51abad9b51eba#diff-e91be36adf148d7583082e3b2d81a1e8075677b1c1080ed03ed9fd3a1646326d