### PR TITLE
Add ecephys/icephys to physio/stim timeseries datatypes

### DIFF
--- a/src/schema/rules/files/raw/task.yaml
+++ b/src/schema/rules/files/raw/task.yaml
@@ -9,8 +9,10 @@ timeseries:
     - .json
   datatypes:
     - beh
+    - ecephys
     - eeg
     - emg
+    - icephys
     - ieeg
     - nirs
   entities:


### PR DESCRIPTION
Adds `ecephys` and `icephys` to the allowed datatypes for `physio`, `physioevents`, and `stim` suffixes, enabling physiological and stimulation files alongside microelectrode data.

Related to #2307 