### PR TITLE
Fix a single use of ManufacturerModelName in qmri.md (should be ManufacturersModelName)

### DIFF
--- a/src/appendices/qmri.md
+++ b/src/appendices/qmri.md
@@ -372,7 +372,7 @@ sub-01_T1map.json:
 
 "MagneticFieldStrength": "3",
 "Manufacturer": "Siemens",
-"ManufacturerModelName": "TrioTim",
+"ManufacturersModelName": "TrioTim",
 "InstitutionName": "xxx",
 "PulseSequenceType": "SPGR",
 "PulseSequenceDetails": "Information beyond the sequence type that identifies


### PR DESCRIPTION
https://bids-specification.readthedocs.io/en/stable/glossary.html#manufacturersmodelname-metadata