### PR TITLE
[ENH][SCHEMA] Use Universal Path Library for Schema Retrieval

### DIFF
--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["pdm-backend", "acres", "pyyaml"]
+requires = ["pdm-backend", "acres", "pyyaml", "universal-pathlib", "requests", "aiohttp"]
 build-backend = "pdm.backend"
 
 [project]
@@ -16,7 +16,7 @@ dependencies = [
   "acres",
   "click",
   "pyyaml",
-  "universal_pathlib",
+  "universal-pathlib",
   "requests",
   'aiohttp',
 ]

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -3,9 +3,6 @@ requires = [
   "pdm-backend",
   "acres",
   "pyyaml",
-  "universal-pathlib",
-  "requests",
-  "aiohttp",
 ]
 build-backend = "pdm.backend"
 
@@ -23,9 +20,6 @@ dependencies = [
   "acres",
   "click",
   "pyyaml",
-  "universal-pathlib",
-  "requests",
-  'aiohttp',
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -62,6 +56,7 @@ tests = [
   "coverage[toml]",
   "pytest>6",
   "pytest-cov",
+  "requests",
 ]
 all = [
   "bidsschematools[tests]",

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -1,5 +1,12 @@
 [build-system]
-requires = ["pdm-backend", "acres", "pyyaml", "universal-pathlib", "requests", "aiohttp"]
+requires = [
+  "pdm-backend",
+  "acres",
+  "pyyaml",
+  "universal-pathlib",
+  "requests",
+  "aiohttp",
+]
 build-backend = "pdm.backend"
 
 [project]

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
   "acres",
   "click",
   "pyyaml",
+  "universal_pathlib",
+  "requests",
+  'aiohttp',
 ]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -252,7 +252,7 @@ def load_schema(
     elif schema_path is None and bids_version:
         if re.search(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$", bids_version):
             schema_url = "https://bids-specification.readthedocs.io/en/v{}/schema.json".format(bids_version)
-            
+
         elif bids_version in ("stable", "latest"):
             schema_url = "https://bids-specification.readthedocs.io/en/{}/schema.json".format(bids_version)
         else:
@@ -272,7 +272,7 @@ def load_schema(
                 schema_path = Path(tmp) / "schema.json"
                 with open(schema_path, 'w') as f:
                     json.dump(response.json(), f)
-        
+
                 return Namespace.from_json(schema_path.read_text())
 
     # JSON file: just load it

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -8,8 +8,10 @@ from collections import ChainMap
 from collections.abc import Iterable, Mapping, MutableMapping
 from copy import deepcopy
 from functools import cache, lru_cache
-from sys import version
-from upath import UPath as Path
+from pathlib import Path
+import subprocess
+import urllib3
+from tempfile import TemporaryDirectory
 
 from . import _lazytypes as lt
 from . import data, utils
@@ -249,19 +251,29 @@ def load_schema(
         schema_path = Path(schema_path)
     elif schema_path is None and bids_version:
         if re.search(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$", bids_version):
-            schema_path = Path(
-                "https://bids-specification.readthedocs.io/en/v{}/schema.json".format(bids_version)
-            )
+            schema_url = "https://bids-specification.readthedocs.io/en/v{}/schema.json".format(bids_version)
+            
         elif bids_version in ("stable", "latest"):
-            schema_path = Path(
-                "https://bids-specification.readthedocs.io/en/{}/schema.json".format(bids_version)
-            )
+            schema_url = "https://bids-specification.readthedocs.io/en/{}/schema.json".format(bids_version)
         else:
             raise Exception(
                 NameError(
                     f"BIDS version is limited to `stable`, `latest`, or semantic format `X.X.X`, you gave {bids_version}"
                 )
             )
+        http = urllib3.PoolManager()
+        response = http.request("GET", schema_url)
+        if response.status != 200:
+            raise urllib3.exceptions.HTTPError(
+                f"Unable to retrieve schema from {schema_url} (status {response.status})"
+            )
+        else:
+            with TemporaryDirectory() as tmp:
+                schema_path = Path(tmp) / "schema.json"
+                with open(schema_path, 'w') as f:
+                    json.dump(response.json(), f)
+        
+                return Namespace.from_json(schema_path.read_text())
 
     # JSON file: just load it
     if schema_path.is_file():

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -8,7 +8,8 @@ from collections import ChainMap
 from collections.abc import Iterable, Mapping, MutableMapping
 from copy import deepcopy
 from functools import cache, lru_cache
-from pathlib import Path
+from sys import version
+from upath import UPath as Path
 
 from . import _lazytypes as lt
 from . import data, utils
@@ -204,7 +205,7 @@ def flatten_enums(namespace: Namespace, inplace=True) -> Namespace:
 
 
 @lru_cache
-def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
+def load_schema(schema_path: lt.Traversable | str | None = None, bids_version:str = None) -> Namespace:
     """Load the schema into a dict-like structure.
 
     This function allows the schema, like BIDS itself, to be specified in
@@ -218,6 +219,9 @@ def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
     schema_path : str, optional
         Directory containing yaml files or yaml file. If ``None``, use the
         default schema packaged with ``bidsschematools``.
+    bids_version: str, optional
+        Version of bids release to load schema from, allows user to have full namespace/dict
+        like access to bids schema given a specific version
 
     Returns
     -------
@@ -228,7 +232,7 @@ def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
     -----
     This function is cached, so it will only be called once per schema path.
     """
-    if schema_path is None:
+    if schema_path is None and bids_version is None:
         # Default to bundled JSON, fall back to bundled YAML directory
         schema_path = data.load.readable("schema.json")
         if not schema_path.is_file():
@@ -239,8 +243,15 @@ def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
                 assert isinstance(schema_path, Path)
                 schema_path = Path.resolve(schema_path.parent / content)
         lgr.info("No schema path specified, defaulting to the bundled schema, `%s`.", schema_path)
-    elif isinstance(schema_path, str):
+    elif isinstance(schema_path, str) and bids_version is None:
         schema_path = Path(schema_path)
+    elif schema_path is None and bids_version:
+        if re.search(r'^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$', bids_version):
+            schema_path = Path("https://bids-specification.readthedocs.io/en/v{}/schema.json".format(bids_version))
+        elif bids_version in ('stable', 'latest'):
+            schema_path = Path("https://bids-specification.readthedocs.io/en/{}/schema.json".format(bids_version))
+        else:
+            raise Exception(NameError(f"BIDS version is limited to `stable`, `latest`, or semantic format `X.X.X`, you gave {bids_version}"))
 
     # JSON file: just load it
     if schema_path.is_file():

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -205,7 +205,9 @@ def flatten_enums(namespace: Namespace, inplace=True) -> Namespace:
 
 
 @lru_cache
-def load_schema(schema_path: lt.Traversable | str | None = None, bids_version:str = None) -> Namespace:
+def load_schema(
+    schema_path: lt.Traversable | str | None = None, bids_version: str = None
+) -> Namespace:
     """Load the schema into a dict-like structure.
 
     This function allows the schema, like BIDS itself, to be specified in
@@ -246,12 +248,20 @@ def load_schema(schema_path: lt.Traversable | str | None = None, bids_version:st
     elif isinstance(schema_path, str) and bids_version is None:
         schema_path = Path(schema_path)
     elif schema_path is None and bids_version:
-        if re.search(r'^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$', bids_version):
-            schema_path = Path("https://bids-specification.readthedocs.io/en/v{}/schema.json".format(bids_version))
-        elif bids_version in ('stable', 'latest'):
-            schema_path = Path("https://bids-specification.readthedocs.io/en/{}/schema.json".format(bids_version))
+        if re.search(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$", bids_version):
+            schema_path = Path(
+                "https://bids-specification.readthedocs.io/en/v{}/schema.json".format(bids_version)
+            )
+        elif bids_version in ("stable", "latest"):
+            schema_path = Path(
+                "https://bids-specification.readthedocs.io/en/{}/schema.json".format(bids_version)
+            )
         else:
-            raise Exception(NameError(f"BIDS version is limited to `stable`, `latest`, or semantic format `X.X.X`, you gave {bids_version}"))
+            raise Exception(
+                NameError(
+                    f"BIDS version is limited to `stable`, `latest`, or semantic format `X.X.X`, you gave {bids_version}"
+                )
+            )
 
     # JSON file: just load it
     if schema_path.is_file():

--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -54,11 +54,6 @@ def test_load_schema(schema_dir):
     reason="Unable to reach 'https://bids-specification.readthedocs.io, skipping url retrieval",
 )
 def test_load_schema_from_url():
-    # load from latest release at bids.neuroimaging.io
-    url = "https://bids-specification.readthedocs.io/en/latest/schema.json"
-    schema_obj = schema.load_schema(url)
-    assert isinstance(schema_obj, Mapping)
-
     # load using latest and stable keywords
     assert isinstance(schema.load_schema(bids_version="latest"), Mapping)
     assert isinstance(schema.load_schema(bids_version="stable"), Mapping)
@@ -67,9 +62,9 @@ def test_load_schema_from_url():
     assert isinstance(schema.load_schema(bids_version="1.11.1"), Mapping)
 
     # load with bogus url
-    bad_url = "https://bids-specification.readthedocs.io/en/not-a-real-version/schema.json"
-    with pytest.raises(Exception):
-        schema.load_schema(bad_url)
+    #bad_url = "https://bids-specification.readthedocs.io/en/not-a-real-version/schema.json"
+    #with pytest.raises(Exception):
+    #    schema.load_schema(bad_url)
 
 
 def test_object_definitions(schema_obj):

--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -48,22 +48,26 @@ def test_load_schema(schema_dir):
     # Check that it is fully dereferenced
     assert "$ref" not in str(schema_obj)
 
-@pytest.mark.skipif(requests.get('https://bids-specification.readthedocs.io/').status_code != 200, reason="Unable to reach 'https://bids-specification.readthedocs.io, skipping url retrieval")
+
+@pytest.mark.skipif(
+    requests.get("https://bids-specification.readthedocs.io/").status_code != 200,
+    reason="Unable to reach 'https://bids-specification.readthedocs.io, skipping url retrieval",
+)
 def test_load_schema_from_url():
     # load from latest release at bids.neuroimaging.io
-    url = 'https://bids-specification.readthedocs.io/en/latest/schema.json'
+    url = "https://bids-specification.readthedocs.io/en/latest/schema.json"
     schema_obj = schema.load_schema(url)
     assert isinstance(schema_obj, Mapping)
 
     # load using latest and stable keywords
-    assert isinstance(schema.load_schema(bids_version='latest'), Mapping)
-    assert isinstance(schema.load_schema(bids_version='stable'), Mapping)
+    assert isinstance(schema.load_schema(bids_version="latest"), Mapping)
+    assert isinstance(schema.load_schema(bids_version="stable"), Mapping)
 
     # load with known version
-    assert isinstance(schema.load_schema(bids_version='1.11.1'), Mapping)
+    assert isinstance(schema.load_schema(bids_version="1.11.1"), Mapping)
 
     # load with bogus url
-    bad_url = 'https://bids-specification.readthedocs.io/en/not-a-real-version/schema.json'
+    bad_url = "https://bids-specification.readthedocs.io/en/not-a-real-version/schema.json"
     with pytest.raises(Exception):
         schema.load_schema(bad_url)
 

--- a/tools/schemacode/src/bidsschematools/tests/test_schema.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_schema.py
@@ -3,7 +3,9 @@
 import json
 import os
 import subprocess
+import requests
 from collections.abc import Mapping
+
 
 import pytest
 from jsonschema.exceptions import ValidationError
@@ -45,6 +47,25 @@ def test_load_schema(schema_dir):
 
     # Check that it is fully dereferenced
     assert "$ref" not in str(schema_obj)
+
+@pytest.mark.skipif(requests.get('https://bids-specification.readthedocs.io/').status_code != 200, reason="Unable to reach 'https://bids-specification.readthedocs.io, skipping url retrieval")
+def test_load_schema_from_url():
+    # load from latest release at bids.neuroimaging.io
+    url = 'https://bids-specification.readthedocs.io/en/latest/schema.json'
+    schema_obj = schema.load_schema(url)
+    assert isinstance(schema_obj, Mapping)
+
+    # load using latest and stable keywords
+    assert isinstance(schema.load_schema(bids_version='latest'), Mapping)
+    assert isinstance(schema.load_schema(bids_version='stable'), Mapping)
+
+    # load with known version
+    assert isinstance(schema.load_schema(bids_version='1.11.1'), Mapping)
+
+    # load with bogus url
+    bad_url = 'https://bids-specification.readthedocs.io/en/not-a-real-version/schema.json'
+    with pytest.raises(Exception):
+        schema.load_schema(bad_url)
 
 
 def test_object_definitions(schema_obj):


### PR DESCRIPTION
I had initially added this to a PR for pybids but it seems more appropriate here. I think this also plays a bit into the discussion at issue #965 in so far as python users are concerned.

Conversely, a user could make a request first to `https://bids-specification.readthedocs.io/en/stable/schema.json` then use `schema.load_schema` following that retrieval. 

I don't know, maybe this is a solution in search of a problem and/or should be fleshed out to retrieve specific versions of the schema from bids-standard/bids-schema. 