### PR TITLE
[SCHEMA] Support structured survey data as a BIDS modality

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
           - Intracranial Electroencephalography: modality-specific-files/intracranial-electroencephalography.md
           - Physiological recordings: modality-specific-files/physiological-recordings.md
           - Behavioral experiments (with no neural recordings): modality-specific-files/behavioral-experiments.md
+          - Survey data (instrument-based phenotypic): modality-specific-files/survey.md
           - Genetic Descriptor: modality-specific-files/genetic-descriptor.md
           - Positron Emission Tomography: modality-specific-files/positron-emission-tomography.md
           - Microscopy: modality-specific-files/microscopy.md

--- a/src/modality-specific-files/survey.md
+++ b/src/modality-specific-files/survey.md
@@ -1,0 +1,145 @@
+# Survey data (instrument-based phenotypic)
+
+Survey data files contain responses collected from standardized questionnaires or
+assessment instruments.
+They are organized in the same subject- and session-resolved directory hierarchy
+as other BIDS modalities, with one `.tsv` data file per instrument administration
+and a corresponding `.json` sidecar that documents the instrument and its items.
+
+This representation complements the aggregated `phenotype/` tables described in
+[Phenotypic and assessment data](../modality-agnostic-files/phenotypic-and-assessment-data.md).
+Aggregated phenotype tables MAY be generated from subject-resolved survey data
+and stored under `phenotype/`,
+but the subject-resolved structure is the primary canonical form.
+
+<!--
+This block generates a filename templates.
+The inputs for this macro can be found in the directory
+  src/schema/rules/files/raw
+and a guide for using macros can be found at
+ https://github.com/bids-standard/bids-specification/blob/master/macros_doc.md
+-->
+{{ MACROS___make_filename_template("raw", datatypes=["survey"]) }}
+
+Survey files MUST be stored in a `survey` subdirectory of the subject (and
+optionally session) directory.
+The `task` entity identifies the instrument (for example, `task-pss` for the
+Perceived Stress Scale).
+The `run` entity MAY be used when the same instrument is administered more than
+once within a session.
+
+## Sidecar JSON (`*_survey.json`)
+
+Each survey `.tsv` file MUST be accompanied by a JSON sidecar with the same
+filename stem.
+The sidecar documents the instrument-level metadata and the individual items.
+
+### Instrument metadata
+
+The following top-level fields describe the survey instrument and its
+administration context.
+
+| Field | Requirement | Description |
+| --- | --- | --- |
+| `TaskName` | REQUIRED | Short label identifying the instrument as used in this dataset (MUST match the `task` entity value). |
+| `OriginalName` | REQUIRED | Full canonical name of the instrument. |
+| `StimulusType` | REQUIRED | MUST be `"Questionnaire"`. |
+| `FileFormat` | REQUIRED | MUST be `"tsv"`. |
+| `Language` | REQUIRED | Language code for the administered version (for example, `"en"`, `"de-AT"`). |
+| `Respondent` | REQUIRED | Who provided the responses (`"self"`, `"clinician"`, `"parent"`, or similar). |
+| `ShortName` | OPTIONAL | Common abbreviation of the instrument (for example, `"PSS-10"`). |
+| `Version` | OPTIONAL | Version or edition of the instrument. |
+| `Authors` | OPTIONAL | Array of instrument authors. |
+| `DOI` | OPTIONAL | DOI for the instrument or its primary validation paper. |
+| `License` | OPTIONAL | License under which the instrument may be used. |
+| `Construct` | OPTIONAL | Psychological or clinical construct measured (for example, `"perceived stress"`). |
+| `Instructions` | OPTIONAL | Instructions given to the participant. |
+| `AdministrationMethod` | OPTIONAL | How the instrument was administered (`"online"`, `"paper"`, `"interview"`, `"phone"`, or `"mixed"`). |
+| `SoftwarePlatform` | OPTIONAL | Software used to administer the instrument (for example, `"LimeSurvey"`, `"REDCap"`). |
+
+### Item-level metadata
+
+Any top-level key in the sidecar that is not one of the instrument-level fields
+listed above is treated as a column-level variable definition (for example, `"Q01"`,
+`"item_1"`).
+
+| Field | Requirement | Description |
+| --- | --- | --- |
+| `Description` | REQUIRED | The exact text of the question or item. |
+| `Levels` | OPTIONAL | Mapping of response values to their labels (for example, `{"0": "Not at all", "4": "Very often"}`). |
+| `MinValue` | OPTIONAL | Minimum expected value. |
+| `MaxValue` | OPTIONAL | Maximum expected value. |
+| `DataType` | OPTIONAL | Expected data type of the column (`"string"`, `"integer"`, or `"float"`). |
+| `Units` | OPTIONAL | Units, if applicable. |
+
+## Example dataset structure
+
+```text
+study/
+├── dataset_description.json
+├── participants.tsv
+├── sub-01/
+│   ├── ses-baseline/
+│   │   └── survey/
+│   │       ├── sub-01_ses-baseline_task-pss_run-01_survey.tsv
+│   │       └── sub-01_ses-baseline_task-pss_run-01_survey.json
+│   └── ses-week04/
+│       └── survey/
+│           ├── sub-01_ses-week04_task-pss_run-01_survey.tsv
+│           ├── sub-01_ses-week04_task-pss_run-01_survey.json
+│           ├── sub-01_ses-week04_task-pss_run-02_survey.tsv
+│           └── sub-01_ses-week04_task-pss_run-02_survey.json
+└── phenotype/
+    └── pss_summary.tsv
+```
+
+The `phenotype/` entry in this example is an optional aggregated downstream
+view of the subject-resolved survey data.
+
+## Example `*_survey.tsv`
+
+```tsv
+participant_id	Q01	Q02	Q03
+sub-01	2	1	3
+```
+
+## Example `*_survey.json`
+
+```json
+{
+  "TaskName": "pss",
+  "OriginalName": "Perceived Stress Scale",
+  "ShortName": "PSS-10",
+  "StimulusType": "Questionnaire",
+  "FileFormat": "tsv",
+  "Language": "en",
+  "Respondent": "self",
+  "AdministrationMethod": "online",
+  "Q01": {
+    "Description": "In the last month, how often have you been upset because of something that happened unexpectedly?",
+    "Levels": {
+      "0": "Never",
+      "1": "Almost never",
+      "2": "Sometimes",
+      "3": "Fairly often",
+      "4": "Very often"
+    },
+    "MinValue": 0,
+    "MaxValue": 4,
+    "DataType": "integer"
+  },
+  "Q02": {
+    "Description": "In the last month, how often have you felt that you were unable to control the important things in your life?",
+    "Levels": {
+      "0": "Never",
+      "1": "Almost never",
+      "2": "Sometimes",
+      "3": "Fairly often",
+      "4": "Very often"
+    },
+    "MinValue": 0,
+    "MaxValue": 4,
+    "DataType": "integer"
+  }
+}
+```

