### PR TITLE
[FIX] Add emg to timeseries rule for physio/stim files

### DIFF
--- a/src/modality-specific-files/electromyography.md
+++ b/src/modality-specific-files/electromyography.md
@@ -13,10 +13,17 @@ this extension when referring to it in the context of the academic literature.
 
 ## EMG data
 
+<!--
+This block generates a filename templates.
+The inputs for this macro can be found in the directory
+  src/schema/rules/files/raw
+and a guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
 {{ MACROS___make_filename_template(
-"raw",
-datatypes=["emg"],
-suffixes=["emg", "events"])
+   "raw",
+   datatypes=["emg"],
+   suffixes=["emg", "events", "physio", "stim"])
 }}
 
 EMG device manufacturers use a variety of formats for storing raw data, and there is

--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -10,6 +10,7 @@ timeseries:
   datatypes:
     - beh
     - eeg
+    - emg
     - ieeg
     - nirs
   entities:


### PR DESCRIPTION
## Summary
- Add `emg` to the base `timeseries` rule datatypes in `src/schema/rules/files/raw/task.yaml`
- This allows `_physio`, `_physioevents`, and `_stim` suffixes to be valid within `emg/` directories
- EMG was the only datatype missing from the timeseries rule, despite being a first-class BIDS datatype since v1.11.0 (BEP 042)

## Context
When converting the [HySER dataset](https://physionet.org/content/hd-semg/1.0.0/) to BIDS-EMG format, finger force sensor recordings (`_physio.tsv.gz`) placed alongside EMG data cause `ALL_FILENAME_RULES_HAVE_ISSUES` validation errors because the validator schema does not include `emg` in the timeseries rule.

All other electrophysiology datatypes (`eeg`, `ieeg`, `nirs`) as well as `beh`, `func`, `meg`, `motion`, `pet`, `anat`, `dwi`, and `perf` already support physio/stim files.

## Test plan
- [x] Verify `emg` is a defined datatype in `src/schema/objects/datatypes.yaml`
- [x] Run schema tests
- [x] Validate a BIDS-EMG dataset with `_physio.tsv.gz` files passes after this change