### PR TITLE
Add channels -> electrodes -> probes consistency checks

### DIFF
--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -94,7 +94,7 @@ coordsystem:
 
 electrodes:
   selectors:
-    - intersects([suffix], ['eeg', 'emg', 'ieeg', 'meg', 'ecephys', 'icephys'])
+    - intersects([suffix], ['eeg', 'emg', 'ieeg', 'meg', 'ecephys', 'icephys', 'channels'])
     - extension != '.json'
   target:
     suffix: electrodes
@@ -105,11 +105,12 @@ electrodes:
 
 probes:
   selectors:
-    - intersects([suffix], ['ecephys', 'icephys'])
+    - intersects([suffix], ['ecephys', 'icephys', 'electrodes'])
     - extension != '.json'
   target:
     suffix: probes
     extension: .tsv
+  inherit: true
 
 physio:
   selectors:

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -271,6 +271,25 @@ properties:
           path:
             description: 'Path to associated electrodes.tsv file'
             type: string
+          name:
+            description: 'Contents of the name column'
+            type: array
+            items:
+              type: string
+      probes:
+        description: 'Probes file'
+        type: object
+        required: [path]
+        additionalProperties: false
+        properties:
+          path:
+            description: 'Path to associated probes.tsv file'
+            type: string
+          probe_name:
+            description: 'Contents of the probe_name column'
+            type: array
+            items:
+              type: string
       coordsystem:
         description: 'Coordinate system file (first found)'
         type: object

--- a/src/schema/rules/checks/microephys.yaml
+++ b/src/schema/rules/checks/microephys.yaml
@@ -16,3 +16,47 @@ MicroephysRequiredCoordsystemWithSpace:
     - '"space" in entities'
   checks:
     - associations.coordsystem != null
+
+# Cross-file consistency checks for the channels -> electrodes -> probes hierarchy.
+# Direction: child -> parent only (references must resolve).
+# We do not check parent -> child (completeness) because not all electrodes
+# need channels (broken contacts, reference-only) and not all probes need
+# electrodes (subset recordings, run-specific channel selections).
+
+MicroephysElectrodeProbeReference:
+  issue:
+    code: MICROEPHYS_ELECTRODE_PROBE_MISMATCH
+    message: |
+      All probe_name values in electrodes.tsv (except "n/a") must match
+      a probe_name entry in the corresponding probes.tsv file.
+    level: warning
+  selectors:
+    - intersects([datatype], ["ecephys", "icephys"])
+    - suffix == "electrodes"
+    - extension == ".tsv"
+    - associations.probes.probe_name != null
+    - columns.probe_name != null
+  checks:
+    - |
+      length(intersects(unique(columns.probe_name), associations.probes.probe_name))
+      + count(unique(columns.probe_name), "n/a")
+      >= length(unique(columns.probe_name))
+
+MicroephysChannelElectrodeReference:
+  issue:
+    code: MICROEPHYS_CHANNEL_ELECTRODE_MISMATCH
+    message: |
+      All electrode_name values in channels.tsv (except "n/a") must match
+      a name entry in the corresponding electrodes.tsv file.
+    level: warning
+  selectors:
+    - intersects([datatype], ["ecephys", "icephys"])
+    - suffix == "channels"
+    - extension == ".tsv"
+    - associations.electrodes.name != null
+    - columns.electrode_name != null
+  checks:
+    - |
+      length(intersects(unique(columns.electrode_name), associations.electrodes.name))
+      + count(unique(columns.electrode_name), "n/a")
+      >= length(unique(columns.electrode_name))


### PR DESCRIPTION
Thanks @effigies and @rwblair for the meeting and feedback yesterday. I have tried drafting a rule for the channels -> electrodes -> probes consistency checks.

### What this does

Validates that references from child files resolve in parent files:
- `electrode_name` in `channels.tsv` must exist in `electrodes.tsv`
- `probe_name` in `electrodes.tsv` must exist in `probes.tsv`

Both checks allow `n/a` (for aux channels without electrodes, or standalone electrodes without probes). We intentionally do not check the reverse direction (parent -> child) since not all electrodes need channels (broken contacts, reference-only, run-specific subsets).

### Changes

- **`context.yaml`**: Added `name` column to `electrodes` association and new `probes` association with `probe_name` column
- **`associations.yaml`**: Extended selectors so `electrodes` is resolved when visiting `channels.tsv` and `probes` is resolved when visiting `electrodes.tsv` (follows the `coordsystem` precedent which already includes `electrodes` in its selector). Added `inherit: true` to `probes`.
- **`checks/microephys.yaml`**: Two warning-level child -> parent reference checks

### Looking for feedback on

I was not able to get the validator to fire these checks when I broke a dataset by replacing `probe_name` values in `electrodes.tsv` with nonexistent names. The schema compiles fine, valid datasets still pass, but the broken dataset did not trigger the new warnings.

Also, the check expression uses `length(intersects(...))`. When `intersects()` finds zero overlap it returns `false` rather than an empty array -- how does `length(false)` behave? If this is problematic, would a simpler check like the following be preferred?

```yaml
count(unique(columns.probe_name), "n/a") == length(unique(columns.probe_name))
|| intersects(unique(columns.probe_name), associations.probes.probe_name)
```

Related #2307 