### PR TITLE
[FIX] Update and render schema definition of dataset_description.json

### DIFF
--- a/src/modality-agnostic-files/dataset-description.md
+++ b/src/modality-agnostic-files/dataset-description.md
@@ -24,26 +24,7 @@ The definitions of these fields can be found in
 and a guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
-{{ MACROS___make_metadata_table(
-   {
-      "Name": "REQUIRED",
-      "BIDSVersion": "REQUIRED",
-      "HEDVersion": "RECOMMENDED",
-      "DatasetLinks": "REQUIRED if [BIDS URIs][] are used",
-      "DatasetType": "RECOMMENDED",
-      "License": "RECOMMENDED",
-      "Authors": "RECOMMENDED if CITATION.cff is not present",
-      "Keywords": "OPTIONAL",
-      "Acknowledgements": "OPTIONAL",
-      "HowToAcknowledge": "OPTIONAL",
-      "Funding": "OPTIONAL",
-      "EthicsApprovals": "OPTIONAL",
-      "ReferencesAndLinks": "OPTIONAL",
-      "DatasetDOI": "OPTIONAL",
-      "GeneratedBy": "RECOMMENDED",
-      "SourceDatasets": "RECOMMENDED",
-   }
-) }}
+{{ MACROS___make_json_table('dataset_metadata.dataset_description') }}
 
 Each object in the `GeneratedBy` array includes the following REQUIRED, RECOMMENDED
 and OPTIONAL keys:
@@ -217,7 +198,3 @@ A guide for using macros can be found at
  https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
 -->
 {{ MACROS___render_text("objects.files.LICENSE.description") }}
-
-<!-- Link Definitions -->
-
-[bids uris]: ../common-principles.md#bids-uri

--- a/src/schema/rules/dataset_metadata.yaml
+++ b/src/schema/rules/dataset_metadata.yaml
@@ -5,11 +5,15 @@ dataset_description:
   fields:
     Name: required
     BIDSVersion: required
+    HEDVersion: recommended
+    DatasetLinks:
+      level: optional
+      level_addendum: required if [BIDS URIs](SPEC_ROOT/common-principles.md#bids-uri) are used
     DatasetType: recommended
     License: recommended
     Authors:
       level: optional
-      level_addendum: recommended if no CITATION.cff file is present
+      level_addendum: recommended if `CITATION.cff` is not present
     Keywords: optional
     Acknowledgements: optional
     HowToAcknowledge: optional


### PR DESCRIPTION
The metadata table displayed in https://bids-specification.readthedocs.io/en/stable/modality-agnostic-files/dataset-description.html and the one in the schema that is validated got out of sync.

This updates the schema table to match the one on the spec, and renders the table from the schema.

* [Updated table](https://bids-specification--2315.org.readthedocs.build/en/2315/modality-agnostic-files/dataset-description.html#dataset_descriptionjson)
* [Original](https://bids-specification.readthedocs.io/en/latest/modality-agnostic-files/dataset-description.html#dataset_descriptionjson)