### PR TITLE
[FIX] Update spacing to fix list rendering

### DIFF
--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -4,6 +4,7 @@ Portions of the BIDS specification are defined using YAML files in order to
 make the specification machine-readable.
 
 Currently the portions of the specification that rely on this schema are:
+
 -   the entity tables,
 -   entity definitions,
 -   filename templates,


### PR DESCRIPTION
The list on the [schema webpage](https://bids-specification.readthedocs.io/en/stable/schema/index.html) does not render correctly due to a minor spacing issue in the markdown file:

<img width="782" height="245" alt="image" src="https://github.com/user-attachments/assets/16bae17a-a7c8-41d7-908e-84a08d20baf0" />

cc @satra @ayendiki