### PR TITLE
[ENH] Allow for institutions to be listed as Authors

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -241,8 +241,7 @@ Authors:
   name: Authors
   display_name: Authors
   description: |
-    List of individuals or organizations (if organization-wide effort)
-    who contributed to the creation/curation of the dataset.
+    List of contributors to the creation and/or curation of the dataset.
   type: array
   items:
     type: string

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -241,7 +241,8 @@ Authors:
   name: Authors
   display_name: Authors
   description: |
-    List of individuals who contributed to the creation/curation of the dataset.
+    List of individuals or organizations (if organization-wide effort)
+    who contributed to the creation/curation of the dataset.
   type: array
   items:
     type: string


### PR DESCRIPTION
It is not uncommon to have datasets which are a truly an institutional effort -- from data collection planing, acquisition, curation, harmonization etc, where it is a pipeline to deliver high quality datasets.  For instance we have a number of such contributions from Allen Institute(s) in DANDI archive.  In DANDI schema we allow for both Person and Organization entries, and e.g. in https://github.com/dandisets/000020 we have

```yaml
contributor:
- affiliation:
  - identifier: https://ror.org/00dcv1019
    name: Allen Institute for Brain Science
    schemaKey: Affiliation
  email: nathang@alleninstitute.org
  identifier: 0000-0001-8429-4090
  includeInCitation: false
  name: Gouwens, Nathan
  roleName:
  - dcite:ContactPerson
  schemaKey: Person
- contactPoint: []
  identifier: https://ror.org/00dcv1019
  includeInCitation: true
  name: Allen Institute for Brain Science
  roleName: []
  schemaKey: Organization
  url: https://alleninstitute.org
```

so there is an Organization, which is actually the one to cite, although we do not list any particular roleName, and then responsible ContactPerson (who is not even listed as an Author) who could be contacted  ATM (but might be a different person later) about this dandiset.

I have tried to make wording a bit more explicit than just listing Organizations as a possible entry here, rather to keep it for large efforts.

Potential TODOs:

If we merge this, it would either
- Close #2255 as it would become impossible to tell person from an organization and thus we would not be able to impose checks.
- [ ] or in spirit of #2255 we could add (hre) recommendation to use `Last, First` form for Person and avoid ',' in  organizations!
