### PR TITLE
[FIX] Update OSIPI task force link for ASL lexicon

### DIFF
--- a/src/appendices/arterial-spin-labeling.md
+++ b/src/appendices/arterial-spin-labeling.md
@@ -69,7 +69,7 @@ m0scan
 The following images illustrate the main BIDS metadata fields for three `ArterialSpinLabelingType`'s:
 `CASL`, `PCASL`, and `PASL`.
 Images are courtesy of, and adapted with permission from
-Y. Suzuki and [OSIPI Task force 4.1: ASL lexicon milestone 1](https://osipi.github.io/task-force-4-1/).
+Y. Suzuki and [OSIPI Task force 4.1: ASL lexicon milestone 1](https://osipi.github.io/ASL-Lexicon/).
 
 ### (P)CASL sequence
 


### PR DESCRIPTION
CI caught that the original link does not resolve.  See [here](https://github.com/OSIPI/osipi.github.io/blob/3ad682905aa44662b52eaa4ef73417d9663a7a80/mkdocs.yml#L146) for the new URL in the OSIPI repo. Tagging the OSIPI maintainers for visibility: @ltorres6 @RohanKrMahato

cc @satra @ayendiki