### PR TITLE
[FIX] Use http://www.dicomlookup.com for DICOM tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
                 --ignore-url 'https://github.com/[^/]*' \
                 --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
                 --ignore-url 'https://www.incf.org' \
-                --ignore-url 'https://dicomlookup.com/dicomtags/.*' \
+                --ignore-url 'http://www.dicomlookup.com/dicomtags/.*' \
                 --ignore-url 'https://www.instagram.com/bidsstandard/' \
                 --ignore-url 'https://jsoneditoronline.org' \
                 --ignore-url 'https://rrid.site.*' \

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -78,7 +78,7 @@ A guide for using macros can be found at
 
 <sup>2</sup>Conveniently, for Siemens data, this value is easily obtained as
 `1 / (BWPPPE * ReconMatrixPE)`, where BWPPPE is the
-"BandwidthPerPixelPhaseEncode" in [DICOM Tag 0019, 1028](https://dicomlookup.com/dicomtags/(0019,1028)) and ReconMatrixPE is
+"BandwidthPerPixelPhaseEncode" in [DICOM Tag 0019, 1028](http://www.dicomlookup.com/dicomtags/(0019,1028)) and ReconMatrixPE is
 the size of the actual reconstructed data in the phase direction (which is NOT
 reflected in a single DICOM Tag for all possible aforementioned scan
 manipulations). See
@@ -952,7 +952,7 @@ accompanied by two ancillary files: `*_asl.json` and `*_aslcontext.tsv`.
 
 The `*_aslcontext.tsv` table consists of a single column of labels identifying the
 `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.
-Volume types are defined in the following table, based on [DICOM Tag 0018, 9257](https://dicomlookup.com/dicomtags/(0018,9257)) `ASL Context`.
+Volume types are defined in the following table, based on [DICOM Tag 0018, 9257](http://www.dicomlookup.com/dicomtags/(0018,9257)) `ASL Context`.
 Note that the volume_types `control` and  `label` within BIDS only serve
 to specify the magnetization state of the blood and thus the ASL subtraction order.
 See the [ASL Appendix](../appendices/arterial-spin-labeling.md#which-image-is-control-and-which-is-label)

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -40,7 +40,8 @@ AcquisitionDuration:
   display_name: Acquisition Duration
   description: |
     Duration (in seconds) of scan acquisition, including all volumes for multi-volume scans.
-    Corresponds to [DICOM Tag 0018, 9073](https://dicomlookup.com/dicomtags/(0018,9073)) `Acquisition Duration`.
+    Corresponds to [DICOM Tag 0018, 9073](https://dicomlookup.com/dicomtags/(0018,9073))
+    `Acquisition Duration`.
   type: number
   exclusiveMinimum: 0
   unit: s
@@ -388,7 +389,8 @@ BolusCutOffDelayTime:
     cut-off saturation pulses.
     For Q2TIPS, only the values for the first and last bolus cut-off saturation
     pulses are provided.
-    Based on [DICOM Tag 0018, 925F](https://dicomlookup.com/dicomtags/(0018,925F)) `ASL Bolus Cut-off Delay Time`.
+    Based on [DICOM Tag 0018, 925F](https://dicomlookup.com/dicomtags/(0018,925F))
+    `ASL Bolus Cut-off Delay Time`.
   anyOf:
     - type: number
       minimum: 0
@@ -403,14 +405,16 @@ BolusCutOffFlag:
   display_name: Bolus Cut Off Flag
   description: |
     Boolean indicating if a bolus cut-off technique is used.
-    Corresponds to [DICOM Tag 0018, 925C](https://dicomlookup.com/dicomtags/(0018,925C)) `ASL Bolus Cut-off Flag`.
+    Corresponds to [DICOM Tag 0018, 925C](https://dicomlookup.com/dicomtags/(0018,925C))
+    `ASL Bolus Cut-off Flag`.
   type: boolean
 BolusCutOffTechnique:
   name: BolusCutOffTechnique
   display_name: Bolus Cut Off Technique
   description: |
     Name of the technique used, for example `"Q2TIPS"`, `"QUIPSS"`, `"QUIPSSII"`.
-    Corresponds to [DICOM Tag 0018, 925E](https://dicomlookup.com/dicomtags/(0018,925E)) `ASL Bolus Cut-off Technique`.
+    Corresponds to [DICOM Tag 0018, 925E](https://dicomlookup.com/dicomtags/(0018,925E))
+    `ASL Bolus Cut-off Technique`.
   type: string
 BrainLocation:
   name: BrainLocation
@@ -508,7 +512,8 @@ ChemicalShiftReference:
   display_name: Chemical Shift Reference
   description: |
     The chemical shift at the transmitter frequency, specified in ppm (for example, `2.68`).
-    Corresponds to [DICOM Tag 0018, 9053](https://dicomlookup.com/dicomtags/(0018,9053)) `Chemical Shift Reference`.
+    Corresponds to [DICOM Tag 0018, 9053](https://dicomlookup.com/dicomtags/(0018,9053))
+    `Chemical Shift Reference`.
   type: number
   unit: ppm
 ChunkTransformationMatrix:
@@ -569,14 +574,16 @@ CodeValue:
   description: |
     An identifier that is unambiguous within the Coding Scheme
     denoted by Coding Scheme Designator and Coding Scheme Version.
-    Corresponds to [DICOM Tag 0008, 0100](https://dicomlookup.com/dicomtags/(0008,0100)) `Code Value`.
+    Corresponds to [DICOM Tag 0008, 0100](https://dicomlookup.com/dicomtags/(0008,0100))
+    `Code Value`.
   type: string
 CodeMeaning:
   name: CodeMeaning
   display_name: Code Meaning
   description: |
     Text that has meaning to a human and conveys the meaning of the term
-    Corresponds to [DICOM Tag 0008, 0104](https://dicomlookup.com/dicomtags/(0008,0104)) `Code Meaning`.
+    Corresponds to [DICOM Tag 0008, 0104](https://dicomlookup.com/dicomtags/(0008,0104))
+    `Code Meaning`.
   type: string
 CodingSchemeDesignator:
   name: CodingSchemeDesignator
@@ -591,7 +598,8 @@ CodingSchemeVersion:
   display_name: Coding Scheme version
   description: |
     An identifier of the version of the coding scheme if necessary to resolve ambiguity.
-    Corresponds to [DICOM Tag 0008, 0103](https://dicomlookup.com/dicomtags/(0008,0103)) `Coding Scheme Version`.
+    Corresponds to [DICOM Tag 0008, 0103](https://dicomlookup.com/dicomtags/(0008,0103))
+    `Coding Scheme Version`.
   type: string
 CodeURL:
   name: CodeURL
@@ -684,7 +692,8 @@ ContrastBolusIngredient:
   display_name: Contrast Bolus Ingredient
   description: |
     Active ingredient of agent.
-    Corresponds to [DICOM Tag 0018, 1048](https://dicomlookup.com/dicomtags/(0018,1048)) `Contrast/Bolus Ingredient`.
+    Corresponds to [DICOM Tag 0018, 1048](https://dicomlookup.com/dicomtags/(0018,1048))
+    `Contrast/Bolus Ingredient`.
   type: string
   enum:
     - $ref: objects.enums.IODINE.value
@@ -786,7 +795,8 @@ DeidentificationMethod:
   display_name: Deidentification Method
   description: |
     A description of the mechanism or method used to remove the Patient's identity.
-    Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063)) `De-identification Method`.
+    Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063))
+    `De-identification Method`.
   type: array
   items:
     type: string
@@ -1015,7 +1025,8 @@ DoseCalibrationFactor:
   display_name: Dose Calibration Factor
   description: |
     Multiplication factor used to transform raw data (in counts/sec) to meaningful unit (Bq/ml).
-    Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322)) `Dose Calibration Factor`.
+    Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322))
+    `Dose Calibration Factor`.
   type: number
 DwellTime:
   name: DwellTime
@@ -1247,7 +1258,8 @@ EchoTime:
   display_name: Echo Time
   description: |
     The echo time (TE) for the acquisition, specified in seconds.
-    Corresponds to [DICOM Tag 0018, 0081](https://dicomlookup.com/dicomtags/(0018,0081)) `Echo Time`
+    Corresponds to [DICOM Tag 0018, 0081](https://dicomlookup.com/dicomtags/(0018,0081))
+    `Echo Time`
     (please note that the DICOM term is in milliseconds not seconds).
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
@@ -1514,7 +1526,8 @@ FlipAngle:
   display_name: Flip Angle
   description: |
     Flip angle (FA) for the acquisition, specified in degrees.
-    Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
+    Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+    `Flip Angle`.
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
     [file collection](SPEC_ROOT/appendices/file-collections.md)
@@ -1958,7 +1971,8 @@ InjectedRadioactivity:
     Total amount of radioactivity injected into the patient (for example, `400`).
     For bolus-infusion experiments, this value should be the sum of all injected
     radioactivity originating from both bolus and infusion.
-    Corresponds to [DICOM Tag 0018, 1074](https://dicomlookup.com/dicomtags/(0018,1074)) `Radionuclide Total Dose`.
+    Corresponds to [DICOM Tag 0018, 1074](https://dicomlookup.com/dicomtags/(0018,1074))
+    `Radionuclide Total Dose`.
   type: number
 InjectedRadioactivityUnits:
   name: InjectedRadioactivityUnits
@@ -2081,7 +2095,8 @@ InversionTime:
     The inversion time (TI) for the acquisition, specified in seconds.
     Inversion time is the time after the middle of inverting RF pulse to middle
     of excitation pulse to detect the amount of longitudinal magnetization.
-    Corresponds to [DICOM Tag 0018, 0082](https://dicomlookup.com/dicomtags/(0018,0082)) `Inversion Time`
+    Corresponds to [DICOM Tag 0018, 0082](https://dicomlookup.com/dicomtags/(0018,0082))
+    `Inversion Time`
     (please note that the DICOM term is in milliseconds not seconds).
   type: number
   unit: s
@@ -2129,7 +2144,8 @@ LabelingDuration:
     In case an array of numbers is provided,
     its length should be equal to the number of volumes specified in
     `*_aslcontext.tsv`.
-    Corresponds to [DICOM Tag 0018, 9258](https://dicomlookup.com/dicomtags/(0018,9258)) `ASL Pulse Train Duration`.
+    Corresponds to [DICOM Tag 0018, 9258](https://dicomlookup.com/dicomtags/(0018,9258))
+    `ASL Pulse Train Duration`.
   anyOf:
     - type: number
       minimum: 0
@@ -2166,7 +2182,8 @@ LabelingOrientation:
     Orientation of the labeling plane (`(P)CASL`) or slab (`PASL`).
     The direction cosines of a normal vector perpendicular to the ASL labeling
     slab or plane with respect to the patient.
-    Corresponds to [DICOM Tag 0018, 9255](https://dicomlookup.com/dicomtags/(0018,9255)) `ASL Slab Orientation`.
+    Corresponds to [DICOM Tag 0018, 9255](https://dicomlookup.com/dicomtags/(0018,9255))
+    `ASL Slab Orientation`.
   type: array
   items:
     type: number
@@ -2228,7 +2245,8 @@ LabelingSlabThickness:
   description: |
     Thickness of the labeling slab in millimeters.
     For non-selective FAIR a zero is entered.
-    Corresponds to [DICOM Tag 0018, 9254](https://dicomlookup.com/dicomtags/(0018,9254)) `ASL Slab Thickness`.
+    Corresponds to [DICOM Tag 0018, 9254](https://dicomlookup.com/dicomtags/(0018,9254))
+    `ASL Slab Thickness`.
   type: number
   exclusiveMinimum: 0
   unit: mm
@@ -2385,7 +2403,8 @@ MRAcquisitionType:
   display_name: MR Acquisition Type
   description: |
     Type of sequence readout.
-    Corresponds to [DICOM Tag 0018, 0023](https://dicomlookup.com/dicomtags/(0018,0023)) `MR Acquisition Type`.
+    Corresponds to [DICOM Tag 0018, 0023](https://dicomlookup.com/dicomtags/(0018,0023))
+    `MR Acquisition Type`.
   type: string
   enum:
     - $ref: objects.enums.OneD.value
@@ -2396,7 +2415,8 @@ MRTransmitCoilSequence:
   display_name: MR Transmit Coil Sequence
   description: |
     This is a relevant field if a non-standard transmit coil is used.
-    Corresponds to [DICOM Tag 0018, 9049](https://dicomlookup.com/dicomtags/(0018,9049)) `MR Transmit Coil Sequence`.
+    Corresponds to [DICOM Tag 0018, 9049](https://dicomlookup.com/dicomtags/(0018,9049))
+    `MR Transmit Coil Sequence`.
   type: string
 MTNumberOfPulses:
   name: MTNumberOfPulses
@@ -2448,14 +2468,16 @@ MTState:
   display_name: MT State
   description: |
     Boolean stating whether the magnetization transfer pulse is applied.
-    Corresponds to [DICOM Tag 0018, 9020](https://dicomlookup.com/dicomtags/(0018,9020)) `Magnetization Transfer`.
+    Corresponds to [DICOM Tag 0018, 9020](https://dicomlookup.com/dicomtags/(0018,9020))
+    `Magnetization Transfer`.
   type: boolean
 MagneticFieldStrength:
   name: MagneticFieldStrength
   display_name: Magnetic Field Strength
   description: |
     Nominal field strength of MR magnet in Tesla.
-    Corresponds to [DICOM Tag 0018, 0087](https://dicomlookup.com/dicomtags/(0018,0087)) `Magnetic Field Strength`.
+    Corresponds to [DICOM Tag 0018, 0087](https://dicomlookup.com/dicomtags/(0018,0087))
+    `Magnetic Field Strength`.
   type: number
 Magnification:
   name: Magnification
@@ -2926,7 +2948,8 @@ PartialFourierDirection:
   display_name: Partial Fourier Direction
   description: |
     The direction where only partial Fourier information was collected.
-    Corresponds to [DICOM Tag 0018, 9036](https://dicomlookup.com/dicomtags/(0018,9036)) `Partial Fourier Direction`.
+    Corresponds to [DICOM Tag 0018, 9036](https://dicomlookup.com/dicomtags/(0018,9036))
+    `Partial Fourier Direction`.
   type: string
 PharmaceuticalDoseAmount:
   name: PharmaceuticalDoseAmount
@@ -3238,7 +3261,8 @@ ReceiveCoilName:
   display_name: Receive Coil Name
   description: |
     Information describing the receiver coil.
-    Corresponds to [DICOM Tag 0018, 1250](https://dicomlookup.com/dicomtags/(0018,1250)) `Receive Coil Name`,
+    Corresponds to [DICOM Tag 0018, 1250](https://dicomlookup.com/dicomtags/(0018,1250))
+    `Receive Coil Name`,
     although not all vendors populate that DICOM Tag,
     in which case this field can be derived from an appropriate
     private DICOM field.
@@ -3454,7 +3478,8 @@ ResonantNucleus:
     The isotope of interest of an MR experiment (for example, `"1H"`, `"13C"`, `"31P"`).
     For multi-nuclei experiments such as <sup>1</sup>H-[<sup>13</sup>C] MR,
     an array can be used: `["1H", "13C"]`.
-    Corresponds to [DICOM Tag 0018, 9100](https://dicomlookup.com/dicomtags/(0018,9100)) `Resonant Nucleus`.
+    Corresponds to [DICOM Tag 0018, 9100](https://dicomlookup.com/dicomtags/(0018,9100))
+    `Resonant Nucleus`.
   anyOf:
     - type: string
     - type: array
@@ -3663,7 +3688,8 @@ ScanOptions:
   display_name: Scan Options
   description: |
     Parameters of ScanningSequence.
-    Corresponds to [DICOM Tag 0018, 0022](https://dicomlookup.com/dicomtags/(0018,0022)) `Scan Options`.
+    Corresponds to [DICOM Tag 0018, 0022](https://dicomlookup.com/dicomtags/(0018,0022))
+    `Scan Options`.
   anyOf:
     - type: string
     - type: array
@@ -3681,7 +3707,8 @@ ScanningSequence:
   display_name: Scanning Sequence
   description: |
     Description of the type of data acquired.
-    Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020)) `Scanning Sequence`.
+    Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020))
+    `Scanning Sequence`.
   anyOf:
     - type: string
     - type: array
@@ -3794,14 +3821,16 @@ SequenceName:
   display_name: Sequence Name
   description: |
     Manufacturer's designation of the sequence name.
-    Corresponds to [DICOM Tag 0018, 0024](https://dicomlookup.com/dicomtags/(0018,0024)) `Sequence Name`.
+    Corresponds to [DICOM Tag 0018, 0024](https://dicomlookup.com/dicomtags/(0018,0024))
+    `Sequence Name`.
   type: string
 SequenceVariant:
   name: SequenceVariant
   display_name: Sequence Variant
   description: |
     Variant of the ScanningSequence.
-    Corresponds to [DICOM Tag 0018, 0021](https://dicomlookup.com/dicomtags/(0018,0021)) `Sequence Variant`.
+    Corresponds to [DICOM Tag 0018, 0021](https://dicomlookup.com/dicomtags/(0018,0021))
+    `Sequence Variant`.
   anyOf:
     - type: string
     - type: array
@@ -4066,7 +4095,8 @@ SpectralWidth:
   display_name: Spectral Width
   description: |
     The spectral bandwidth of the MR signal that is sampled, specified in Hz.
-    Corresponds to [DICOM Tag 0018, 9052](https://dicomlookup.com/dicomtags/(0018,9052)) `Spectral Width`.
+    Corresponds to [DICOM Tag 0018, 9052](https://dicomlookup.com/dicomtags/(0018,9052))
+    `Spectral Width`.
   type: number
   unit: Hz
 SpectrometerFrequency:
@@ -4401,7 +4431,8 @@ VascularCrushing:
   display_name: Vascular Crushing
   description: |
     Boolean indicating if Vascular Crushing is used.
-    Corresponds to [DICOM Tag 0018, 9259](https://dicomlookup.com/dicomtags/(0018,9259)) `ASL Crusher Flag`.
+    Corresponds to [DICOM Tag 0018, 9259](https://dicomlookup.com/dicomtags/(0018,9259))
+    `ASL Crusher Flag`.
   type: boolean
 VascularCrushingVENC:
   name: VascularCrushingVENC
@@ -4411,7 +4442,8 @@ VascularCrushingVENC:
     Specify either one number for the total time-series, or provide an array of
     numbers, for example when using QUASAR, using the value zero to identify
     volumes for which `VascularCrushing` was turned off.
-    Corresponds to [DICOM Tag 0018, 925A](https://dicomlookup.com/dicomtags/(0018,925A)) `ASL Crusher Flow Limit`.
+    Corresponds to [DICOM Tag 0018, 925A](https://dicomlookup.com/dicomtags/(0018,925A))
+    `ASL Crusher Flow Limit`.
   anyOf:
     - type: number
       unit: cm/s

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -40,7 +40,7 @@ AcquisitionDuration:
   display_name: Acquisition Duration
   description: |
     Duration (in seconds) of scan acquisition, including all volumes for multi-volume scans.
-    Corresponds to [DICOM Tag 0018, 9073](https://dicomlookup.com/dicomtags/(0018,9073))
+    Corresponds to [DICOM Tag 0018, 9073](http://www.dicomlookup.com/dicomtags/(0018,9073))
     `Acquisition Duration`.
   type: number
   exclusiveMinimum: 0
@@ -389,7 +389,7 @@ BolusCutOffDelayTime:
     cut-off saturation pulses.
     For Q2TIPS, only the values for the first and last bolus cut-off saturation
     pulses are provided.
-    Based on [DICOM Tag 0018, 925F](https://dicomlookup.com/dicomtags/(0018,925F))
+    Based on [DICOM Tag 0018, 925F](http://www.dicomlookup.com/dicomtags/(0018,925F))
     `ASL Bolus Cut-off Delay Time`.
   anyOf:
     - type: number
@@ -405,7 +405,7 @@ BolusCutOffFlag:
   display_name: Bolus Cut Off Flag
   description: |
     Boolean indicating if a bolus cut-off technique is used.
-    Corresponds to [DICOM Tag 0018, 925C](https://dicomlookup.com/dicomtags/(0018,925C))
+    Corresponds to [DICOM Tag 0018, 925C](http://www.dicomlookup.com/dicomtags/(0018,925C))
     `ASL Bolus Cut-off Flag`.
   type: boolean
 BolusCutOffTechnique:
@@ -413,7 +413,7 @@ BolusCutOffTechnique:
   display_name: Bolus Cut Off Technique
   description: |
     Name of the technique used, for example `"Q2TIPS"`, `"QUIPSS"`, `"QUIPSSII"`.
-    Corresponds to [DICOM Tag 0018, 925E](https://dicomlookup.com/dicomtags/(0018,925E))
+    Corresponds to [DICOM Tag 0018, 925E](http://www.dicomlookup.com/dicomtags/(0018,925E))
     `ASL Bolus Cut-off Technique`.
   type: string
 BrainLocation:
@@ -512,7 +512,7 @@ ChemicalShiftReference:
   display_name: Chemical Shift Reference
   description: |
     The chemical shift at the transmitter frequency, specified in ppm (for example, `2.68`).
-    Corresponds to [DICOM Tag 0018, 9053](https://dicomlookup.com/dicomtags/(0018,9053))
+    Corresponds to [DICOM Tag 0018, 9053](http://www.dicomlookup.com/dicomtags/(0018,9053))
     `Chemical Shift Reference`.
   type: number
   unit: ppm
@@ -574,7 +574,7 @@ CodeValue:
   description: |
     An identifier that is unambiguous within the Coding Scheme
     denoted by Coding Scheme Designator and Coding Scheme Version.
-    Corresponds to [DICOM Tag 0008, 0100](https://dicomlookup.com/dicomtags/(0008,0100))
+    Corresponds to [DICOM Tag 0008, 0100](http://www.dicomlookup.com/dicomtags/(0008,0100))
     `Code Value`.
   type: string
 CodeMeaning:
@@ -582,7 +582,7 @@ CodeMeaning:
   display_name: Code Meaning
   description: |
     Text that has meaning to a human and conveys the meaning of the term
-    Corresponds to [DICOM Tag 0008, 0104](https://dicomlookup.com/dicomtags/(0008,0104))
+    Corresponds to [DICOM Tag 0008, 0104](http://www.dicomlookup.com/dicomtags/(0008,0104))
     `Code Meaning`.
   type: string
 CodingSchemeDesignator:
@@ -590,7 +590,7 @@ CodingSchemeDesignator:
   display_name: Coding Scheme Designator
   description: |
     The identifier of the coding scheme in which the coded entry is defined.
-    Corresponds to [DICOM Tag 0008, 0102](https://dicomlookup.com/dicomtags/(0008,0102))
+    Corresponds to [DICOM Tag 0008, 0102](http://www.dicomlookup.com/dicomtags/(0008,0102))
     `Coding Scheme Designator`.
   type: string
 CodingSchemeVersion:
@@ -598,7 +598,7 @@ CodingSchemeVersion:
   display_name: Coding Scheme version
   description: |
     An identifier of the version of the coding scheme if necessary to resolve ambiguity.
-    Corresponds to [DICOM Tag 0008, 0103](https://dicomlookup.com/dicomtags/(0008,0103))
+    Corresponds to [DICOM Tag 0008, 0103](http://www.dicomlookup.com/dicomtags/(0008,0103))
     `Coding Scheme Version`.
   type: string
 CodeURL:
@@ -692,7 +692,7 @@ ContrastBolusIngredient:
   display_name: Contrast Bolus Ingredient
   description: |
     Active ingredient of agent.
-    Corresponds to [DICOM Tag 0018, 1048](https://dicomlookup.com/dicomtags/(0018,1048))
+    Corresponds to [DICOM Tag 0018, 1048](http://www.dicomlookup.com/dicomtags/(0018,1048))
     `Contrast/Bolus Ingredient`.
   type: string
   enum:
@@ -795,7 +795,7 @@ DeidentificationMethod:
   display_name: Deidentification Method
   description: |
     A description of the mechanism or method used to remove the Patient's identity.
-    Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063))
+    Corresponds to [DICOM Tag 0012, 0063](http://www.dicomlookup.com/dicomtags/(0012,0063))
     `De-identification Method`.
   type: array
   items:
@@ -805,7 +805,7 @@ DeidentificationMethodCodeSequence:
   display_name: Deidentification Method Code Sequence
   description: |
     A sequence of code objects describing the mechanism or method use to remove the Patient's identity.
-    Corresponds to [DICOM Tag 0012, 0064](https://dicomlookup.com/dicomtags/(0012,0064))
+    Corresponds to [DICOM Tag 0012, 0064](http://www.dicomlookup.com/dicomtags/(0012,0064))
     `De-identification Method Code Sequence`.
   type: array
   items:
@@ -1025,7 +1025,7 @@ DoseCalibrationFactor:
   display_name: Dose Calibration Factor
   description: |
     Multiplication factor used to transform raw data (in counts/sec) to meaningful unit (Bq/ml).
-    Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322))
+    Corresponds to [DICOM Tag 0054, 1322](http://www.dicomlookup.com/dicomtags/(0054,1322))
     `Dose Calibration Factor`.
   type: number
 DwellTime:
@@ -1258,7 +1258,7 @@ EchoTime:
   display_name: Echo Time
   description: |
     The echo time (TE) for the acquisition, specified in seconds.
-    Corresponds to [DICOM Tag 0018, 0081](https://dicomlookup.com/dicomtags/(0018,0081))
+    Corresponds to [DICOM Tag 0018, 0081](http://www.dicomlookup.com/dicomtags/(0018,0081))
     `Echo Time`
     (please note that the DICOM term is in milliseconds not seconds).
     The data type number may apply to files from any MRI modality concerned with
@@ -1526,7 +1526,7 @@ FlipAngle:
   display_name: Flip Angle
   description: |
     Flip angle (FA) for the acquisition, specified in degrees.
-    Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+    Corresponds to: [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
     `Flip Angle`.
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
@@ -1599,7 +1599,7 @@ FrameDuration:
   display_name: Frame Duration
   description: |
     Time duration of each frame in default unit seconds.
-    This corresponds to [DICOM Tag 0018, 1242](https://dicomlookup.com/dicomtags/(0018,1242))
+    This corresponds to [DICOM Tag 0018, 1242](http://www.dicomlookup.com/dicomtags/(0018,1242))
     `Actual Frame Duration` converted to seconds.
   type: array
   items:
@@ -1748,7 +1748,7 @@ HardcopyDeviceSoftwareVersion:
   description: |
     Manufacturer's designation of the software of the device that created this
     Hardcopy Image (the printer).
-    Corresponds to [DICOM Tag 0018, 101A](https://dicomlookup.com/dicomtags/(0018,101A))
+    Corresponds to [DICOM Tag 0018, 101A](http://www.dicomlookup.com/dicomtags/(0018,101A))
     `Hardcopy Device Software Version`.
   type: string
 HardwareFilters:
@@ -1971,7 +1971,7 @@ InjectedRadioactivity:
     Total amount of radioactivity injected into the patient (for example, `400`).
     For bolus-infusion experiments, this value should be the sum of all injected
     radioactivity originating from both bolus and infusion.
-    Corresponds to [DICOM Tag 0018, 1074](https://dicomlookup.com/dicomtags/(0018,1074))
+    Corresponds to [DICOM Tag 0018, 1074](http://www.dicomlookup.com/dicomtags/(0018,1074))
     `Radionuclide Total Dose`.
   type: number
 InjectedRadioactivityUnits:
@@ -2002,7 +2002,7 @@ InjectionStart:
   description: |
     Time of start of injection with respect to `"TimeZero"` in the default unit
     seconds.
-    This corresponds to [DICOM Tag 0018, 1072](https://dicomlookup.com/dicomtags/(0018,1072))
+    This corresponds to [DICOM Tag 0018, 1072](http://www.dicomlookup.com/dicomtags/(0018,1072))
     `Contrast/Bolus Start Time` converted to seconds relative to `"TimeZero"`.
   type: number
   unit: s
@@ -2095,7 +2095,7 @@ InversionTime:
     The inversion time (TI) for the acquisition, specified in seconds.
     Inversion time is the time after the middle of inverting RF pulse to middle
     of excitation pulse to detect the amount of longitudinal magnetization.
-    Corresponds to [DICOM Tag 0018, 0082](https://dicomlookup.com/dicomtags/(0018,0082))
+    Corresponds to [DICOM Tag 0018, 0082](http://www.dicomlookup.com/dicomtags/(0018,0082))
     `Inversion Time`
     (please note that the DICOM term is in milliseconds not seconds).
   type: number
@@ -2144,7 +2144,7 @@ LabelingDuration:
     In case an array of numbers is provided,
     its length should be equal to the number of volumes specified in
     `*_aslcontext.tsv`.
-    Corresponds to [DICOM Tag 0018, 9258](https://dicomlookup.com/dicomtags/(0018,9258))
+    Corresponds to [DICOM Tag 0018, 9258](http://www.dicomlookup.com/dicomtags/(0018,9258))
     `ASL Pulse Train Duration`.
   anyOf:
     - type: number
@@ -2182,7 +2182,7 @@ LabelingOrientation:
     Orientation of the labeling plane (`(P)CASL`) or slab (`PASL`).
     The direction cosines of a normal vector perpendicular to the ASL labeling
     slab or plane with respect to the patient.
-    Corresponds to [DICOM Tag 0018, 9255](https://dicomlookup.com/dicomtags/(0018,9255))
+    Corresponds to [DICOM Tag 0018, 9255](http://www.dicomlookup.com/dicomtags/(0018,9255))
     `ASL Slab Orientation`.
   type: array
   items:
@@ -2245,7 +2245,7 @@ LabelingSlabThickness:
   description: |
     Thickness of the labeling slab in millimeters.
     For non-selective FAIR a zero is entered.
-    Corresponds to [DICOM Tag 0018, 9254](https://dicomlookup.com/dicomtags/(0018,9254))
+    Corresponds to [DICOM Tag 0018, 9254](http://www.dicomlookup.com/dicomtags/(0018,9254))
     `ASL Slab Thickness`.
   type: number
   exclusiveMinimum: 0
@@ -2403,7 +2403,7 @@ MRAcquisitionType:
   display_name: MR Acquisition Type
   description: |
     Type of sequence readout.
-    Corresponds to [DICOM Tag 0018, 0023](https://dicomlookup.com/dicomtags/(0018,0023))
+    Corresponds to [DICOM Tag 0018, 0023](http://www.dicomlookup.com/dicomtags/(0018,0023))
     `MR Acquisition Type`.
   type: string
   enum:
@@ -2415,7 +2415,7 @@ MRTransmitCoilSequence:
   display_name: MR Transmit Coil Sequence
   description: |
     This is a relevant field if a non-standard transmit coil is used.
-    Corresponds to [DICOM Tag 0018, 9049](https://dicomlookup.com/dicomtags/(0018,9049))
+    Corresponds to [DICOM Tag 0018, 9049](http://www.dicomlookup.com/dicomtags/(0018,9049))
     `MR Transmit Coil Sequence`.
   type: string
 MTNumberOfPulses:
@@ -2468,7 +2468,7 @@ MTState:
   display_name: MT State
   description: |
     Boolean stating whether the magnetization transfer pulse is applied.
-    Corresponds to [DICOM Tag 0018, 9020](https://dicomlookup.com/dicomtags/(0018,9020))
+    Corresponds to [DICOM Tag 0018, 9020](http://www.dicomlookup.com/dicomtags/(0018,9020))
     `Magnetization Transfer`.
   type: boolean
 MagneticFieldStrength:
@@ -2476,7 +2476,7 @@ MagneticFieldStrength:
   display_name: Magnetic Field Strength
   description: |
     Nominal field strength of MR magnet in Tesla.
-    Corresponds to [DICOM Tag 0018, 0087](https://dicomlookup.com/dicomtags/(0018,0087))
+    Corresponds to [DICOM Tag 0018, 0087](http://www.dicomlookup.com/dicomtags/(0018,0087))
     `Magnetic Field Strength`.
   type: number
 Magnification:
@@ -2631,7 +2631,7 @@ MolarActivity:
   display_name: Molar Activity
   description: |
     Molar activity of compound injected.
-    Corresponds to [DICOM Tag 0018, 1077](https://dicomlookup.com/dicomtags/(0018,1077))
+    Corresponds to [DICOM Tag 0018, 1077](http://www.dicomlookup.com/dicomtags/(0018,1077))
     `Radiopharmaceutical Specific Activity`.
   type: number
 MolarActivityMeasTime:
@@ -2904,7 +2904,7 @@ ParallelAcquisitionTechnique:
   display_name: Parallel Acquisition Technique
   description: |
     The type of parallel imaging used (for example `"GRAPPA"`, `"SENSE"`).
-    Corresponds to [DICOM Tag 0018, 9078](https://dicomlookup.com/dicomtags/(0018,9078))
+    Corresponds to [DICOM Tag 0018, 9078](http://www.dicomlookup.com/dicomtags/(0018,9078))
     `Parallel Acquisition Technique`.
   type: string
 ParallelReductionFactorInPlane:
@@ -2914,7 +2914,7 @@ ParallelReductionFactorInPlane:
     The parallel imaging (for instance, GRAPPA) factor in plane.
     Use the denominator of the fraction of k-space encoded for each slice.
     For example, 2 means half of k-space is encoded.
-    Corresponds to [DICOM Tag 0018, 9069](https://dicomlookup.com/dicomtags/(0018,9069))
+    Corresponds to [DICOM Tag 0018, 9069](http://www.dicomlookup.com/dicomtags/(0018,9069))
     `Parallel Reduction Factor In-plane`.
   type: number
 ParallelReductionFactorOutOfPlane:
@@ -2927,7 +2927,7 @@ ParallelReductionFactorOutOfPlane:
     Will typically be 1 for 2D sequences, as each slice in a 2D acquisition is usually fully encoded.
     `ParallelReductionFactorOutOfPlane` should not be confused with `MultibandAccelerationFactor`,
     as they imply different methods of accelerating the acquisition.
-    Corresponds to [DICOM Tag 0018, 9155](https://dicomlookup.com/dicomtags/(0018,9155))
+    Corresponds to [DICOM Tag 0018, 9155](http://www.dicomlookup.com/dicomtags/(0018,9155))
     `Parallel Reduction Factor out-of-plane`.
   type: number
 ParentCoordinateSystem:
@@ -2948,7 +2948,7 @@ PartialFourierDirection:
   display_name: Partial Fourier Direction
   description: |
     The direction where only partial Fourier information was collected.
-    Corresponds to [DICOM Tag 0018, 9036](https://dicomlookup.com/dicomtags/(0018,9036))
+    Corresponds to [DICOM Tag 0018, 9036](http://www.dicomlookup.com/dicomtags/(0018,9036))
     `Partial Fourier Direction`.
   type: string
 PharmaceuticalDoseAmount:
@@ -3261,7 +3261,7 @@ ReceiveCoilName:
   display_name: Receive Coil Name
   description: |
     Information describing the receiver coil.
-    Corresponds to [DICOM Tag 0018, 1250](https://dicomlookup.com/dicomtags/(0018,1250))
+    Corresponds to [DICOM Tag 0018, 1250](http://www.dicomlookup.com/dicomtags/(0018,1250))
     `Receive Coil Name`,
     although not all vendors populate that DICOM Tag,
     in which case this field can be derived from an appropriate
@@ -3401,10 +3401,10 @@ RepetitionTime:
     and the beginning of acquisition of the volume following it (TR).
     When used in the context of functional acquisitions this parameter best
     corresponds to
-    [DICOM Tag 0020, 0110](https://dicomlookup.com/dicomtags/(0020,0110)):
+    [DICOM Tag 0020, 0110](http://www.dicomlookup.com/dicomtags/(0020,0110)):
     the "time delta between images in a
     dynamic of functional set of images" but may also be found in
-    [DICOM Tag 0018, 0080](https://dicomlookup.com/dicomtags/(0018,0080)):
+    [DICOM Tag 0018, 0080](http://www.dicomlookup.com/dicomtags/(0018,0080)):
     "the period of time in msec between the beginning
     of a pulse sequence and the beginning of the succeeding
     (essentially identical) pulse sequence".
@@ -3421,7 +3421,7 @@ RepetitionTimeExcitation:
   display_name: Repetition Time Excitation
   description: |
     The interval, in seconds, between two successive excitations.
-    [DICOM Tag 0018, 0080](https://dicomlookup.com/dicomtags/(0018,0080))
+    [DICOM Tag 0018, 0080](http://www.dicomlookup.com/dicomtags/(0018,0080))
     best refers to this parameter.
     This field may be used together with the `"RepetitionTimePreparation"` for
     certain use cases, such as
@@ -3478,7 +3478,7 @@ ResonantNucleus:
     The isotope of interest of an MR experiment (for example, `"1H"`, `"13C"`, `"31P"`).
     For multi-nuclei experiments such as <sup>1</sup>H-[<sup>13</sup>C] MR,
     an array can be used: `["1H", "13C"]`.
-    Corresponds to [DICOM Tag 0018, 9100](https://dicomlookup.com/dicomtags/(0018,9100))
+    Corresponds to [DICOM Tag 0018, 9100](http://www.dicomlookup.com/dicomtags/(0018,9100))
     `Resonant Nucleus`.
   anyOf:
     - type: string
@@ -3688,7 +3688,7 @@ ScanOptions:
   display_name: Scan Options
   description: |
     Parameters of ScanningSequence.
-    Corresponds to [DICOM Tag 0018, 0022](https://dicomlookup.com/dicomtags/(0018,0022))
+    Corresponds to [DICOM Tag 0018, 0022](http://www.dicomlookup.com/dicomtags/(0018,0022))
     `Scan Options`.
   anyOf:
     - type: string
@@ -3707,7 +3707,7 @@ ScanningSequence:
   display_name: Scanning Sequence
   description: |
     Description of the type of data acquired.
-    Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020))
+    Corresponds to [DICOM Tag 0018, 0020](http://www.dicomlookup.com/dicomtags/(0018,0020))
     `Scanning Sequence`.
   anyOf:
     - type: string
@@ -3821,7 +3821,7 @@ SequenceName:
   display_name: Sequence Name
   description: |
     Manufacturer's designation of the sequence name.
-    Corresponds to [DICOM Tag 0018, 0024](https://dicomlookup.com/dicomtags/(0018,0024))
+    Corresponds to [DICOM Tag 0018, 0024](http://www.dicomlookup.com/dicomtags/(0018,0024))
     `Sequence Name`.
   type: string
 SequenceVariant:
@@ -3829,7 +3829,7 @@ SequenceVariant:
   display_name: Sequence Variant
   description: |
     Variant of the ScanningSequence.
-    Corresponds to [DICOM Tag 0018, 0021](https://dicomlookup.com/dicomtags/(0018,0021))
+    Corresponds to [DICOM Tag 0018, 0021](http://www.dicomlookup.com/dicomtags/(0018,0021))
     `Sequence Variant`.
   anyOf:
     - type: string
@@ -4095,7 +4095,7 @@ SpectralWidth:
   display_name: Spectral Width
   description: |
     The spectral bandwidth of the MR signal that is sampled, specified in Hz.
-    Corresponds to [DICOM Tag 0018, 9052](https://dicomlookup.com/dicomtags/(0018,9052))
+    Corresponds to [DICOM Tag 0018, 9052](http://www.dicomlookup.com/dicomtags/(0018,9052))
     `Spectral Width`.
   type: number
   unit: Hz
@@ -4431,7 +4431,7 @@ VascularCrushing:
   display_name: Vascular Crushing
   description: |
     Boolean indicating if Vascular Crushing is used.
-    Corresponds to [DICOM Tag 0018, 9259](https://dicomlookup.com/dicomtags/(0018,9259))
+    Corresponds to [DICOM Tag 0018, 9259](http://www.dicomlookup.com/dicomtags/(0018,9259))
     `ASL Crusher Flag`.
   type: boolean
 VascularCrushingVENC:
@@ -4442,7 +4442,7 @@ VascularCrushingVENC:
     Specify either one number for the total time-series, or provide an array of
     numbers, for example when using QUASAR, using the value zero to identify
     volumes for which `VascularCrushing` was turned off.
-    Corresponds to [DICOM Tag 0018, 925A](https://dicomlookup.com/dicomtags/(0018,925A))
+    Corresponds to [DICOM Tag 0018, 925A](http://www.dicomlookup.com/dicomtags/(0018,925A))
     `ASL Crusher Flow Limit`.
   anyOf:
     - type: number

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -47,7 +47,7 @@ ASLFlipAngleNiftiLength:
     message: |
       The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+      Corresponds to: [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
       `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
@@ -71,7 +71,7 @@ ASLFlipAngleASLContextLength:
       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
       associated 'aslcontext.tsv'.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+      Corresponds to: [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
       `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -47,7 +47,8 @@ ASLFlipAngleNiftiLength:
     message: |
       The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
+      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+      `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
       The data type array provides a value for each volume in a 4D dataset and should only be used when the
@@ -70,7 +71,8 @@ ASLFlipAngleASLContextLength:
       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
       associated 'aslcontext.tsv'.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
+      Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+      `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
       The data type array provides a value for each volume in a 4D dataset and should only be used when the volume

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -14,27 +14,27 @@ MRIHardware:
     Manufacturer:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070))
+        Corresponds to [DICOM Tag 0008, 0070](http://www.dicomlookup.com/dicomtags/(0008,0070))
         `Manufacturer`.
     ManufacturersModelName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090))
+        Corresponds to [DICOM Tag 0008, 1090](http://www.dicomlookup.com/dicomtags/(0008,1090))
         `Manufacturers Model Name`.
     DeviceSerialNumber:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1000](https://dicomlookup.com/dicomtags/(0018,1000))
+        Corresponds to [DICOM Tag 0018, 1000](http://www.dicomlookup.com/dicomtags/(0018,1000))
         `DeviceSerialNumber`.
     StationName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1010](https://dicomlookup.com/dicomtags/(0008,1010))
+        Corresponds to [DICOM Tag 0008, 1010](http://www.dicomlookup.com/dicomtags/(0008,1010))
         `Station Name`.
     SoftwareVersions:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1020](https://dicomlookup.com/dicomtags/(0018,1020))
+        Corresponds to [DICOM Tag 0018, 1020](http://www.dicomlookup.com/dicomtags/(0018,1020))
         `Software Versions`.
     HardcopyDeviceSoftwareVersion: deprecated
     MagneticFieldStrength:
@@ -73,7 +73,7 @@ MRISample:
     BodyPart:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag 0018, 0015](http://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
@@ -100,7 +100,7 @@ MRISequenceSpecifics:
     ScanningSequence:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020))
+        Corresponds to [DICOM Tag 0018, 0020](http://www.dicomlookup.com/dicomtags/(0018,0020))
         `Scanning Sequence`.
     SequenceVariant: recommended
     ScanOptions: optional
@@ -363,7 +363,7 @@ MRIFlipAngleLookLockerTrue:
           You should define 'FlipAngle' for this file, in
           case of a LookLocker acquisition. 'FlipAngle' is the
           flip angle (FA) for the acquisition, specified in degrees.
-          Corresponds to [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+          Corresponds to [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
           `Flip Angle`.
           The data type number may apply to files from any MRI modality
           concerned with a single value for this field,
@@ -414,17 +414,17 @@ MRIInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080))
+        Corresponds to [DICOM Tag 0008, 0080](http://www.dicomlookup.com/dicomtags/(0008,0080))
         `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081))
+        Corresponds to [DICOM Tag 0008, 0081](http://www.dicomlookup.com/dicomtags/(0008,0081))
         `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1040](https://dicomlookup.com/dicomtags/(0008,1040))
+        Corresponds to [DICOM Tag 0008, 1040](http://www.dicomlookup.com/dicomtags/(0008,1040))
         `Institutional Department Name`.
 
 DeidentificationMethod:
@@ -435,10 +435,10 @@ DeidentificationMethod:
     DeidentificationMethod:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063))
+        Corresponds to [DICOM Tag 0012, 0063](http://www.dicomlookup.com/dicomtags/(0012,0063))
         `De-identification Method`.
     DeidentificationMethodCodeSequence:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0012, 0064](https://dicomlookup.com/dicomtags/(0012,0064))
+        Corresponds to [DICOM Tag 0012, 0064](http://www.dicomlookup.com/dicomtags/(0012,0064))
         `De-identification Method Code Sequence`.

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -356,14 +356,14 @@ MRIFlipAngleLookLockerTrue:
           You should define 'FlipAngle' for this file, in
           case of a LookLocker acquisition. 'FlipAngle' is the
           flip angle (FA) for the acquisition, specified in degrees.
-          Corresponds to: [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`. The data
-          type number may apply to files from any MRI modality concerned
-          with a single value for this field, or to the files in a file
-          collection where the value of this field is iterated using the
-          flip entity. The data type array provides a value for each volume
-          in a 4D dataset and should only be used when the volume timing is
-          critical for interpretation of the data, such as in ASL or
-          variable flip angle fMRI sequences.
+          Corresponds to [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
+          The data type number may apply to files from any MRI modality
+          concerned with a single value for this field,
+          or to the files in a file collection where the value of this field
+          is iterated using the flip entity.
+          The data type array provides a value for each volume in a 4D dataset and
+          should only be used when the volume timing is critical for interpretation of the data,
+          such as in ASL or variable flip angle fMRI sequences.
 
 MRISliceAcceleration:
   selectors:

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -14,23 +14,28 @@ MRIHardware:
     Manufacturer:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070)) `Manufacturer`.
+        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070))
+        `Manufacturer`.
     ManufacturersModelName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090)) `Manufacturers Model Name`.
