### PR TITLE
[ENH] Add participant+sessions.tsv for session-varying participant metadata

### DIFF
--- a/src/longitudinal-and-multi-site-studies.md
+++ b/src/longitudinal-and-multi-site-studies.md
@@ -56,6 +56,7 @@ A guide for using macros can be found at
             },
         "sub-control01_sessions.tsv": "",
         },
+    "participant+sessions.tsv": "",
     "participants.tsv": "",
     "dataset_description.json": "",
     "README": "",
@@ -70,6 +71,13 @@ session_id	acq_time	systolic_blood_pressure
 ses-predrug	2009-06-15T13:45:30	120
 ses-postdrug	2009-06-16T13:45:30	100
 ```
+
+In addition to per-subject `_sessions.tsv` files,
+a dataset-level `participant+sessions.tsv` file can aggregate
+metadata that varies across both participants and sessions
+(such as age at each session) into a single file.
+See [Participant and sessions file](modality-agnostic-files/data-summary-files.md#participant-and-sessions-file)
+for details.
 
 See this [example dataset](https://github.com/bids-standard/bids-examples/tree/master/7t_trt)
 that has been formatted

--- a/src/modality-agnostic-files/data-summary-files.md
+++ b/src/modality-agnostic-files/data-summary-files.md
@@ -81,6 +81,63 @@ to date of birth.
 }
 ```
 
+## Participant and sessions file
+
+Template:
+
+```Text
+participant+sessions.tsv
+participant+sessions.json
+```
+
+<!-- This block generates a description.
+A guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___render_text("objects.files.participant_sessions.description") }}
+
+We RECOMMEND to make use of these columns, and
+in case that you do use them, we RECOMMEND to use the following values
+for them:
+
+<!-- This block generates a columns table.
+The definitions of these fields can be found in
+  src/schema/rules/tabular_data/*.yaml
+and a guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_columns_table("modality_agnostic.ParticipantSessions") }}
+
+`participant+sessions.tsv` example:
+
+```tsv
+participant_id	session_id	age	body_weight
+sub-01	ses-predrug	34	81.3
+sub-01	ses-postdrug	35	83.1
+sub-02	ses-predrug	12	45.2
+sub-02	ses-postdrug	13	48.7
+```
+
+It is RECOMMENDED to accompany each `participant+sessions.tsv` file with a sidecar
+`participant+sessions.json` file to describe the TSV column names and properties
+of their values (see also
+the [section on tabular files](../common-principles.md#tabular-files)).
+Such sidecar files are needed to interpret the data, especially so when
+additional columns are defined beyond `age`,
+such as `body_weight` in this example.
+
+`participant+sessions.json` example:
+
+```JSON
+{
+    "body_weight": {
+        "Description": "body weight of the participant at the time of the session",
+        "Format": "number",
+        "Units": "kg"
+    }
+}
+```
+
 ## Samples file
 
 Template:

--- a/src/schema/README.md
+++ b/src/schema/README.md
@@ -732,8 +732,9 @@ Here, `README` and `README.md` are both valid, while only `dataset_description.j
 #### Tabular metadata files
 
 `rules.files.common.tables` describes TSV files and their associated metadata,
-including `participants.tsv`, `samples.tsv`, `*_sessions.tsv` and `*_scans.tsv`.
-The first two use the `stem` field, while the latter two specify the entities used
+including `participants.tsv`, `participant+sessions.tsv`, `samples.tsv`,
+`*_sessions.tsv` and `*_scans.tsv`.
+The first three use the `stem` field, while the latter two specify the entities used
 to construct the filename.
 
 The valid fields are:

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -80,6 +80,18 @@ properties:
             type: array
             items:
               type: string
+      sessions:
+        description: 'Collections of sessions in dataset'
+        type: object
+        required:
+          - ses_dirs
+        additionalProperties: false
+        properties:
+          ses_dirs:
+            description: 'Union of all ses-* directories found across all subjects'
+            type: array
+            items:
+              type: string
   subject:
     description: 'Properties and contents of the current subject'
     type: object

--- a/src/schema/objects/files.yaml
+++ b/src/schema/objects/files.yaml
@@ -87,6 +87,16 @@ participants:
     (for examples `homo sapiens`, `mus musculus`, `rattus norvegicus`).
     For backwards compatibility, if `species` is absent, the participant is assumed to be
     `homo sapiens`.
+participant_sessions:
+  display_name: Participant and Session Information
+  file_type: regular
+  description: |
+    The purpose of this OPTIONAL file is to describe properties that vary
+    across both participants and sessions, such as age at each session.
+    If this file exists, it MUST contain the columns `participant_id` and `session_id`,
+    which MUST consist of `sub-<label>` and `ses-<label>` values respectively,
+    identifying one row for each participant-session combination.
+    Each combination of participant and session MUST be described by one and only one row.
 samples:
   display_name: Sample Information
   file_type: regular

--- a/src/schema/rules/checks/dataset.yaml
+++ b/src/schema/rules/checks/dataset.yaml
@@ -43,6 +43,43 @@ ParticipantIDMismatch:
         sorted(dataset.subjects.sub_dirs)
       )
 
+ParticipantSessionsParticipantsMissing:
+  issue:
+    code: PARTICIPANT_SESSIONS_PARTICIPANTS_MISSING
+    message: |
+      participant+sessions.tsv lists participant_id values that do not correspond
+      to subject directories found in the dataset.
+    level: error
+  selectors:
+    - path == '/participant+sessions.tsv'
+  checks:
+    - |
+      allequal(
+        sorted(intersects(columns.participant_id, dataset.subjects.sub_dirs)),
+        sorted(unique(columns.participant_id))
+      )
+
+ParticipantSessionsSessionsMissing:
+  issue:
+    code: PARTICIPANT_SESSIONS_SESSIONS_MISSING
+    message: |
+      participant+sessions.tsv lists session_id values that do not correspond
+      to session directories found in the dataset.
+    level: error
+  selectors:
+    - path == '/participant+sessions.tsv'
+  checks:
+    - |
+      allequal(
+        sorted(intersects(columns.session_id, dataset.sessions.ses_dirs)),
+        sorted(unique(columns.session_id))
+      )
+
+# TODO: Add a check that each (participant_id, session_id) *combination*
+# corresponds to an actual sub-*/ses-*/ directory. The current check only
+# validates the sets independently. Checking combinations requires either
+# string concatenation in the expression language or a dedicated function.
+
 # 214
 SamplesTSVMissing:
   issue:

