### PR TITLE
DOCS: Add ignore rule for rrid.site in link checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
                 --ignore-url 'https://dicomlookup.com/dicomtags/.*' \
                 --ignore-url 'https://www.instagram.com/bidsstandard/' \
                 --ignore-url 'https://jsoneditoronline.org' \
-                --ignore-url 'https://rrid.site/.*' \
+                --ignore-url 'https://rrid.site.*' \
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"


### PR DESCRIPTION
RRID requires human verification, so all RRID links currently fail validation