+        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090))
+        `Manufacturers Model Name`.
     DeviceSerialNumber:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1000](https://dicomlookup.com/dicomtags/(0018,1000)) `DeviceSerialNumber`.
+        Corresponds to [DICOM Tag 0018, 1000](https://dicomlookup.com/dicomtags/(0018,1000))
+        `DeviceSerialNumber`.
     StationName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1010](https://dicomlookup.com/dicomtags/(0008,1010)) `Station Name`.
+        Corresponds to [DICOM Tag 0008, 1010](https://dicomlookup.com/dicomtags/(0008,1010))
+        `Station Name`.
     SoftwareVersions:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1020](https://dicomlookup.com/dicomtags/(0018,1020)) `Software Versions`.
+        Corresponds to [DICOM Tag 0018, 1020](https://dicomlookup.com/dicomtags/(0018,1020))
+        `Software Versions`.
     HardcopyDeviceSoftwareVersion: deprecated
     MagneticFieldStrength:
       level: recommended
@@ -68,7 +73,8 @@ MRISample:
     BodyPart:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
 
@@ -94,7 +100,8 @@ MRISequenceSpecifics:
     ScanningSequence:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020)) `Scanning Sequence`.
+        Corresponds to [DICOM Tag 0018, 0020](https://dicomlookup.com/dicomtags/(0018,0020))
+        `Scanning Sequence`.
     SequenceVariant: recommended
     ScanOptions: optional
     SequenceName: recommended
@@ -356,7 +363,8 @@ MRIFlipAngleLookLockerTrue:
           You should define 'FlipAngle' for this file, in
           case of a LookLocker acquisition. 'FlipAngle' is the
           flip angle (FA) for the acquisition, specified in degrees.
-          Corresponds to [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314)) `Flip Angle`.
+          Corresponds to [DICOM Tag 0018, 1314](https://dicomlookup.com/dicomtags/(0018,1314))
+          `Flip Angle`.
           The data type number may apply to files from any MRI modality
           concerned with a single value for this field,
           or to the files in a file collection where the value of this field
@@ -406,11 +414,13 @@ MRIInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080)) `InstitutionName`.
+        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080))
+        `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081)) `InstitutionAddress`.
+        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081))
+        `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
@@ -425,7 +435,8 @@ DeidentificationMethod:
     DeidentificationMethod:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063)) `De-identification Method`.
