### PR TITLE
[FIX] Update navigation with respect to the `bids-starter-kit`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,8 +49,8 @@ nav:
           - Arterial Spin Labeling: appendices/arterial-spin-labeling.md
           - Cross modality correspondence: appendices/cross-modality-correspondence.md
       - Changelog: CHANGES.md
-  - The BIDS Starter Kit:
-      - Website: https://bids.neuroimaging.io/getting_started/
+  - The BIDS Website:
+      - Getting started: https://bids.neuroimaging.io/getting_started/
       - Tutorials: https://bids.neuroimaging.io/getting_started/tutorials/
 exclude_docs: |
   README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,6 @@ nav:
   - The BIDS Starter Kit:
       - Website: https://bids.neuroimaging.io/getting_started/
       - Tutorials: https://bids.neuroimaging.io/getting_started/tutorials/
-      - GitHub repository: https://github.com/bids-standard/bids-starter-kit
 exclude_docs: |
   README.md
   pregh-changes.md


### PR DESCRIPTION
- [x] Remove link to `bids-starter-kit` GitHub repo since those files are now hosted in the `bids-website` repo
- [x] Change navigation accordingly: `The BIDS Starter Kit` -> `The BIDS Website`

cc @satra @ayendiki