### PR TITLE
Fix multiple validation errors for EMG coordsystem and electrode files

### DIFF
--- a/src/schema/rules/errors.yaml
+++ b/src/schema/rules/errors.yaml
@@ -142,8 +142,8 @@ SidecarWithoutDatafile:
   level: error
   selectors:
     - extension == ".json"
-    - suffix != "coordsystem" || modality != "emg"
-    # ↑ EMG allows multiple coordsys files per data file (distinguished via `space` entity)
+    - suffix != "coordsystem"
+    # ↑ coordsystem files can be shared via inheritance principle and may not have direct data files
 
 # BIDS Validator Original Issue Code #97
 MissingSession:

--- a/src/schema/rules/files/raw/channels.yaml
+++ b/src/schema/rules/files/raw/channels.yaml
@@ -62,12 +62,29 @@ coordsystem__eeg:
     space: optional
 
 # emg may have a `recording` entity
+# EMG coordsystem files can be at root level (no subject) when using
+# the inheritance principle for shared coordinate systems across subjects
 coordsystem__emg:
   $ref: rules.files.raw.channels.coordsystem__eeg
   datatypes:
     - emg
   entities:
     $ref: rules.files.raw.channels.coordsystem__eeg.entities
+    subject: optional
+    recording: optional
+    space: optional
+
+# EMG coordsystem files at dataset root level (no datatype directory)
+# Used for sharing coordinate systems across all subjects via inheritance
+# Example: /space-leftForearm_coordsystem.json
+coordsystem__emg_root:
+  suffixes:
+    - coordsystem
+  extensions:
+    - .json
+  datatypes: []
+  entities:
+    session: optional
     recording: optional
     space: optional
 

--- a/src/schema/rules/tabular_data/emg.yaml
+++ b/src/schema/rules/tabular_data/emg.yaml
@@ -29,17 +29,41 @@ EMGChannels:
   index_columns: [name__channels]
   additional_columns: allowed_if_defined
 
+# EMG electrodes without group column - name must be unique
 EMGElectrodes:
   selectors:
     - datatype == "emg"
     - suffix == "electrodes"
     - extension == ".tsv"
+    - '!columns.group'
   initial_columns:
     - name__electrodes
     - x
     - y
-    - z
-    - coordinate_system
+  columns:
+    name__electrodes: required
+    x: required
+    y: required
+    z: optional
+    coordinate_system: recommended
+    type__electrodes: recommended
+    material: recommended
+    impedance: recommended
+    group__emg: recommended
+  index_columns: [name__electrodes]
+  additional_columns: allowed_if_defined
+
+# EMG electrodes with group column - (name, group) must be unique
+EMGElectrodes__grouped:
+  selectors:
+    - datatype == "emg"
+    - suffix == "electrodes"
+    - extension == ".tsv"
+    - columns.group
+  initial_columns:
+    - name__electrodes
+    - x
+    - y
   columns:
     name__electrodes: required
     x: required

--- a/tools/schemacode/src/bidsschematools/tests/test_render_text.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_render_text.py
@@ -118,6 +118,9 @@ sub-<label>/
             continue
         if line.startswith("    [ses-<label>/]"):
             continue
+        # Skip patterns with optional subject (EMG coordsystem allows root-level placement)
+        if line.lstrip().startswith("[sub-<label>]"):
+            continue
 
         if line in datatype_bases:
             datatype_bases_found += 1
@@ -153,6 +156,9 @@ sub-<label>/
         if line.startswith("sub-<label>"):
             continue
         if line.startswith("    [ses-<label>/]"):
+            continue
+        # Skip patterns with optional subject (EMG coordsystem allows root-level placement)
+        if line.lstrip().startswith("[sub-<label>]"):
             continue
 
         if line in datatype_bases:


### PR DESCRIPTION
## Summary
Fix multiple validation errors for EMG coordsystem and electrode files.

## Changes

### 1. Fix SIDECAR_WITHOUT_DATAFILE for coordsystem files (errors.yaml)
Changed selector from:
```yaml
- suffix != "coordsystem" || modality != "emg"
```
To:
```yaml
- suffix != "coordsystem"
```

**Reason:** Coordsystem files can be shared via the inheritance principle and may not have direct data files. This applies to all modalities, not just EMG. The simpler selector excludes all coordsystem files from this check. Also, it seems that when in root, the error comes up before modality is checked, therefore, the error is being raised.

### 2. Allow root-level EMG coordsystem files (channels.yaml)
- Added `subject: optional` to `coordsystem__emg` rule
- Added new `coordsystem__emg_root` rule with `datatypes: []` for root-level placement

**Reason:** EMG datasets can place coordsystem files at root level (no subject entity) to share coordinate system definitions across all subjects via inheritance.

### 3. Conditional uniqueness for EMG electrodes (emg.yaml)
Split `EMGElectrodes` into two rules:
- `EMGElectrodes`: When no `group` column exists, electrode `name` must be unique
- `EMGElectrodes__grouped`: When `group` column exists, the combination of `(name, group)` must be unique

Uses selectors `!columns.group` and `columns.group` to determine which rule applies.

**Reason:** EMG datasets with bilateral recordings (left/right arm) may have the same electrode names (e.g., E0-E15) repeated across different groups. The uniqueness constraint should be conditional on whether grouping is used.

### 4. Update test for optional subject (test_render_text.py)
Added handling for patterns with optional subject entity in filename template rendering test.

**Reason:** Subject is required for coordsystem files in other modalities (EEG, MEG, NIRS, iEEG), but optional for EMG to allow root-level placement. When the schema renders filename templates, the output shows `[sub-<label>]` for optional subject patterns. The test parses this rendered text without modality context, so it cannot distinguish EMG patterns from other modalities. We skip `[sub-<label>]` patterns in the test since they represent valid EMG coordsystem files.

## Valid coordsystem patterns now supported
- `space-leftForearm_coordsystem.json` (root level, with space entity)
- `sub-01/emg/sub-01_coordsystem.json` (subject level)
- `sub-01/emg/sub-01_space-hand_coordsystem.json` (subject level with space)

## Related
- Affects emg_TwoWristbands and emg_MultiBodyParts examples in bids-examples