### PR TITLE
test(bst): Narrow glossary validation test

### DIFF
--- a/tools/schemacode/src/bidsschematools/tests/test_render_text.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_render_text.py
@@ -60,9 +60,9 @@ def test_make_glossary(schema_obj, schema_dir):
     for line in glossary.split("\n"):
         if line.startswith('<a name="objects.'):
             # Are all objects objects?
-            assert any([line.startswith(f'<a name="objects.{i}') for i in object_files])
+            assert any(line.startswith(f'<a name="objects.{i}.') for i in object_files)
             # Are rules loaded incorrectly?
-            assert not any([line.startswith(f'<a name="objects.{i}') for i in rules_only])
+            assert not any(line.startswith(f'<a name="objects.{i}.') for i in rules_only)
 
 
 @pytest.mark.parametrize("placeholders", [True, False])


### PR DESCRIPTION
Addresses comment on #1714:

> generic, worth introducing outside of the PR unless to be merged soon?

_Originally posted by @yarikoptic in https://github.com/bids-standard/bids-specification/pull/1714#discussion_r2627855937_

Not strictly necessary until BEP38 is merged, but the change is correct, so might as well include the fix in the maintenance branch.