--- a/src/modality-specific-files/survey.md
+++ b/src/modality-specific-files/survey.md
@@ -39,23 +39,23 @@ The sidecar documents the instrument-level metadata and the individual items.
 The following top-level fields describe the survey instrument and its
 administration context.
 
-| Field | Requirement | Description |
-| --- | --- | --- |
-| `TaskName` | REQUIRED | Short label identifying the instrument as used in this dataset (MUST match the `task` entity value). |
-| `OriginalName` | REQUIRED | Full canonical name of the instrument. |
-| `StimulusType` | REQUIRED | MUST be `"Questionnaire"`. |
-| `FileFormat` | REQUIRED | MUST be `"tsv"`. |
-| `Language` | REQUIRED | Language code for the administered version (for example, `"en"`, `"de-AT"`). |
-| `Respondent` | REQUIRED | Who provided the responses (`"self"`, `"clinician"`, `"parent"`, or similar). |
-| `ShortName` | OPTIONAL | Common abbreviation of the instrument (for example, `"PSS-10"`). |
-| `Version` | OPTIONAL | Version or edition of the instrument. |
-| `Authors` | OPTIONAL | Array of instrument authors. |
-| `DOI` | OPTIONAL | DOI for the instrument or its primary validation paper. |
-| `License` | OPTIONAL | License under which the instrument may be used. |
-| `Construct` | OPTIONAL | Psychological or clinical construct measured (for example, `"perceived stress"`). |
-| `Instructions` | OPTIONAL | Instructions given to the participant. |
-| `AdministrationMethod` | OPTIONAL | How the instrument was administered (`"online"`, `"paper"`, `"interview"`, `"phone"`, or `"mixed"`). |
-| `SoftwarePlatform` | OPTIONAL | Software used to administer the instrument (for example, `"LimeSurvey"`, `"REDCap"`). |
+| Field                  | Requirement | Description                                                                                          |
+| ---------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| `TaskName`             | REQUIRED    | Short label identifying the instrument as used in this dataset (MUST match the `task` entity value). |
+| `OriginalName`         | REQUIRED    | Full canonical name of the instrument.                                                               |
+| `StimulusType`         | REQUIRED    | MUST be `"Questionnaire"`.                                                                           |
+| `FileFormat`           | REQUIRED    | MUST be `"tsv"`.                                                                                     |
+| `Language`             | REQUIRED    | Language code for the administered version (for example, `"en"`, `"de-AT"`).                         |
+| `Respondent`           | REQUIRED    | Who provided the responses (`"self"`, `"clinician"`, `"parent"`, or similar).                        |
+| `ShortName`            | OPTIONAL    | Common abbreviation of the instrument (for example, `"PSS-10"`).                                     |
+| `Version`              | OPTIONAL    | Version or edition of the instrument.                                                                |
+| `Authors`              | OPTIONAL    | Array of instrument authors.                                                                         |
+| `DOI`                  | OPTIONAL    | DOI for the instrument or its primary validation paper.                                              |
+| `License`              | OPTIONAL    | License under which the instrument may be used.                                                      |
+| `Construct`            | OPTIONAL    | Psychological or clinical construct measured (for example, `"perceived stress"`).                    |
+| `Instructions`         | OPTIONAL    | Instructions given to the participant.                                                               |
+| `AdministrationMethod` | OPTIONAL    | How the instrument was administered (`"online"`, `"paper"`, `"interview"`, `"phone"`, or `"mixed"`). |
+| `SoftwarePlatform`     | OPTIONAL    | Software used to administer the instrument (for example, `"LimeSurvey"`, `"REDCap"`).                |
 
 ### Item-level metadata
 
