### PR TITLE
[ENH] provide RECOMMENDATION of the "Last, First" form for the `Authors` names

### DIFF
--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -547,6 +547,7 @@
           "datetime",
           "file_relative",
           "participant_relative",
+          "person_name",
           "rrid",
           "stimuli_relative",
           "time",

--- a/src/schema/objects/formats.yaml
+++ b/src/schema/objects/formats.yaml
@@ -112,6 +112,12 @@ participant_relative:
     without starting with "/" (an absolute path) or "sub/"
     (a relative path starting with the participant directory, rather than relative to that directory).
   pattern: '(?!/)(?!sub-)[0-9a-zA-Z+/_\-.]+'
+person_name:
+  display_name: Name of a person
+  description: |
+    Name for a person in a single string with clear disambiguation of First (Given) and Last (Family)
+    name(s).  Should follow `Last Names, First Names` convention.
+  pattern: '.+, .+'
 rrid:
   display_name: Research resource identifier
   description: |

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -213,6 +213,7 @@ Authors:
   type: array
   items:
     type: string
+    format: person_name
 B0FieldIdentifier:
   name: B0FieldIdentifier
   display_name: B0 Field Identifier
@@ -1327,6 +1328,7 @@ Format:
     - stimuli_relative
     # Miscellaneous
     - hed_version
+    - person_name
 FrameAcquisitionDuration:
   name: FrameAcquisitionDuration
   display_name: Frame Acquisition Duration

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -208,6 +208,8 @@ Authors:
   display_name: Authors
   description: |
     List of individuals who contributed to the creation/curation of the dataset.
+    It is RECOMMENDED to use `Last, First` form to ensure clear separation of
+    First (Given) from Last (Family) name(s).
   type: array
   items:
     type: string

--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -107,6 +107,7 @@ def test_formats(schema_obj):
         "stimuli_relative": ["any/arbitrary/path/file.txt"],
         "dataset_relative": ["any/arbitrary/path/file.txt"],
         "participant_relative": ["any/arbitrary/path/file.txt"],
+        "person_name": ["Last, First", "Many Last, a Few Firsts"],
         "rrid": ["RRID:SCR_017398"],
         "uri": ["foo://example.com:8042/over/there?name=ferret#nose"],
         "bids_uri": [


### PR DESCRIPTION
ATM there is no consistency across e.g. OpenNeuro datasets, e.g.

    ds006267/dataset_description.json:
      Authors=['Katherine M. Cole', 'Shau-Ming Wei', 'Pedro E. Martinez', 'Tuong-Vi Nguyen', 'Michael D. Gregory', 'J. Shane Kippenhan', 'Philip D. Kohn', 'Steven J. Soldin', 'Lynnette K. Nieman', 'Jack A. Yanovski', 'Peter J. Schmidt', 'Karen F. Berman']
    ds006269/dataset_description.json:
      Authors=['Lucy Pritchard', 'Ingrid Buller-Peralta', 'Sally M Till', 'Peter C Kind', 'Alfredo Gonzalez-Sulser']
    ds006303/dataset_description.json:
      Authors=['Linke, Julia', 'Naim, Reut', 'Haller, Simone', 'Khosravi, Parmis', 'Scheinberg, Beck', 'Byrne, Meghan', 'Harrewijn, Anita', 'Leibenluft, Ellen', 'Brotman, Melissa', 'Winkler, Anderson', 'Pine, Daniel']

and that is why some are left ambigous like

    ds003834/dataset_description.json:
      Authors=['Matteo Visconti di Oleggio Castello', 'James V. Haxby', 'M. Ida Gobbini']

where for Matteo I believe there is a composite last name of "Visconti di Oleggio Castello" per e.g.

	❯ curl --silent https://raw.githubusercontent.com/bids-standard/pybids/refs/heads/main/.zenodo.json | grep Matteo
		  "name": "Visconti di Oleggio Castello, Matteo",

but for the other 2 authors, the only last word is the Family name.

TODOs
- [ ] validation: add a check for validator to WARN about using `First Last`, in particular if any of the names has more than 2 components?  @effigies do you see an easy way to do that?
- [ ] anywhere else in the text to add information about this?