+        Corresponds to [DICOM Tag 0012, 0063](https://dicomlookup.com/dicomtags/(0012,0063))
+        `De-identification Method`.
     DeidentificationMethodCodeSequence:
       level: optional
       description_addendum: |

--- a/src/schema/rules/sidecars/mrs.yaml
+++ b/src/schema/rules/sidecars/mrs.yaml
@@ -40,7 +40,8 @@ MRSSample:
       level: optional
       level_addendum: required if `voi` entity is present
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        `Body Part Examined`.
     BodyPartDetails:
       level: optional
       level_addendum: required if `voi` entity is present

--- a/src/schema/rules/sidecars/mrs.yaml
+++ b/src/schema/rules/sidecars/mrs.yaml
@@ -40,7 +40,7 @@ MRSSample:
       level: optional
       level_addendum: required if `voi` entity is present
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag 0018, 0015](http://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
     BodyPartDetails:
       level: optional

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -8,20 +8,24 @@ PETHardware:
     Manufacturer:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070)) `Manufacturer`.
+        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070))
+        `Manufacturer`.
     ManufacturersModelName:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090)) `Manufacturers Model Name`.
+        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090))
+        `Manufacturers Model Name`.
     Units:
       level: required
       description_addendum: |
         SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL").
-        Corresponds to [DICOM Tag 0054, 1001](https://dicomlookup.com/dicomtags/(0054,1001)) `Units`.
+        Corresponds to [DICOM Tag 0054, 1001](https://dicomlookup.com/dicomtags/(0054,1001))
+        `Units`.
     BodyPart:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        `Body Part Examined`.
 
 PETInstitutionInformation:
   selectors:
@@ -31,11 +35,13 @@ PETInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080)) `InstitutionName`.
+        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080))
+        `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081)) `InstitutionAddress`.
+        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081))
+        `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
@@ -50,7 +56,8 @@ PETSample:
     BodyPart:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
