### PR TITLE
[FIX] Allowing to render JSON null type

### DIFF
--- a/tools/schemacode/src/bidsschematools/render/utils.py
+++ b/tools/schemacode/src/bidsschematools/render/utils.py
@@ -221,7 +221,7 @@ def get_link(string):
         "object": "https://www.json.org/json-en.html",
         "integer": "https://www.w3schools.com/js/js_json_datatypes.asp",
         "boolean": "https://www.w3schools.com/js/js_json_datatypes.asp",
-        "null": "https://www.w3schools.com/js/js_json_datatypes.asp"
+        "null": "https://www.w3schools.com/js/js_json_datatypes.asp",
     }
     # Allow plurals (e.g., strings -> links to string)
     dtype = string[:-1] if string[-1] == "s" else string


### PR DESCRIPTION
Closes #2260 

Nothing in the specification prevents from using JSON's `null` as value for metadata fields.
Although it is not rendered properly e.g. in metadata tables.

This PR modifies the `get_link` function in `bids-specification/tools/schemacode/src/bidsschematools/render/utils.py` to allow for this kind of rendering (provide a link for the `null` type):

|Key name|Requirement Level|Data type|Description|
|---|---|---|---|
|Command|REQUIRED|[string](https://www.w3schools.com/js/js_json_datatypes.asp) or [null](https://www.w3schools.com/js/js_json_datatypes.asp)|Command used to run the tool. Set to null to describe that the activity was performed manually.|

> [!NOTE]
> For this to work, `src/schema/objects/metadata.yaml` must be filled like this:
> 
> ```yaml
> Command:
>   ...
>  anyOf:
>    type: string
>    type: "null"
>```