### PR TITLE
[ENH] Link to example datasets page on the website

### DIFF
--- a/src/appendices/qmri.md
+++ b/src/appendices/qmri.md
@@ -213,7 +213,7 @@ A guide for using macros can be found at
 ### Example datasets
 
 You can find example file collections and qMRI maps organized according to BIDS
-in the [BIDS examples](https://bids-standard.github.io/bids-examples/#qmri).
+in the [BIDS examples](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#qmri).
 
 ## Metadata requirements for qMRI data
 

--- a/src/appendices/qmri.md
+++ b/src/appendices/qmri.md
@@ -213,7 +213,7 @@ A guide for using macros can be found at
 ### Example datasets
 
 You can find example file collections and qMRI maps organized according to BIDS
-in the [BIDS examples](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#qmri).
+in the [BIDS examples](https://bids.neuroimaging.io/datasets/examples.html#qmri).
 
 ## Metadata requirements for qMRI data
 

--- a/src/derivatives/atlas.md
+++ b/src/derivatives/atlas.md
@@ -11,6 +11,12 @@ as BIDS-Derivatives.
     subject's space, please refer to the
     [Derivatives from atlases](imaging.md#derivatives-from-atlases) subsection.
 
+!!! example "Example datasets"
+
+    Templates and atlases datasets formatted according to this specification are available on
+    the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#atlas)
+    and can be emulated when curating new datasets.
+
 ## Derived templates
 
 Many analyses include spatial standardization to pull individuals' data

--- a/src/derivatives/atlas.md
+++ b/src/derivatives/atlas.md
@@ -14,7 +14,7 @@ as BIDS-Derivatives.
 !!! example "Example datasets"
 
     Templates and atlases datasets formatted according to this specification are available on
-    the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#atlas)
+    the [BIDS examples repository](https://bids.neuroimaging.io/datasets/examples.html#atlas)
     and can be emulated when curating new datasets.
 
 ## Derived templates

--- a/src/modality-agnostic-files/events.md
+++ b/src/modality-agnostic-files/events.md
@@ -333,7 +333,7 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
 
 !!! example "Example datasets"
 
-      The following [BIDS-Examples](https://bids-standard.github.io/bids-examples/#dataset-index)
+      The following [BIDS-Examples](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
       showcase stimulus-related signals and may be used as a reference
       when curating a new dataset:
 

--- a/src/modality-agnostic-files/events.md
+++ b/src/modality-agnostic-files/events.md
@@ -333,7 +333,7 @@ in the accompanying JSON sidecar as follows (based on the example of the previou
 
 !!! example "Example datasets"
 
-      The following [BIDS-Examples](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
+      The following [BIDS-Examples](https://bids.neuroimaging.io/datasets/examples.html#dataset-index)
       showcase stimulus-related signals and may be used as a reference
       when curating a new dataset:
 

--- a/src/modality-specific-files/behavioral-experiments.md
+++ b/src/modality-specific-files/behavioral-experiments.md
@@ -3,7 +3,7 @@
 !!! example "Example datasets"
 
     Datasets containing behavioral data can be found
-    in the [BIDS examples repository](https://bids-standard.github.io/bids-examples/#behavioral)
+    in the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#behavioral)
     and can be used as helpful guidance when curating new datasets.
 
 <!--

--- a/src/modality-specific-files/behavioral-experiments.md
+++ b/src/modality-specific-files/behavioral-experiments.md
@@ -3,7 +3,7 @@
 !!! example "Example datasets"
 
     Datasets containing behavioral data can be found
-    in the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#behavioral)
+    in the [BIDS examples repository](https://bids.neuroimaging.io/datasets/examples.html#behavioral)
     and can be used as helpful guidance when curating new datasets.
 
 <!--

--- a/src/modality-specific-files/electroencephalography.md
+++ b/src/modality-specific-files/electroencephalography.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example EEG datasets](https://bids-standard.github.io/bids-examples/#eeg)
+    Several [example EEG datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#eeg)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 

--- a/src/modality-specific-files/electroencephalography.md
+++ b/src/modality-specific-files/electroencephalography.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example EEG datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#eeg)
+    Several [example EEG datasets](https://bids.neuroimaging.io/datasets/examples.html#eeg)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 

--- a/src/modality-specific-files/electromyography.md
+++ b/src/modality-specific-files/electromyography.md
@@ -8,7 +8,7 @@ this extension when referring to it in the context of the academic literature.
 !!! example "Example datasets"
 
     Electromyography datasets formatted according to this specification are available on
-    the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#emg)
+    the [BIDS examples repository](https://bids.neuroimaging.io/datasets/examples.html#emg)
     and can be emulated when curating new datasets.
 
 ## EMG data

--- a/src/modality-specific-files/electromyography.md
+++ b/src/modality-specific-files/electromyography.md
@@ -8,7 +8,7 @@ this extension when referring to it in the context of the academic literature.
 !!! example "Example datasets"
 
     Electromyography datasets formatted according to this specification are available on
-    the [BIDS examples repository](https://github.com/bids-standard/bids-examples#emg)
+    the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#emg)
     and can be emulated when curating new datasets.
 
 ## EMG data

--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example iEEG datasets](https://bids-standard.github.io/bids-examples/#ieeg)
+    Several [example iEEG datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#ieeg)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 

--- a/src/modality-specific-files/intracranial-electroencephalography.md
+++ b/src/modality-specific-files/intracranial-electroencephalography.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example iEEG datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#ieeg)
+    Several [example iEEG datasets](https://bids.neuroimaging.io/datasets/examples.html#ieeg)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -932,7 +932,7 @@ JSON example:
 
 !!! example "Example datasets"
 
-    Several [example ASL datasets](https://bids-standard.github.io/bids-examples/#asl)
+    Several [example ASL datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#asl)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 
@@ -1186,7 +1186,7 @@ For example:
 
 !!! example "Example datasets"
 
-    [Example datasets](https://bids-standard.github.io/bids-examples/#dataset-index)
+    [Example datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
     containing that type of fieldmap can be found here:
 
     -   [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -932,7 +932,7 @@ JSON example:
 
 !!! example "Example datasets"
 
-    Several [example ASL datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#asl)
+    Several [example ASL datasets](https://bids.neuroimaging.io/datasets/examples.html#asl)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 
@@ -1186,7 +1186,7 @@ For example:
 
 !!! example "Example datasets"
 
-    [Example datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
+    [Example datasets](https://bids.neuroimaging.io/datasets/examples.html#dataset-index)
     containing that type of fieldmap can be found here:
 
     -   [`7t_trt`](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)

--- a/src/modality-specific-files/magnetic-resonance-spectroscopy.md
+++ b/src/modality-specific-files/magnetic-resonance-spectroscopy.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example MRS datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#mrs) have
+    Several [example MRS datasets](https://bids.neuroimaging.io/datasets/examples.html#mrs) have
     been formatted using this specification and can be used for practical guidance when curating a new dataset.
 
 ## MRS data

--- a/src/modality-specific-files/magnetic-resonance-spectroscopy.md
+++ b/src/modality-specific-files/magnetic-resonance-spectroscopy.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example MRS datasets](https://github.com/bids-standard/bids-examples?tab=readme-ov-file#mrs) have
+    Several [example MRS datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#mrs) have
     been formatted using this specification and can be used for practical guidance when curating a new dataset.
 
 ## MRS data

--- a/src/modality-specific-files/magnetoencephalography.md
+++ b/src/modality-specific-files/magnetoencephalography.md
@@ -14,7 +14,7 @@ context of the academic literature.
     -   [`multimodal MEG and MRI`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
 
     Further datasets are available from
-    the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#meg).
+    the [BIDS examples repository](https://bids.neuroimaging.io/datasets/examples.html#meg).
 
 ## MEG recording data
 

--- a/src/modality-specific-files/magnetoencephalography.md
+++ b/src/modality-specific-files/magnetoencephalography.md
@@ -14,7 +14,7 @@ context of the academic literature.
     -   [`multimodal MEG and MRI`](https://github.com/bids-standard/bids-examples/tree/master/ds000117)
 
     Further datasets are available from
-    the [BIDS examples repository](https://bids-standard.github.io/bids-examples/#meg).
+    the [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#meg).
 
 ## MEG recording data
 

--- a/src/modality-specific-files/microscopy.md
+++ b/src/modality-specific-files/microscopy.md
@@ -10,7 +10,7 @@ context of the academic literature.
 !!! example "Example datasets"
 
       Microscopy datasets formatted using this specification are available on the
-      [BIDS examples repository](https://bids-standard.github.io/bids-examples/#microscopy)
+      [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#microscopy)
       and can be used for practical guidance when curating a new dataset.
 
       Further Microscopy datasets are available:

--- a/src/modality-specific-files/microscopy.md
+++ b/src/modality-specific-files/microscopy.md
@@ -10,7 +10,7 @@ context of the academic literature.
 !!! example "Example datasets"
 
       Microscopy datasets formatted using this specification are available on the
-      [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#microscopy)
+      [BIDS examples repository](https://bids.neuroimaging.io/datasets/examples.html#microscopy)
       and can be used for practical guidance when curating a new dataset.
 
       Further Microscopy datasets are available:

--- a/src/modality-specific-files/motion.md
+++ b/src/modality-specific-files/motion.md
@@ -5,7 +5,7 @@ For information on how to cite this extension when referencing it in the context
 !!! example "Example datasets"
 
     Motion datasets formatted using this specification are available on the
-    [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#motion)
+    [BIDS examples repository](https://bids.neuroimaging.io/datasets/examples.html#motion)
     and can be used as helpful guidance when curating new datasets.
 
 ## Motion recording data

--- a/src/modality-specific-files/motion.md
+++ b/src/modality-specific-files/motion.md
@@ -5,7 +5,7 @@ For information on how to cite this extension when referencing it in the context
 !!! example "Example datasets"
 
     Motion datasets formatted using this specification are available on the
-    [BIDS examples repository](https://bids-standard.github.io/bids-examples/#motion)
+    [BIDS examples repository](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#motion)
     and can be used as helpful guidance when curating new datasets.
 
 ## Motion recording data

--- a/src/modality-specific-files/near-infrared-spectroscopy.md
+++ b/src/modality-specific-files/near-infrared-spectroscopy.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example NIRS datasets](https://bids-standard.github.io/bids-examples/#nirs)
+    Several [example NIRS datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#nirs)
     have been formatted using this specification and can be used for practical guidance when curating a new dataset.
 
 ## NIRS recording data

--- a/src/modality-specific-files/near-infrared-spectroscopy.md
+++ b/src/modality-specific-files/near-infrared-spectroscopy.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example NIRS datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#nirs)
+    Several [example NIRS datasets](https://bids.neuroimaging.io/datasets/examples.html#nirs)
     have been formatted using this specification and can be used for practical guidance when curating a new dataset.
 
 ## NIRS recording data

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -2,7 +2,7 @@
 
 !!! example "Example datasets"
 
-      [Example datasets](https://bids-standard.github.io/bids-examples/#dataset-index)
+      [Example datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
       with physiological data have been formatted using this specification
       and can be used for practical guidance when curating a new dataset:
 
@@ -437,7 +437,7 @@ the `OnsetSource` is set to `"n/a"` in `sub-01_task-nback_physioevents.json`:
 -->
 !!! example "Example datasets"
 
-    [Example datasets](https://bids-standard.github.io/bids-examples/#dataset-index)
+    [Example datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
     with eye-tracking data have been formatted using this specification
     and can be used for practical guidance when curating a new dataset:
 

--- a/src/modality-specific-files/physiological-recordings.md
+++ b/src/modality-specific-files/physiological-recordings.md
@@ -2,7 +2,7 @@
 
 !!! example "Example datasets"
 
-      [Example datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
+      [Example datasets](https://bids.neuroimaging.io/datasets/examples.html#dataset-index)
       with physiological data have been formatted using this specification
       and can be used for practical guidance when curating a new dataset:
 
@@ -437,7 +437,7 @@ the `OnsetSource` is set to `"n/a"` in `sub-01_task-nback_physioevents.json`:
 -->
 !!! example "Example datasets"
 
-    [Example datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#dataset-index)
+    [Example datasets](https://bids.neuroimaging.io/datasets/examples.html#dataset-index)
     with eye-tracking data have been formatted using this specification
     and can be used for practical guidance when curating a new dataset:
 

--- a/src/modality-specific-files/positron-emission-tomography.md
+++ b/src/modality-specific-files/positron-emission-tomography.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example PET datasets](https://bids-standard.github.io/bids-examples/#pet)
+    Several [example PET datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#pet)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 

--- a/src/modality-specific-files/positron-emission-tomography.md
+++ b/src/modality-specific-files/positron-emission-tomography.md
@@ -8,7 +8,7 @@ context of the academic literature.
 
 !!! example "Example datasets"
 
-    Several [example PET datasets](https://bids-website.readthedocs.io/en/latest/datasets/examples.html#pet)
+    Several [example PET datasets](https://bids.neuroimaging.io/datasets/examples.html#pet)
     have been formatted using this specification
     and can be used for practical guidance when curating a new dataset.
 


### PR DESCRIPTION
update link to example datasets from old and deprecated bids-examples mkdocs website (https://bids-standard.github.io/bids-examples/) to the equivalent page in the BIDS website (https://bids-website.readthedocs.io/en/latest/datasets/examples.html)