### PR TITLE
chore(tox): Fix environment to avoid pre-release tests

### DIFF
--- a/.github/workflows/schemacode_ci.yml
+++ b/.github/workflows/schemacode_ci.yml
@@ -72,6 +72,8 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             dependencies: min
+    env:
+      DEPENDS: ${{ matrix.dependencies }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tools/schemacode/tox.ini
+++ b/tools/schemacode/tox.ini
@@ -32,7 +32,7 @@ python =
 [gh-actions:env]
 DEPENDS =
   pre: pre
-  full: full
+  latest: latest
   min: min
 
 [testenv]


### PR DESCRIPTION
Slight misconfiguration is resulting in pre-release tests getting run in jobs that are intended to run only locked dependencies.