@@ -63,14 +63,14 @@ Any top-level key in the sidecar that is not one of the instrument-level fields
 listed above is treated as a column-level variable definition (for example, `"Q01"`,
 `"item_1"`).
 
-| Field | Requirement | Description |
-| --- | --- | --- |
-| `Description` | REQUIRED | The exact text of the question or item. |
-| `Levels` | OPTIONAL | Mapping of response values to their labels (for example, `{"0": "Not at all", "4": "Very often"}`). |
-| `MinValue` | OPTIONAL | Minimum expected value. |
-| `MaxValue` | OPTIONAL | Maximum expected value. |
-| `DataType` | OPTIONAL | Expected data type of the column (`"string"`, `"integer"`, or `"float"`). |
-| `Units` | OPTIONAL | Units, if applicable. |
+| Field         | Requirement | Description                                                                                         |
+| ------------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| `Description` | REQUIRED    | The exact text of the question or item.                                                             |
+| `Levels`      | OPTIONAL    | Mapping of response values to their labels (for example, `{"0": "Not at all", "4": "Very often"}`). |
+| `MinValue`    | OPTIONAL    | Minimum expected value.                                                                             |
+| `MaxValue`    | OPTIONAL    | Maximum expected value.                                                                             |
+| `DataType`    | OPTIONAL    | Expected data type of the column (`"string"`, `"integer"`, or `"float"`).                           |
+| `Units`       | OPTIONAL    | Units, if applicable.                                                                               |
 
 ## Example dataset structure
 

--- a/src/modality-specific-files/survey.md
+++ b/src/modality-specific-files/survey.md
@@ -30,8 +30,12 @@ once within a session.
 
 ## Sidecar JSON (`*_survey.json`)
 
