### PR TITLE
fix: Get TSV tables rendering again

### DIFF
--- a/tools/schemacode/src/bidsschematools/render/tsv.py
+++ b/tools/schemacode/src/bidsschematools/render/tsv.py
@@ -7,12 +7,12 @@ import pandas as pd
 from markdown_it import MarkdownIt
 from tabulate import tabulate
 
-from ..utils import filter_warnings, in_context
+from ..utils import WarningsFilter, in_context
 from .utils import propagate_fence_exception
 
 
-@in_context(filter_warnings(["error"]))
 @propagate_fence_exception
+@in_context(WarningsFilter(["error"]))
 def fence(
     source: str,
     language: str,

--- a/tools/schemacode/src/bidsschematools/utils.py
+++ b/tools/schemacode/src/bidsschematools/utils.py
@@ -179,14 +179,19 @@ def in_context(context_manager):
     return decorator
 
 
-@contextmanager
-def filter_warnings(*filters):
+class WarningsFilter:
     """Context manager to apply warning filters.
 
     Arguments are lists of positional arguments to :func:`warnings.filterwarnings`.
     """
+    def __init__(self, *filters):
+        self.filters = filters
 
-    with warnings.catch_warnings():
-        for filt in filters:
+    def __enter__(self):
+        self.catcher = warnings.catch_warnings()
+        self.catcher.__enter__()
+        for filt in self.filters:
             warnings.filterwarnings(*filt)
-        yield
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.catcher.__exit__(exc_type, exc_value, traceback)


### PR DESCRIPTION
#2240 broke TSV builds due to an issue with `@contextlib.contextmanager`-built context managers. This replaces it with a normal context manager.