### PR TITLE
[FIX] Add desc- entity name into descriptions.tsv example

### DIFF
--- a/src/derivatives/common-data-types.md
+++ b/src/derivatives/common-data-types.md
@@ -331,9 +331,9 @@ Contents of the `descriptions.tsv` file:
 
 ```tsv
 desc_id	description
-Filt	low-pass filtered at 30Hz
-FiltDs	low-pass filtered at 30Hz, downsampled to 250Hz
-preproc	low-pass filtered at 30Hz, downsampled to 250Hz, and rereferenced to a common average reference
+desc-Filt	low-pass filtered at 30Hz
+desc-FiltDs	low-pass filtered at 30Hz, downsampled to 250Hz
+desc-preproc	low-pass filtered at 30Hz, downsampled to 250Hz, and rereferenced to a common average reference
 ```
 
 <!-- Link Definitions -->


### PR DESCRIPTION
consistent with other uses of {ent}_id -- like session_id, participant_id etc, and per description for the column already saying
"A desc-<label> entity present in the derivatives dataset."

This would be another good use case for upgrade/migrate command to fixup those:
- https://github.com/bids-standard/bids-specification/issues/1984
