### PR TITLE
[FIX] Add `MixingTime` to the DWI section

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -900,7 +900,7 @@ A guide for using macros can be found at
    }
 ) }}
 
-### Other RECOMMENDED metadata
+### Other RECOMMENDED and OPTIONAL metadata
 
 The `PhaseEncodingDirection` and `TotalReadoutTime` metadata
 fields are RECOMMENDED to enable the correction of geometrical distortions

--- a/src/schema/rules/sidecars/dwi.yaml
+++ b/src/schema/rules/sidecars/dwi.yaml
@@ -9,12 +9,13 @@ MRIDiffusionMultipart:
   fields:
     MultipartID: optional
 
-# Other recommended metadata
+# Other recommended and optional metadata
 MRIDiffusionOtherMetadata:
   selectors:
     - datatype == "dwi"
     - suffix == "dwi"
     - match(extension, "^\.nii(\.gz)?$")
   fields:
+    MixingTime: optional
     PhaseEncodingDirection: recommended
     TotalReadoutTime: recommended


### PR DESCRIPTION
I am not too familiar with the `MixingTime` field, but the [MixingTime](https://bids-specification.readthedocs.io/en/stable/glossary.html#objects.metadata.MixingTime) description says that certain diffusion-weighted sequences should include this field.  The `MixingTime` is currently listed in the [Spatial Encoding](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#in-and-out-of-plane-spatial-encoding) section, and here I have added it to the DWI section so that it is easier to discover.

cc @satra @ayendiki