### PR TITLE
[ENH] Additional age related columns for participants.tsv file to cover animal data contd.

### DIFF
--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -47,6 +47,42 @@ age:
     "Units": "year",
     "Maximum": 89,
   }
+age_category:
+  name: age_category
+  display_name: Age category
+  description: |
+    A non-numeric term for a subject's life cycle stage (for instance, `adult`).
+    Inspired by the
+    [UBERON life cycle stage](http://purl.obolibrary.org/obo/UBERON_0000105).
+  type: string
+  enum:
+    - $ref: objects.enums.adolescent.value
+    - $ref: objects.enums.adult.value
+    - $ref: objects.enums.embryo.value
+    - $ref: objects.enums.infant.value
+    - $ref: objects.enums.juvenile.value
+    - $ref: objects.enums.late_adult.value
+    - $ref: objects.enums.neonate.value
+    - $ref: objects.enums.perinate.value
+    - $ref: objects.enums.prime_adult.value
+    - $ref: objects.enums.young_adult.value
+birthdate:
+  name: birthdate
+  display_name: Birth date
+  description: |
+    Date of the start of a subject's neonate stage. Date format (YYYY-MM-DD).
+    Should not be provided or anonymized for human subjects.
+  type: string
+  format: date
+birthtime:
+  name: birthtime
+  display_name: Birth time
+  description: |
+    Time (or estimated time) of birth. Time format (hh:mm:ssZ).
+    Typically, this field will be combined with birthdate.
+    Should not be provided or anonymized for human subjects.
+  type: string
+  format: time
 cardiac:
   name: cardiac
   display_name: Cardiac measurement
@@ -99,6 +135,23 @@ coordinate_system:
     Name of the coordinate system defined in `coordsystem.json` in which the electrode's
     `x`, `y`, and (optionally) `z` coordinates are given.
   type: string
+deathdate:
+  name: deathdate
+  display_name: Death date
+  description: |
+    Date of the end of a subject's life cycle. Date format (YYYY-MM-DD).
+    Should not be provided or anonymized for human subjects.
+  type: string
+  format: date
+deathtime:
+  name: deathtime
+  display_name: Death time
+  description: |
+    Time (or estimated time) of death. Time format (hh:mm:ssZ).
+    Typically, this field will be combined with deathdate.
+    Should not be provided or anonymized for human subjects.
+  type: string
+  format: time
 detector__channels:
   name: detector
   display_name: Detector Name

--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1481,3 +1481,67 @@ PhysioTypeEyetrack:
   display_name: Eye-tracking recording
   description: |
     A specific physiological recording type: eye-tracking.
+# Life cycle stages for age_category
+adolescent:
+  value: adolescent
+  display_name: Adolescent
+  description: |
+    Life cycle stage of a subject loosely defined by the transitional growth
+    and development between childhood and adulthood, often described as puberty.
+adult:
+  value: adult
+  display_name: Adult
+  description: |
+    Life cycle stage of a subject that starts with sexual maturity and ends with
+    death. Adapted from UBERON - http://purl.obolibrary.org/obo/UBERON_0000113.
+embryo:
+  value: embryo
+  display_name: Embryo
+  description: |
+    Life cycle stage of a subject that starts with fertilization and ends with the
+    fully formed embryo. If fertilization is unknown the LMP startdate is assumed.
+    Adapted from UBERON - http://purl.obolibrary.org/obo/UBERON_0000068.
+infant:
+  value: infant
+  display_name: Infant
+  description: |
+    Life cycle stage of subjects (mammals) that follows the neonate stage and ends at
+    weaning. Adapted from UBERON - http://purl.obolibrary.org/obo/UBERON_0034920.
+juvenile:
+  value: juvenile
+  display_name: Juvenile
+  description: |
+    Life cycle stage of a subject that starts with the independence of the nest
+    and/or caregivers and ends with sexual maturity. Adapted from
+    UBERON - http://purl.obolibrary.org/obo/UBERON_0034919.
+late_adult:
+  value: late adult
+  display_name: Late adult
+  description: |
+    Life cycle stage of a subject that follows the prime adult stage and ends with
+    death. Adapted from UBERON - http://purl.obolibrary.org/obo/UBERON_0007222.
+neonate:
+  value: neonate
+  display_name: Neonate
+  description: |
+    Life cycle stage of a subject that immediately follows birth.
+    Adapted from UBERON - http://purl.obolibrary.org/obo/UBERON_0007221.
+perinate:
+  value: perinate
+  display_name: Perinate
+  description: |
+    Life cycle stage of a subject that starts right before and ends right after birth.
+    Adapted from UBERON - http://purl.obolibrary.org/obo/UBERON_0012101.
+prime_adult:
+  value: prime adult
+  display_name: Prime adult
+  description: |
+    Life cycle stage of a subject that starts with sexual maturity or
+    the cessation of growth, whichever comes last, and ends before senescence.
+    Adapted from UBERON - http://purl.obolibrary.org/obo/UBERON_0018241.
+young_adult:
+  value: young adult
+  display_name: Young adult
+  description: |
+    Life cycle stage of a subject that starts with sexual maturity and ends with the
+    cessation of growth (if this is reached after sexual maturity).

--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -15,6 +15,11 @@ Participants:
     handedness: recommended
     strain: recommended
     strain_rrid: recommended
+    birthdate: optional
+    birthtime: optional
+    deathdate: optional
+    deathtime: optional
+    age_category: optional
     HED: optional
   index_columns: [participant_id]
   additional_columns: allowed


### PR DESCRIPTION
## Summary

This PR adds age-related columns and metadata to `participants.tsv` to better support animal data and clarify age specifications across species. Key additions include:

- **`life_cycle_stage`** column with enums based on UBERON ontology (embryo, neonate, juvenile, adult, etc.)
- **`AgeReference`** metadata field for `participants.json` to specify what the `age` value is relative to (birth, fertilization, LMP_startdate)
- **`birthdate`/`birthtime`** and **`deathdate`/`deathtime`** optional columns
- Schema rules to recommend `AgeReference` when `age` column is present

This is a continuation of #1839, which was accidentally closed due to a force-push. 
**Please refer to #1839 for the full discussion history and review comments.** Since the commits were too many and too conflicting to do a rebase, only the final edits with a single commit was made to restore from this point. A backup with the history of the commits is [here](https://github.com/ree-gupta/bids-specification/tree/animal-data-columns-backup).

## Related Issues

- #1705
- #1634
- #1791
- #1826

TODO:

- [x] Add the info that either birthdate or age should be specified - decision to keep birthdate as optional and if age is specified, `AgeReference` must be used in sidecar JSON
- [x] Feedback on term name to include 'stage' to match UBERON - deviate slighly from UBERON and not use 'stage' in the enum names
- [x] Confirm introduction of `AgeReference` rule in schema for `participant.tsv`
- [x] Which key to use for `age` column definition that would specify that one must use `AgeReference` in sidecar?
- [ ] Default for 'AgeReference'
- [ ] Add rule that either `birthdate` or `age` must be specified
- [ ] Formalized 'TermURL' as suggested by @yarikoptic [here](https://github.com/bids-standard/bids-specification/pull/1839/files/95804e4a1d2102f7e0c066d1bf8c8272d4641d0f#r1803340723) - ??
- [x] Resolve conflicts (definition was used - different from description and enums use)

cc: @bids-standard/bep032 @lzehl @yarikoptic @bendichter


