### PR TITLE
[ENH] Make Pharmaceutical metadata terms less PET-specific

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2839,7 +2839,7 @@ PharmaceuticalName:
   name: PharmaceuticalName
   display_name: Pharmaceutical Name
   description: |
-    Name of pharmaceutical coadministered with tracer.
+    Name of pharmaceutical.
   type: string
 PhaseEncodingDirection:
   name: PhaseEncodingDirection

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -123,6 +123,7 @@ PETPharmaceuticals:
     PharmaceuticalName:
       level: recommended
       description_addendum: |
+        For pharmaceutical co-administered with tracer.
         Corresponds to [DICOM Tag 0018, 0034](https://dicomlookup.com/dicomtags/(0018,0034)) `Intervention Drug Name`.
     PharmaceuticalDoseAmount:
       level: recommended


### PR DESCRIPTION
We are to introduce use of Pharma* fields into BEP032 (#1705) where it has no notion of tracers. I am moving this extra description to become PET specific, but also @bids-standard/raw-pet  people might want to double check if that is what was actually intended (or it could be administered separate from the tracer