### PR TITLE
fix(schema): Check SpatialReference for space, template entities

### DIFF
--- a/src/schema/rules/sidecars/derivatives/atlas.yaml
+++ b/src/schema/rules/sidecars/derivatives/atlas.yaml
@@ -2,9 +2,8 @@
 TemplateNonStandard:
   selectors:
     - dataset.dataset_description.DatasetType == "derivative"
-    - '!intersects(schema.objects.enums._StandardTemplateCoordSys.enum, [entities.tpl])'
-    - >
-      type(entities.space) == 'null' ||
-      !intersects(schema.objects.enums._StandardTemplateCoordSys.enum, [entities.space])
+    - '"template" in entities'
+    - type(entities.space) == 'null'
+    - '!intersects(schema.objects.enums._StandardTemplateCoordSys.enum, [entities.template])'
   fields:
     SpatialReference: required

--- a/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
+++ b/src/schema/rules/sidecars/derivatives/common_derivatives.yaml
@@ -25,7 +25,6 @@ SpatialReferenceNonStandard:
     - dataset.dataset_description.DatasetType == "derivative"
     - '"space" in entities'
     - '!intersects(schema.objects.enums._StandardTemplateCoordSys.enum, [entities.space])'
-    - type(entities.tpl) == 'null' || !intersects(schema.objects.enums._StandardTemplateCoordSys.enum, [entities.tpl])
   fields:
     SpatialReference: required
 


### PR DESCRIPTION
The rule changes in #1714 were a bit off. If the `space-<label>` entity is set, then the file is in that space, regardless of whether the file is `tpl-<label>-*` or `sub-<label>-*`, so check for a spatial reference if that value is unknown.

If space is not absent, *then* we check for whether `tpl-<label>` is defined and unknown.