### PR TITLE
[FIX] Accept MiscChannelCount in EEG/Motion sidecars; deprecate MISCChannelCount alias

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2389,6 +2389,9 @@ MISCChannelCount:
   display_name: Miscellaneous channel count
   description: |
     Number of miscellaneous channels not covered otherwise.
+
+    Deprecated alias of `MiscChannelCount`. New datasets SHOULD use
+    `MiscChannelCount`.
   type: integer
   minimum: 0
 MotionChannelCount:

--- a/src/schema/rules/sidecars/eeg.yaml
+++ b/src/schema/rules/sidecars/eeg.yaml
@@ -71,13 +71,7 @@ EEGRecommended:
     EMGChannelCount: recommended
     EOGChannelCount: recommended
     MiscChannelCount: recommended
-    MISCChannelCount:
-      level: deprecated
-      description_addendum: |
-        Deprecated alias of `MiscChannelCount`. Existing datasets remain valid;
-        new datasets SHOULD use `MiscChannelCount`, which matches the MEG and
-        iEEG sidecar rules, the EEG channel-count consistency check, and the
-        documentation example in this modality.
+    MISCChannelCount: deprecated
     TriggerChannelCount: recommended
     RecordingDuration: recommended
     RecordingType: recommended

--- a/src/schema/rules/sidecars/eeg.yaml
+++ b/src/schema/rules/sidecars/eeg.yaml
@@ -70,7 +70,14 @@ EEGRecommended:
     ECGChannelCount: recommended
     EMGChannelCount: recommended
     EOGChannelCount: recommended
-    MISCChannelCount: recommended
+    MiscChannelCount: recommended
+    MISCChannelCount:
+      level: deprecated
+      description_addendum: |
+        Deprecated alias of `MiscChannelCount`. Existing datasets remain valid;
+        new datasets SHOULD use `MiscChannelCount`, which matches the MEG and
+        iEEG sidecar rules, the EEG channel-count consistency check, and the
+        documentation example in this modality.
     TriggerChannelCount: recommended
     RecordingDuration: recommended
     RecordingType: recommended

--- a/src/schema/rules/sidecars/motion.yaml
+++ b/src/schema/rules/sidecars/motion.yaml
@@ -61,7 +61,8 @@ motionRecommended:
     JNTANGChannelCount: recommended
     LATENCYChannelCount: recommended
     MAGNChannelCount: recommended
-    MISCChannelCount: recommended
+    MiscChannelCount: recommended
+    MISCChannelCount: deprecated
     MissingValues: recommended
     MotionChannelCount: recommended
     ORNTChannelCount: recommended


### PR DESCRIPTION
Closes #2393.

## Problem

The EEG sidecar's `EEGRecommended` rule names the misc-channel-count key as `MISCChannelCount`, but the rest of the schema and the docs use `MiscChannelCount`:

| Source | Key |
| --- | --- |
| `src/schema/rules/sidecars/eeg.yaml:73` (`EEGRecommended`) | **`MISCChannelCount`** |
| `src/schema/rules/checks/eeg.yaml` (`MiscChannelCountReq`) | `MiscChannelCount` |
| `src/schema/rules/sidecars/meg.yaml:101` | `MiscChannelCount` |
| `src/schema/rules/sidecars/ieeg.yaml:79` | `MiscChannelCount` |
| `src/schema/rules/sidecars/motion.yaml:64` | **`MISCChannelCount`** |
| `src/modality-specific-files/electroencephalography.md:179` (example) | `MiscChannelCount` |
| `bids-validator@1.x` legacy `eeg.json` schema (`additionalProperties: false`) | `MiscChannelCount` |

The contradiction means writers cannot satisfy both rules at once: writing `MiscChannelCount` triggers a missing-recommended warning, writing `MISCChannelCount` triggers `JSON_SCHEMA_VALIDATION_ERROR (code 55)` against the legacy validator and silences the consistency check. Reproducer / impact: mne-tools/mne-bids#1546.

## Fix

Make `MiscChannelCount` the canonical recommended key in both EEG and motion sidecars (matching the rest of the schema, the docs example, and the legacy validator), and keep `MISCChannelCount` as a `deprecated` alias in both so datasets in the wild that already use that spelling keep validating.

```yaml
EEGRecommended / motionRecommended:
  fields:
    ...
    MiscChannelCount: recommended
    MISCChannelCount: deprecated
```

The deprecation note lives on the field definition itself (`src/schema/objects/metadata.yaml`), so the glossary entry for `MISCChannelCount` points readers at the canonical `MiscChannelCount` wherever the field is referenced.

## Validator behaviour

Checked with `bids-validator@2.4.1` against the updated schema:

- Datasets using `MiscChannelCount` validate cleanly.
- Datasets using the deprecated `MISCChannelCount` are accepted without error (existing datasets keep passing). bids-validator v2 does not currently emit a dedicated `DEPRECATED_SIDECAR_KEY` warning for any `deprecated`-level sidecar field (e.g. `DCOffsetCorrection`, `HardcopyDeviceSoftwareVersion`) — that gap is pre-existing and belongs upstream in `bids-standard/bids-validator`, not in this spec PR.

cc @effigies (since #1319 introduced the EEG check rules)