--- a/src/schema/rules/files/common/tables.yaml
+++ b/src/schema/rules/files/common/tables.yaml
@@ -5,6 +5,12 @@ participants:
   extensions:
     - .tsv
     - .json
+participant_sessions:
+  level: optional
+  stem: participant+sessions
+  extensions:
+    - .tsv
+    - .json
 samples:
   level: optional
   stem: samples

--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -19,6 +19,26 @@ Participants:
   index_columns: [participant_id]
   additional_columns: allowed
 
+ParticipantSessions:
+  selectors:
+    - path == "/participant+sessions.tsv"
+  initial_columns:
+    - participant_id
+    - session_id
+  columns:
+    participant_id:
+      level: required
+      description_addendum: |
+        There MUST be exactly one row for each combination of participant and session.
+    session_id: required
+    age:
+      level: optional
+      description_addendum: |
+        Age of the participant at the time of the session.
+    HED: optional
+  index_columns: [participant_id, session_id]
+  additional_columns: allowed
+
 Samples:
   selectors:
     - path == "/samples.tsv"


### PR DESCRIPTION
Introduces a single new optional dataset-level file `participant+sessions.tsv` with a composite index `[participant_id, session_id]`.  This provides a single top-level location for metadata that varies across both participants and sessions -- e.g. age at each visit, body weight, clinical scores in longitudinal studies -- complementing the existing `participants.tsv` (participant-constant) and per-subject `*_sessions.tsv` files.

Note that it is already possible to provide such metadata in `sub-*/ses-*_sessions.tsv` file. So such approach just serves the way to provide an "aggregate" collection of metadata.  As such, we might then need to define how it interacts with the inheritance principle, but defining that yet TODO in general for .tsv files.

The `+` in the filename signals a composite index, following the convention proposed in 

- #2273 
- and alternative to freshly proposed #2402 
 
inspired by a work on BEP036 (@bids-standard/bep036):

- https://github.com/bids-standard/bids-specification/pull/2123

Most of the changes are just straightforward interpolation of `participants.tsv` and `sessions.tsv` files definitions.

One of the notable changes is to `meta/context.yaml` where we added `dataset.sessions` (union of all session directories across subjects) to enable session-level validation checks.  I think it is only reasonable given that we did already included dataset level summaries for datatypes and modalities. But it would require bids-validator to support it.  Alternative - is to drop it and that extra check we added.

Ideally though we should figure out how to validate specific combinations of sub/sessions and TODO was left for that.

An example `participant+sessions.tsv` with `body_weight` column for the already `7t_trt` bids-examples dataset is at

- https://github.com/bids-standard/bids-examples/pull/556

where, if you also look into original `participants.tsv`, makes it a little obvious that duplication of all entries across all sessions would be dubious.


- I think overall we can state that it closes #1020 which theoretically could have been closed with original introduction of _sessions.tsv files.

TODOs
- [ ] clarify relationship (summarization AKA formerly inheritance) to the per subject `sub-*/sub-*_sessions.tsv` files. Two possibilities:
   - a. ad-hoc within description of elaborated here "Participant and sessions file" section
   - b. "Common principles/Inheritance" thus pre-empting a solution for more generic #2273 
   - c. both