### PR TITLE
[Schema][Fix] add checks for multiple frame consistency issues 

### DIFF
--- a/src/schema/rules/checks/pet.yaml
+++ b/src/schema/rules/checks/pet.yaml
@@ -5,20 +5,15 @@ PETFrameConsistency:
   issue:
     code: PET_FRAME_CONSISTENCY
     message: |
-      The number of frames in this scan does not match the number of frames
-      (as defined by FrameDuration and FrameTimesStart) in the
+      The number of frames as defined by FrameDuration and FrameTimesStart do not match in the
       associated '.json' file.
     level: error
   selectors:
     - suffix == 'pet'
-    - type(nifti_header) != "null"
     - sidecar.FrameDuration
     - sidecar.FrameTimesStart
   checks:
-    - |
-      length(sidecar.FrameDuration) == nifti_header.dim[4] &&
-      length(sidecar.FrameTimesStart) == nifti_header.dim[4] &&
-      length(sidecar.FrameDuration) == length(sidecar.FrameTimesStart)
+    - length(sidecar.FrameDuration) == length(sidecar.FrameTimesStart)
 
 PETFrameConsistencyFrameDuration:
   issue:
@@ -47,18 +42,3 @@ PETFrameConsistencyFrameTimesStart:
     - sidecar.FrameTimesStart
   checks:
     - length(sidecar.FrameTimesStart) == nifti_header.dim[4]
-
-
-PETFrameConsistencyFrameDurationAndFrameTimesStart:
-  issue:
-    code: PET_FRAME_CONSISTENCY_FRAME_DURATION_AND_FRAME_TIMES_START
-    message: |
-      The number of frames as defined by FrameDuration and FrameTimesStart do not match in the
-      associated '.json' file.
-    level: error
-  selectors:
-    - suffix == 'pet'
-    - sidecar.FrameDuration
-    - sidecar.FrameTimesStart
-  checks:
-    - length(sidecar.FrameDuration) == length(sidecar.FrameTimesStart)


### PR DESCRIPTION
This was discovered by @mnoergaard during the processing of a dataset recently uploaded to openneuro -> https://github.com/nipreps/petprep/issues/223

(Not a validator issue 👍 )

This adds checks for the following cases:

- Number of frames differ between nifti, FrameDuration, and FrameTimesStart
- Number of frames mismatch between FrameDuration and nifti
- Number of frames mismatch between FramesTimeStart and nifti
- Number of frames mismatch between FramesTimesStart and FrameDuration when nifti header is null (`--ignoreNiftiHeader` flag use case)

