### PR TITLE
Add swi and minIP suffixes for susceptibility weighted imaging

### DIFF
--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -237,6 +237,8 @@ and a guide for using macros can be found at
          "PDT2",
          "UNIT1",
          "angio",
+         "swi",
+         "minIP",
       ])
 }}
 
@@ -261,6 +263,8 @@ and a guide for using macros can be found at
          "PDT2",
          "UNIT1",
          "angio",
+         "swi",
+         "minIP",
       ]
    )
 }}

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -727,6 +727,17 @@ meg:
   description: |
     Unprocessed MEG data stored in the native file format of the MEG instrument
     with which the data was collected.
+minIP:
+  value: minIP
+  display_name: Minimum intensity projection
+  description: |
+    In arbitrary units (arbitrary).
+    Minimum intensity projection is a post-processing technique
+    applied to susceptibility weighted images (SWI),
+    where the minimum intensity is projected across a slab
+    of a specified thickness
+    ([Haacke et al., 2004](https://doi.org/10.1002/mrm.20198)).
+  unit: arbitrary
 motion:
   value: motion
   display_name: Motion
@@ -881,6 +892,17 @@ svs:
   display_name: Single-voxel spectroscopy
   description: |
     MRS acquisitions where the detected MR signal is spatially localized to a single volume.
+swi:
+  value: swi
+  display_name: Susceptibility weighted image
+  description: |
+    In arbitrary units (arbitrary).
+    Susceptibility weighted imaging (SWI) is a contrast mechanism
+    that combines magnitude and phase information from gradient-echo
+    sequences to enhance the visibility of substances with magnetic
+    susceptibility different from surrounding tissues
+    ([Haacke et al., 2004](https://doi.org/10.1002/mrm.20198)).
+  unit: arbitrary
 trace:
   value: trace
   display_name: Trace-weighted diffusion image

--- a/src/schema/rules/files/raw/anat.yaml
+++ b/src/schema/rules/files/raw/anat.yaml
@@ -53,6 +53,20 @@ parametric:
     $ref: meta.templates.raw.mri.entities
     task: optional
 
+swi:
+  suffixes:
+    - swi
+    - minIP
+  extensions:
+    - .nii.gz
+    - .nii
+    - .json
+  datatypes:
+    - anat
+  entities:
+    $ref: meta.templates.raw.mri.entities
+    task: optional
+
 defacemask:
   suffixes:
     - defacemask


### PR DESCRIPTION
## Summary

Adds support for susceptibility weighted images (`swi`) and minimum intensity projections (`minIP`) as non-parametric anatomical MRI suffixes, addressing the remaining gaps identified in #1566.

- Adds `swi` and `minIP` suffix definitions to `src/schema/objects/suffixes.yaml`
- Adds a file rule group in `src/schema/rules/files/raw/anat.yaml` with standard MRI entities (no `echo` or `part`, since multi-echo combination occurs before SWI generation)
- Adds `swi` and `minIP` to the non-parametric suffix table and filename template in the MRI documentation

These suffixes are classified as non-parametric (arbitrary intensity scale), consistent with how `T2starw` and other contrast-weighted images are handled. Like `Chimap` and other parametric maps, they can appear in raw datasets when pre-generated by the scanner, or in derivative datasets when computed offline.

Ref: https://github.com/bids-standard/bids-specification/issues/1566#issuecomment-3878452407

## Test plan

- [ ] Schema validation passes
- [ ] Rendered docs show `swi` and `minIP` in the non-parametric suffix table and filename templates
- [ ] Example dataset validates (see companion PR in bids-examples)