### PR TITLE
[FIX] Correct typos and formatting in specification documents

### DIFF
--- a/src/CHANGES.md
+++ b/src/CHANGES.md
@@ -77,7 +77,7 @@
 -   \[FIX] Add misssing files in filename template for NIRS [1716](https://github.com/bids-standard/bids-specification/pull/1716) ([Remi-Gau](https://github.com/Remi-Gau))
 -   \[FIX] Remove task entity from DWI and PERF time series file templates [1703](https://github.com/bids-standard/bids-specification/pull/1703) ([Remi-Gau](https://github.com/Remi-Gau))
 -   \[FIX] Add `part-<value>` to the PEPOLAR fieldmaps [1685](https://github.com/bids-standard/bids-specification/pull/1685) ([oesteban](https://github.com/oesteban))
--   \[INFRA] Publish schema to Javascript Registry (https://jsr.io/@bids/schema) on changes and releases [1899](https://github.com/bids-standard/bids-specification/pull/1899) ([effigies](https://github.com/effigies))
+-   \[INFRA] Publish schema to Javascript Registry (<https://jsr.io/@bids/schema>) on changes and releases [1899](https://github.com/bids-standard/bids-specification/pull/1899) ([effigies](https://github.com/effigies))
 -   \[INFRA] Introduce metaschema [1787](https://github.com/bids-standard/bids-specification/pull/1787) ([bendichter](https://github.com/bendichter))
 -   \[MISC] Restructure MEG empty room example texts [1677](https://github.com/bids-standard/bids-specification/pull/1677) ([guiomar](https://github.com/guiomar))
 

--- a/src/appendices/meg-systems.md
+++ b/src/appendices/meg-systems.md
@@ -13,18 +13,18 @@ Preferred names of MEG systems comprise restricted keywords for Manufacturer fie
 
 Restricted keywords for ManufacturersModelName field in the `*_meg.json` file:
 
-| **System Model Name**     | **Manufacturer**      | **Details**                                                                                  |
-| ------------------------- | --------- ----------- | -------------------------------------------------------------------------------------------- |
-| CTF-64                    | CTF                   |                                                                                              |
-| CTF-151                   | CTF                   | [https://www.ctf.com/products](https://www.ctf.com/products)                                 |
-| CTF-275                   | CTF                   | CTF-275: OMEGA 2000                                                                          |
-| Neuromag-122              | Neuromag/Elekta/Megin |                                                                                              |
-| ElektaVectorview          | Neuromag/Elekta/Megin | 102 magnetometers + 204 planar gradiometers                                                  |
-| ElektaTRIUX               | Neuromag/Elekta/Megin | [https://www.elekta.com/products/neurosurgery/](https://www.elekta.com/products/neurosurgery/) |
-| 4D-Magnes-WH2500          | BTi/4D                |                                                                                              |
-| 4D-Magnes-WH3600          | BTi/4D                |                                                                                              |
-| KIT-157                   | KIT/Yokogawa          |                                                                                              |
-| KIT-160                   | KIT/Yokogawa          |                                                                                              |
-| KIT-208                   | KIT/Yokogawa          |                                                                                              |
-| ITAB-ARGOS153             | ITAB                  |                                                                                              |
-| Aalto-MEG-MRI-YYYY/MM     | Aalto/MEG-MRI         | YYYY-MM (year, month; or major version)                                                      |
+| **System Model Name** | **Manufacturer**      | **Details**                                     |
+| --------------------- | --------------------- | ----------------------------------------------- |
+| CTF-64                | CTF                   |                                                 |
+| CTF-151               | CTF                   | <https://www.ctf.com/products>                  |
+| CTF-275               | CTF                   | CTF-275: OMEGA 2000                             |
+| Neuromag-122          | Neuromag/Elekta/Megin |                                                 |
+| ElektaVectorview      | Neuromag/Elekta/Megin | 102 magnetometers + 204 planar gradiometers     |
+| ElektaTRIUX           | Neuromag/Elekta/Megin | <https://www.elekta.com/products/neurosurgery/> |
+| 4D-Magnes-WH2500      | BTi/4D                |                                                 |
+| 4D-Magnes-WH3600      | BTi/4D                |                                                 |
+| KIT-157               | KIT/Yokogawa          |                                                 |
+| KIT-160               | KIT/Yokogawa          |                                                 |
+| KIT-208               | KIT/Yokogawa          |                                                 |
+| ITAB-ARGOS153         | ITAB                  |                                                 |
+| Aalto-MEG-MRI-YYYY/MM | Aalto/MEG-MRI         | YYYY-MM (year, month; or major version)         |

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -15,7 +15,7 @@ REQUIRED, RECOMMENDED, and OPTIONAL.
 The guiding principles for when particular data is placed under a given requirement level
 can be loosely described as below:
 
--   REQUIRED: Data cannot be be interpreted without this information (or the ambiguity is unacceptably high)
+-   REQUIRED: Data cannot be interpreted without this information (or the ambiguity is unacceptably high)
 -   RECOMMENDED: Interpretation/utility would be dramatically improved with this information
 -   OPTIONAL: Users and/or tools might find it useful to have this information
 
@@ -93,7 +93,7 @@ be reviewed to include common data types in the future releases of the BIDS
 specification.
 
 It is RECOMMENDED that non-compulsory metadata fields (like `notch` in `channels.tsv` files)
-and/or files (like `events.tsv`) are fully omitted *when they are unavailable or unapplicable*,
+and/or files (like `events.tsv`) are fully omitted *when they are unavailable or inapplicable*,
 instead of specified with an `n/a` value, or included as an empty file
 (for example an empty `events.tsv` file with only the headers included).
 
@@ -631,7 +631,7 @@ Rules for formatting plain-text tabular files apply to TSVGZ files with three ex
 !!! warning "Attention"
 
     In contrast to plain-text TSV files,
-    compressed tabular files files MUST NOT include a header line.
+    compressed tabular files MUST NOT include a header line.
     Column names MUST be provided in the JSON file with the
     [`Columns`](glossary.md#columns-metadata) field.
     Each column MAY additionally be described with a column description,
@@ -1067,7 +1067,7 @@ Describing dates and timestamps:
 -   Dates can be shifted by a random number of days for privacy protection
     reasons.
     To distinguish real dates from shifted dates,
-    is is RECOMMENDED to set shifted dates to the year 1925 or earlier.
+    it is RECOMMENDED to set shifted dates to the year 1925 or earlier.
     Note that some data formats do not support arbitrary recording dates.
     For example, the [EDF](https://www.edfplus.info/)
     data format can only contain recording dates after 1985.

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -150,7 +150,7 @@ inversion:
     If files belonging to an entity-linked file collection are acquired at different inversion times,
     the `inv-<index>` entity MUST be used to distinguish individual files.
 
-    This entity represents the `"InversionTime` metadata field.
+    This entity represents the `"InversionTime"` metadata field.
     Therefore, if the `inv-<index>` entity is present in a filename,
     `"InversionTime"` MUST be defined in the associated metadata.
     Please note that the `<index>` denotes the number/index (in the form of a nonnegative integer),

--- a/src/schema/rules/checks/deprecations.yml
+++ b/src/schema/rules/checks/deprecations.yml
@@ -1,3 +1,4 @@
+---
 AnatomicalLandmarkCoordinateSystemDeprecation:
   issue:
     code: ELEKTA_NEUROMAG_DEPRECATED


### PR DESCRIPTION
Produced with the help of
- #2252 

Fixed several language and formatting errors discovered during comprehensive proofing of specification files using the proof-spec skill:

In src/common-principles.md:
- Line 18: Fixed duplicated "be" in "cannot be be interpreted"
- Line 96: Changed "unapplicable" to correct form "inapplicable"
- Line 634: Removed duplicated "files" in "files files MUST NOT"
- Line 1070: Fixed duplicated "is" to "it is RECOMMENDED"

In src/CHANGES.md:
- Line 80: Wrapped literal URL in angle brackets per markdown style guide (remark-lint: no-literal-urls rule)

In src/appendices/meg-systems.md:
- Line 17: Fixed broken table separator with space in middle
- Auto-formatted table and list styling for consistency

In src/schema/objects/entities.yaml:
- Line 153: Fixed missing closing quote in "InversionTime" metadata field reference

In src/schema/rules/checks/deprecations.yml:
- Line 1: Added missing YAML document start marker (---) to resolve yamllint warning

All fixes improve readability and correctness of the specification without changing any technical requirements or meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