+        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
 
@@ -124,12 +131,14 @@ PETPharmaceuticals:
       level: recommended
       description_addendum: |
         For pharmaceutical co-administered with tracer.
-        Corresponds to [DICOM Tag 0018, 0034](https://dicomlookup.com/dicomtags/(0018,0034)) `Intervention Drug Name`.
+        Corresponds to [DICOM Tag 0018, 0034](https://dicomlookup.com/dicomtags/(0018,0034))
+        `Intervention Drug Name`.
     PharmaceuticalDoseAmount:
       level: recommended
       description_addendum: |
         For pharmaceutical co-administered with tracer.
-        Corresponds to [DICOM Tag 0018, 0028](https://dicomlookup.com/dicomtags/(0018,0028)) `Intervention Drug Dose`.
+        Corresponds to [DICOM Tag 0018, 0028](https://dicomlookup.com/dicomtags/(0018,0028))
+        `Intervention Drug Dose`.
     PharmaceuticalDoseUnits: recommended
     PharmaceuticalDoseRegimen: recommended
     PharmaceuticalDoseTime:
@@ -162,7 +171,8 @@ PETTime:
     ScanDate:
       level: deprecated
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0022](https://dicomlookup.com/dicomtags/(0008,0022)) `Acquisition Date`.
+        Corresponds to [DICOM Tag 0008, 0022](https://dicomlookup.com/dicomtags/(0008,0022))
+        `Acquisition Date`.
 
 PETReconstruction:
   selectors:
@@ -216,15 +226,18 @@ PETReconstruction:
     ScatterFraction:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0054, 1323](https://dicomlookup.com/dicomtags/(0054,1323)) `Scatter Fraction Factor`.
+        Corresponds to [DICOM Tag 0054, 1323](https://dicomlookup.com/dicomtags/(0054,1323))
+        `Scatter Fraction Factor`.
     DecayCorrectionFactor:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0054, 1321](https://dicomlookup.com/dicomtags/(0054,1321)) `Decay Factor`.
+        Corresponds to [DICOM Tag 0054, 1321](https://dicomlookup.com/dicomtags/(0054,1321))
+        `Decay Factor`.
     DoseCalibrationFactor:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322)) `Dose Calibration Factor`.
+        Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322))
+        `Dose Calibration Factor`.
     PromptRate: recommended
     SinglesRate: recommended
     RandomRate: recommended

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -8,23 +8,23 @@ PETHardware:
     Manufacturer:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0070](https://dicomlookup.com/dicomtags/(0008,0070))
+        Corresponds to [DICOM Tag 0008, 0070](http://www.dicomlookup.com/dicomtags/(0008,0070))
         `Manufacturer`.
     ManufacturersModelName:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1090](https://dicomlookup.com/dicomtags/(0008,1090))
+        Corresponds to [DICOM Tag 0008, 1090](http://www.dicomlookup.com/dicomtags/(0008,1090))
         `Manufacturers Model Name`.
     Units:
       level: required
       description_addendum: |
         SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL").
-        Corresponds to [DICOM Tag 0054, 1001](https://dicomlookup.com/dicomtags/(0054,1001))
+        Corresponds to [DICOM Tag 0054, 1001](http://www.dicomlookup.com/dicomtags/(0054,1001))
         `Units`.
     BodyPart:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag 0018, 0015](http://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
 
 PETInstitutionInformation:
@@ -35,17 +35,17 @@ PETInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0080](https://dicomlookup.com/dicomtags/(0008,0080))
+        Corresponds to [DICOM Tag 0008, 0080](http://www.dicomlookup.com/dicomtags/(0008,0080))
         `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0081](https://dicomlookup.com/dicomtags/(0008,0081))
+        Corresponds to [DICOM Tag 0008, 0081](http://www.dicomlookup.com/dicomtags/(0008,0081))
         `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1040](https://dicomlookup.com/dicomtags/(0008,1040))
+        Corresponds to [DICOM Tag 0008, 1040](http://www.dicomlookup.com/dicomtags/(0008,1040))
         `Institutional Department Name`.
 
 PETSample:
@@ -56,7 +56,7 @@ PETSample:
     BodyPart:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](https://dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag 0018, 0015](http://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
@@ -131,13 +131,13 @@ PETPharmaceuticals:
       level: recommended
       description_addendum: |
         For pharmaceutical co-administered with tracer.
-        Corresponds to [DICOM Tag 0018, 0034](https://dicomlookup.com/dicomtags/(0018,0034))
+        Corresponds to [DICOM Tag 0018, 0034](http://www.dicomlookup.com/dicomtags/(0018,0034))
         `Intervention Drug Name`.
     PharmaceuticalDoseAmount:
       level: recommended
       description_addendum: |
         For pharmaceutical co-administered with tracer.
-        Corresponds to [DICOM Tag 0018, 0028](https://dicomlookup.com/dicomtags/(0018,0028))
+        Corresponds to [DICOM Tag 0018, 0028](http://www.dicomlookup.com/dicomtags/(0018,0028))
         `Intervention Drug Dose`.
     PharmaceuticalDoseUnits: recommended
     PharmaceuticalDoseRegimen: recommended
@@ -145,8 +145,8 @@ PETPharmaceuticals:
       level: recommended
       description_addendum: |
         Corresponds to a combination of DICOM Tags
-        [0018, 0027](https://dicomlookup.com/dicomtags/(0018,0027)) `Intervention Drug Stop Time` and
-        [0018, 0035](https://dicomlookup.com/dicomtags/(0018,0035)) `Intervention Drug Start Time`.
+        [0018, 0027](http://www.dicomlookup.com/dicomtags/(0018,0027)) `Intervention Drug Stop Time` and
+        [0018, 0035](http://www.dicomlookup.com/dicomtags/(0018,0035)) `Intervention Drug Start Time`.
     Anaesthesia: optional
 
 PETTime:
@@ -159,19 +159,19 @@ PETTime:
     InjectionStart:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1072](https://dicomlookup.com/dicomtags/(0018,1072))
+        Corresponds to [DICOM Tag 0018, 1072](http://www.dicomlookup.com/dicomtags/(0018,1072))
         `Radiopharmaceutical Start Time`.
     FrameTimesStart: required
     FrameDuration: required
     InjectionEnd:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1073](https://dicomlookup.com/dicomtags/(0018,1073))
+        Corresponds to [DICOM Tag 0018, 1073](http://www.dicomlookup.com/dicomtags/(0018,1073))
         `Radiopharmaceutical Stop Time` converted to seconds relative to TimeZero.
     ScanDate:
       level: deprecated
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0022](https://dicomlookup.com/dicomtags/(0008,0022))
+        Corresponds to [DICOM Tag 0008, 0022](http://www.dicomlookup.com/dicomtags/(0008,0022))
         `Acquisition Date`.
 
 PETReconstruction:
@@ -185,40 +185,40 @@ PETReconstruction:
     ReconMethodName:
       level: required
       description_addendum: |
-        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
         `Reconstruction Method`.
     ReconMethodParameterLabels:
       level: required
       description_addendum: |
-        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
         `Reconstruction Method`.
     ReconMethodParameterUnits:
       level: recommended
       level_addendum: required if `ReconMethodParameterLabels` does not contain `"none"`
       description_addendum: |
-        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
         `Reconstruction Method`.
     ReconMethodParameterValues:
       level: recommended
       level_addendum: required if `ReconMethodParameterLabels` does not contain `"none"`
       description_addendum: |
-        This partly matches the [DICOM Tag 0054, 1103](https://dicomlookup.com/dicomtags/(0054,1103))
+        This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
         `Reconstruction Method`.
     ReconFilterType:
       level: required
       description_addendum: |
-        This partly matches the [DICOM Tag 0018, 1210](https://dicomlookup.com/dicomtags/(0018,1210))
+        This partly matches the [DICOM Tag 0018, 1210](http://www.dicomlookup.com/dicomtags/(0018,1210))
         `Convolution Kernel`.
     ReconFilterSize:
       level: recommended
       level_addendum: required if `ReconFilterType` is not `"none"`
       description_addendum: |
-        This partly matches the [DICOM Tag 0018, 1210](https://dicomlookup.com/dicomtags/(0018,1210))
+        This partly matches the [DICOM Tag 0018, 1210](http://www.dicomlookup.com/dicomtags/(0018,1210))
         `Convolution Kernel`.
     AttenuationCorrection:
       level: required
       description_addendum: |
-        This corresponds to [DICOM Tag 0054, 1101](https://dicomlookup.com/dicomtags/(0054,1101))
+        This corresponds to [DICOM Tag 0054, 1101](http://www.dicomlookup.com/dicomtags/(0054,1101))
         `Attenuation Correction Method`.
     ReconMethodImplementationVersion: recommended
     AttenuationCorrectionMethodReference: recommended
@@ -226,17 +226,17 @@ PETReconstruction:
     ScatterFraction:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0054, 1323](https://dicomlookup.com/dicomtags/(0054,1323))
+        Corresponds to [DICOM Tag 0054, 1323](http://www.dicomlookup.com/dicomtags/(0054,1323))
         `Scatter Fraction Factor`.
     DecayCorrectionFactor:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0054, 1321](https://dicomlookup.com/dicomtags/(0054,1321))
+        Corresponds to [DICOM Tag 0054, 1321](http://www.dicomlookup.com/dicomtags/(0054,1321))
         `Decay Factor`.
     DoseCalibrationFactor:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0054, 1322](https://dicomlookup.com/dicomtags/(0054,1322))
+        Corresponds to [DICOM Tag 0054, 1322](http://www.dicomlookup.com/dicomtags/(0054,1322))
         `Dose Calibration Factor`.
     PromptRate: recommended
     SinglesRate: recommended


### PR DESCRIPTION
http://www.dicomlookup.com is back up. It no longer accepts HTTPS connections or dropping the `www`.

Based on http://www.dicomlookup.com/about:

> This site is a hobby project. Your support to cover hosting costs is greatly appreciated.

I think it's not ideal to slam their server thousands of times a day, so I'm still excluding them from the link checker.