### PR TITLE
[ENH] Recommend controlled vocabulary for age Units, clarify that it can be overloaded

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -1135,9 +1135,16 @@ Describing dates and timestamps:
     for more information.
 
 -   Age SHOULD be given as the number of years since birth at the time of
-    scanning (or first scan in case of multi session datasets). Using higher
-    accuracy (weeks) should in general be avoided due to privacy protection,
-    unless when appropriate given the study goals, for example, when scanning babies.
+    scanning (or first scan in case of multi session datasets).
+    The default unit is `"year"`, but it MAY be overridden in the JSON sidecar
+    (for example, `participants.json`) by setting `"Units"` to one of the
+    following values based on
+    [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration
+    designators: `"year"`, `"month"`, `"week"`, `"day"`, `"hour"`, `"minute"`,
+    or `"second"`.
+    Using higher accuracy (for example, weeks or days) should in general be
+    avoided due to privacy protection, unless when appropriate given the study
+    goals, for example, when scanning babies or animals.
 
 ## Directory structure
 

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -44,7 +44,7 @@ age:
     Using "89+" for ages above 88 is DEPRECATED.
   definition: {
     "LongName": "Subject age",
-    "Description": "Subject postnatal age (by default in years)",
+    "Description": "Subject postnatal age",
     "Format": "number",
     "Units": "year",
     "Maximum": 89,

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -36,13 +36,15 @@ age:
   name: age
   display_name: Subject age
   description: |
-    Numeric value in years (float or integer value).
+    Numeric value (float or integer value).
+    By default expressed using "year" as the unit. Other possible "Units" are described in
+    [Units](SPEC_ROOT/common-principles.md#units).
 
-    For privacy purposes, participant ages should be capped at 89.
+    For privacy purposes, participant ages should be capped at 89 years.
     Using "89+" for ages above 88 is DEPRECATED.
   definition: {
     "LongName": "Subject age",
-    "Description": "Subject age in postnatal years",
+    "Description": "Subject postnatal age (by default in years)",
     "Format": "number",
     "Units": "year",
     "Maximum": 89,

--- a/src/schema/rules/checks/dataset.yaml
+++ b/src/schema/rules/checks/dataset.yaml
@@ -43,6 +43,23 @@ ParticipantIDMismatch:
         sorted(dataset.subjects.sub_dirs)
       )
 
+AgeUnits:
+  issue:
+    code: AGE_UNITS
+    message: |
+      The "Units" value for age in 'participants.json' is not a valid
+      ISO 8601-based duration unit.
+      Allowed values are "year", "month", "week", "day", "hour", "minute",
+      or "second".
+    level: error
+  selectors:
+    - path == '/participants.json'
+    - '"age" in json'
+    - type(json.age) != 'null'
+    - '"Units" in json.age'
+  checks:
+    - intersects([json.age.Units], ["year", "month", "week", "day", "hour", "minute", "second"])
+
 # 214
 SamplesTSVMissing:
   issue:

--- a/src/schema/rules/checks/dataset.yaml
+++ b/src/schema/rules/checks/dataset.yaml
@@ -51,11 +51,9 @@ AgeUnits:
       ISO 8601-based duration unit.
       Allowed values are "year", "month", "week", "day", "hour", "minute",
       or "second".
-    level: error
+    level: warning
   selectors:
     - path == '/participants.json'
-    - '"age" in json'
-    - type(json.age) != 'null'
     - '"Units" in json.age'
   checks:
     - intersects([json.age.Units], ["year", "month", "week", "day", "hour", "minute", "second"])

--- a/src/schema/rules/checks/dataset.yaml
+++ b/src/schema/rules/checks/dataset.yaml
@@ -53,10 +53,10 @@ AgeUnits:
       or "second".
     level: warning
   selectors:
-    - path == '/participants.json'
-    - '"Units" in json.age'
+    - path == '/participants.tsv'
+    - '"Units" in sidecar.age'
   checks:
-    - intersects([json.age.Units], ["year", "month", "week", "day", "hour", "minute", "second"])
+    - intersects([sidecar.age.Units], ["year", "month", "week", "day", "hour", "minute", "second"])
 
 # 214
 SamplesTSVMissing:


### PR DESCRIPTION
Of high relevance to @bids-standard/bep032 effort, but also potentially to @bids-standard/bep036 and others.

- Most recent relevant discussion is in https://github.com/bids-standard/bids-specification/issues/1633#issuecomment-4253350012 
 - Ultimately closes #1633
- Reincarnated  https://github.com/bids-standard/bids-specification/pull/1791 which was partially addressed elsewhere
- and relates to freshly filed https://github.com/bids-standard/bids-validator/issues/386 as we might need to adjust this depending on the solution there. 

TODOs/Notes
- [x] it will make some bids-example datasets invalid since they use "years" for "Units" instead of "year", submitted https://github.com/bids-standard/bids-examples/pull/553
- [x] Review/fix for that test fix.  ~~Unclear why NOW it became applicable/failing~~
   - we ran into this since this is presumably the first rule adding custom checks on the column definition (not sidecar) .json files? (according to claude).  But reworked test selection seems became  too cumbersome
   - no more changes to tests -- validating against .tsv
- [x] For BIDS 2.0 make 'warning' into 'error' there Units not being from allowed values. Added to TODOs of #1775