### PR TITLE
fix: Fix TOTAL_ACQUIRED_VOLUMES_NOT_CONSISTENT

### DIFF
--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -201,16 +201,18 @@ ASLTotalAcquiredPairsASLContextLength:
     code: TOTAL_ACQUIRED_VOLUMES_NOT_CONSISTENT
     message: |
       The number of values for 'TotalAcquiredPairs' for this file does not match number of
-      volumes in the associated 'aslcontext.tsv'.
-      'TotalAcquiredPairs' is the original number of 3D volumes acquired for each volume defined in the
-      associated 'aslcontext.tsv'.
+      control-label pairs in the associated 'aslcontext.tsv'.
+      'TotalAcquiredPairs' is the original number of control-label pairs
+      defined in the associated 'aslcontext.tsv'.
     level: warning
   selectors:
     - suffix == "asl"
     - type(associations.aslcontext) != "null"
     - '"TotalAcquiredPairs" in sidecar'
+    - count(associations.aslcontext.volume_type, "control") > 0
   checks:
-    - aslcontext.n_rows == sidecar.TotalAcquiredPairs
+    - count(associations.aslcontext.volume_type, "control") == sidecar.TotalAcquiredPairs
+    - count(associations.aslcontext.volume_type, "label") == sidecar.TotalAcquiredPairs
 
 # 184
 PostLabelingDelayGreater:


### PR DESCRIPTION
Closes #1975.

Changes proposed:

- Compare TotalAcquiredPairs against both the number of control volumes and the number of label volumes in the aslcontext.tsv file. Only do this if the number of control volumes is greater than 0, in case the ASL scan just contains deltam or cbf volumes.