-Each survey `.tsv` file MUST be accompanied by a JSON sidecar with the same
-filename stem.
+Each survey `.tsv` file MUST be accompanied by a JSON sidecar.
+Following the [Inheritance Principle](../common-principles.md#the-inheritance-principle),
+the sidecar MAY be placed at any level of the hierarchy
+(for example, at the dataset root as `task-<label>_survey.json`)
+to apply to all survey files with matching entities,
+or alongside individual `.tsv` files with the same filename stem.
 The sidecar documents the instrument-level metadata and the individual items.
 
 ### Instrument metadata
@@ -47,12 +51,12 @@ administration context.
 | `FileFormat`           | REQUIRED    | MUST be `"tsv"`.                                                                                     |
 | `Language`             | REQUIRED    | Language code for the administered version (for example, `"en"`, `"de-AT"`).                         |
 | `Respondent`           | REQUIRED    | Who provided the responses (`"self"`, `"clinician"`, `"parent"`, or similar).                        |
-| `ShortName`            | OPTIONAL    | Common abbreviation of the instrument (for example, `"PSS-10"`).                                     |
+| `ShortName`            | OPTIONAL    | Common abbreviation of the instrument (for example, `"ESQ-3"`).                                      |
 | `Version`              | OPTIONAL    | Version or edition of the instrument.                                                                |
 | `Authors`              | OPTIONAL    | Array of instrument authors.                                                                         |
 | `DOI`                  | OPTIONAL    | DOI for the instrument or its primary validation paper.                                              |
 | `License`              | OPTIONAL    | License under which the instrument may be used.                                                      |
-| `Construct`            | OPTIONAL    | Psychological or clinical construct measured (for example, `"perceived stress"`).                    |
+| `Construct`            | OPTIONAL    | Psychological or clinical construct measured (for example, `"sleep quality"`).                       |
 | `Instructions`         | OPTIONAL    | Instructions given to the participant.                                                               |
 | `AdministrationMethod` | OPTIONAL    | How the instrument was administered (`"online"`, `"paper"`, `"interview"`, `"phone"`, or `"mixed"`). |
 | `SoftwarePlatform`     | OPTIONAL    | Software used to administer the instrument (for example, `"LimeSurvey"`, `"REDCap"`).                |
@@ -78,67 +82,68 @@ listed above is treated as a column-level variable definition (for example, `"Q0
 study/
 ├── dataset_description.json
 ├── participants.tsv
+├── task-sleep_survey.json
 ├── sub-01/
 │   ├── ses-baseline/
 │   │   └── survey/
-│   │       ├── sub-01_ses-baseline_task-pss_run-01_survey.tsv
-│   │       └── sub-01_ses-baseline_task-pss_run-01_survey.json
+│   │       └── sub-01_ses-baseline_task-sleep_run-01_survey.tsv
 │   └── ses-week04/
 │       └── survey/
-│           ├── sub-01_ses-week04_task-pss_run-01_survey.tsv
-│           ├── sub-01_ses-week04_task-pss_run-01_survey.json
-│           ├── sub-01_ses-week04_task-pss_run-02_survey.tsv
-│           └── sub-01_ses-week04_task-pss_run-02_survey.json
+│           ├── sub-01_ses-week04_task-sleep_run-01_survey.tsv
+│           └── sub-01_ses-week04_task-sleep_run-02_survey.tsv
 └── phenotype/
-    └── pss_summary.tsv
+    └── sleep_summary.tsv
 ```
 
-The `phenotype/` entry in this example is an optional aggregated downstream
-view of the subject-resolved survey data.
+The root-level `task-sleep_survey.json` applies to all `task-sleep` survey files
+through the inheritance principle, avoiding duplication across sessions and runs.
+The `phenotype/` entry is an optional aggregated downstream view of the subject-resolved survey data.
 
 ## Example `*_survey.tsv`
 
 ```tsv
 participant_id	Q01	Q02	Q03
-sub-01	2	1	3
+sub-01	7	4	0
 ```
 
-## Example `*_survey.json`
+## Example `task-sleep_survey.json`
 
 ```json
 {
-  "TaskName": "pss",
-  "OriginalName": "Perceived Stress Scale",
-  "ShortName": "PSS-10",
+  "TaskName": "sleep",
+  "OriginalName": "Example Sleep Questionnaire",
+  "ShortName": "ESQ-3",
   "StimulusType": "Questionnaire",
   "FileFormat": "tsv",
   "Language": "en",
   "Respondent": "self",
   "AdministrationMethod": "online",
   "Q01": {
-    "Description": "In the last month, how often have you been upset because of something that happened unexpectedly?",
-    "Levels": {
-      "0": "Never",
-      "1": "Almost never",
-      "2": "Sometimes",
-      "3": "Fairly often",
-      "4": "Very often"
-    },
+    "Description": "How many hours did you sleep last night?",
     "MinValue": 0,
-    "MaxValue": 4,
-    "DataType": "integer"
+    "MaxValue": 24,
+    "DataType": "float",
+    "Units": "h"
   },
   "Q02": {
-    "Description": "In the last month, how often have you felt that you were unable to control the important things in your life?",
+    "Description": "How would you rate your overall sleep quality?",
     "Levels": {
-      "0": "Never",
-      "1": "Almost never",
-      "2": "Sometimes",
-      "3": "Fairly often",
-      "4": "Very often"
+      "1": "Very poor",
+      "2": "Poor",
+      "3": "Fair",
+      "4": "Good",
+      "5": "Very good"
     },
-    "MinValue": 0,
-    "MaxValue": 4,
+    "MinValue": 1,
+    "MaxValue": 5,
+    "DataType": "integer"
+  },
+  "Q03": {
+    "Description": "Did you wake up during the night?",
+    "Levels": {
+      "0": "No",
+      "1": "Yes"
+    },
     "DataType": "integer"
   }
 }

--- a/src/schema/objects/datatypes.yaml
+++ b/src/schema/objects/datatypes.yaml
@@ -76,3 +76,9 @@ nirs:
   value: nirs
   display_name: Near-Infrared Spectroscopy
   description: Near-Infrared Spectroscopy data organized around the SNIRF format
+survey:
+  value: survey
+  display_name: Survey data
+  description: |
+    Structured instrument-based phenotypic data (questionnaires and assessment
+    instruments) organized in a subject- and session-resolved directory hierarchy.

--- a/src/schema/objects/modalities.yaml
+++ b/src/schema/objects/modalities.yaml
@@ -42,3 +42,7 @@ nirs:
 mrs:
   display_name: Magnetic Resonance Spectroscopy
   description: Data acquired with MRS.
+survey:
+  display_name: Survey
+  description: |
+    Data collected with standardized questionnaires or assessment instruments.

--- a/src/schema/objects/suffixes.yaml
+++ b/src/schema/objects/suffixes.yaml
@@ -891,6 +891,14 @@ uCT:
   display_name: Micro-CT
   description: |
     Micro-CT imaging data
+survey:
+  value: survey
+  display_name: Survey
+  description: |
+    Instrument-based phenotypic survey data.
+    Responses collected from a structured questionnaire or assessment instrument,
+    organized as subject- and session-resolved tabular data with a corresponding
+    JSON sidecar.
 unloc:
   value: unloc
   display_name: Unlocalized spectroscopy

--- a/src/schema/rules/files/raw/survey.yaml
+++ b/src/schema/rules/files/raw/survey.yaml
@@ -1,0 +1,11 @@
+---
+# Instrument-based phenotypic survey data
+survey:
+  $ref: meta.templates.raw.task
+  suffixes:
+    - survey
+  extensions:
+    - .tsv
+    - .json
+  datatypes:
+    - survey

--- a/src/schema/rules/modalities.yaml
+++ b/src/schema/rules/modalities.yaml
@@ -37,3 +37,6 @@ nirs:
 mrs:
   datatypes:
     - mrs
+survey:
+  datatypes:
+    - survey


### PR DESCRIPTION
## Summary

This PR proposes adding schema support for structured instrument-based survey data as a valid BIDS representation, organized in the same subject-, session-, and run-resolved way as other BIDS modalities.

The goal is not to replace aggregated tabular phenotypic data. It is to complement them with a canonical acquisition-facing structure that preserves provenance, timing, and instrument context, while still allowing aggregated tables to be generated later when needed.

A working reference implementation already exists in [PRISM Studio](https://github.com/MRI-Lab-Graz/prism-studio), with documentation at [prism-studio.readthedocs.io](https://prism-studio.readthedocs.io/).

## Rationale

BIDS is strongest when its canonical structures reflect how data are actually acquired. For imaging, physio, events, and other modalities, the normative pattern is a subject-resolved structure first, with higher-level summaries and
derivatives produced later.

Instrument-based phenotypic data fit this same pattern. Treating `phenotype/` as the only primary home for those data flattens acquisition context at the point where BIDS usually preserves it.

A structured survey modality would:

- preserve provenance and administration context,
- support repeated assessments across sessions and runs,
- keep sidecar metadata next to the corresponding data files, and
- still allow aggregated phenotype tables to be generated later.

That direction is structurally stronger because aggregated tables can be written from a structured survey layout with little ambiguity, whereas reconstructing the original structure from only an aggregate table often requires extra
assumptions.

## Proposed Changes

This PR implements a minimal but complete first pass:

| File | What changed |
|---|---|
| `src/modality-specific-files/survey.md` | New documentation page: file naming conventions, sidecar structure, instrument-level and item-level field tables, worked dataset structure and JSON/TSV examples |
| `src/schema/objects/datatypes.yaml` | Added `survey` datatype |
| `src/schema/objects/modalities.yaml` | Added `survey` modality |
| `src/schema/objects/suffixes.yaml` | Added `survey` suffix |
| `src/schema/rules/files/raw/survey.yaml` | New file rule using `task` entity template; `.tsv` and `.json` extensions |
| `src/schema/rules/modalities.yaml` | Mapped `survey` modality → `survey` datatype |
| `mkdocs.yml` | Added navigation entry |

## Example Structure

Below is the subject-, session-, and run-resolved structure this PR supports. A root-level sidecar applies to all matching files via the [Inheritance Principle](https://bids-specification.readthedocs.io/en/stable/common-principles.html#the-inheritance-principle), avoiding duplication across sessions and runs. Per-file sidecars remain valid when instrument versions or languages differ between sessions.

```
study/
├── dataset_description.json
├── participants.tsv
├── task-pss_survey.json          ← shared sidecar via inheritance
├── sub-01/
│   ├── ses-baseline/
│   │   └── survey/
│   │       └── sub-01_ses-baseline_task-pss_run-01_survey.tsv
│   └── ses-week04/
│       └── survey/
│           ├── sub-01_ses-week04_task-pss_run-01_survey.tsv
│           └── sub-01_ses-week04_task-pss_run-02_survey.tsv
└── phenotype/
    └── pss_summary.tsv           ← optional aggregated downstream view
```

The `phenotype/` directory in this example is deliberate. It shows that aggregated outputs remain compatible with this proposal, but they are downstream views of structured data rather than the only canonical form.

## Reference Implementation

This proposal is grounded in an existing toolchain rather than a purely abstract design discussion:

- [PRISM Studio repository](https://github.com/MRI-Lab-Graz/prism-studio)
- [PRISM Studio documentation](https://prism-studio.readthedocs.io/)
- [Survey import template](https://github.com/MRI-Lab-Graz/prism-studio/blob/main/docs/examples/survey_import_template.xlsx)
- [Survey schema and modality schemas](https://github.com/MRI-Lab-Graz/prism-studio/tree/main/app/schemas)
- [Template validation documentation](https://github.com/MRI-Lab-Graz/prism-studio/blob/main/docs/TEMPLATE_VALIDATION.md)
- [Dataset validation documentation](https://github.com/MRI-Lab-Graz/prism-studio/blob/main/docs/VALIDATOR.md)

These references show that the proposed structure is already practical for curation, metadata authoring, template-based reuse, and validation.

## Scope

This PR does not propose removing aggregated phenotype tables. It proposes that BIDS should also recognize a canonical modality-style structure for instrument-based phenotypic data, especially when those data are acquired repeatedly across sessions and runs.

## Questions for Reviewers

- Should instrument-based phenotypic data be representable in a subject-, session-, and run-resolved modality structure in the schema?
- If so, should `phenotype/` remain an optional aggregate or derived representation rather than the only primary representation?
- Is `survey` the right directory and suffix label, or should the working group prefer another term such as `pheno`, `assess`, `form`, `inst`, or `meas`?
- The current sidecar spec uses the `task` entity to identify the instrument (e.g. `task-pss`). Should a dedicated `instrument` entity be considered instead?
- The sidecar fields (`TaskName`, `OriginalName`, `StimulusType`, `Respondent`, etc.) follow existing BIDS conventions — are there missing fields, or any that should move between REQUIRED and OPTIONAL?
