### PR TITLE
[ENH] Allow rawbids/ in derivative datasets for the raw BIDS source

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -369,9 +369,14 @@ Derivatives can be stored/distributed in two ways:
     dataset is provided with read-only access, for publishing derivatives as
     independent bodies of work, or for describing derivatives that were created
     from more than one source dataset.
-    The `sourcedata/` subdirectory MAY be used to include the source dataset(s)
-    that were used to generate the derivatives.
-    Likewise, any code used to generate the derivatives from the source data
+    If the source is a raw BIDS dataset,
+    it MAY be included under the `rawbids/` subdirectory (see [Study dataset](#study-dataset) for the same convention used at the study level).
+    The `sourcedata/` subdirectory MAY be used to include any other source dataset(s)
+    used to generate the derivatives, including non-BIDS sources and derived BIDS datasets.
+    In particular, derivatives of derivatives MUST place their source derivative
+    dataset(s) under `sourcedata/`, not `rawbids/`,
+    since `rawbids/` is reserved for raw BIDS datasets.
+    Any code used to generate the derivatives from the source data
     MAY be included in the `code/` subdirectory.
     Extra documentation (and relevant images) MAY be included in the `docs/` subdirectory.
     Logs from running the code or other commands MAY be stored under `logs/` subdirectory.
@@ -390,12 +395,11 @@ Derivatives can be stored/distributed in two ways:
                 "hpc_submitter.sh": "",
                 "...": "",
             },
-            "sourcedata": {
-                "raw": {
-                    "sub-01": {},
-                    "sub-02": {},
-                    "...": "",
-                },
+            "rawbids": {
+                "sub-01": {},
+                "sub-02": {},
+                "...": "",
+                "dataset_description.json": "",
             },
             "sub-01": {},
             "sub-02": {},
@@ -463,6 +467,9 @@ A guide for using macros can be found at
 ) }}
 
 In this example, `sourcedata`, `rawbids`, and `derivatives` are top-level directories. **Only the `rawbids` directory** is a BIDS-compliant dataset.
+The `rawbids/` subdirectory is reserved for the raw BIDS dataset
+(the same convention applies inside a `derivative` dataset when its source is a raw BIDS dataset;
+see [Storage of derived datasets](#storage-of-derived-datasets)).
 The subdirectories of `derivatives` MAY be BIDS-compliant derivatives datasets
 (see [Non-compliant derivatives](#non-compliant-derivatives) for further discussion).
 The above example is a fully compliant BIDS dataset, providing a convention useful for organizing source, raw BIDS, and derived BIDS data

--- a/src/schema/rules/directories.yaml
+++ b/src/schema/rules/directories.yaml
@@ -118,6 +118,7 @@ derivative:
     subdirs:
       - code
       - docs
+      - rawbids
       - derivatives
       - logs
       - phenotype
@@ -137,6 +138,10 @@ derivative:
       - datatype
   docs:
     name: docs
+    level: optional
+    opaque: true
+  rawbids:
+    name: rawbids
     level: optional
     opaque: true
   derivatives:


### PR DESCRIPTION
PR #2191 added rawbids/ to the study DatasetType but not to derivative, even though the same convention -- "rawbids/ holds the raw BIDS dataset" -- is equally applicable when a standalone derivative dataset includes its raw source.  I think everyone was just too tired and ready to move on with their lives, thus missed that omission, although the wise @effigies [said in his final word](https://github.com/bids-standard/bids-specification/pull/2191#issuecomment-4225841301)

> Finally, for the sake of consistency, rawbids/ is permitted for derivative datasets, while it is not meaningful for raw datasets.

but we (attn @julia-pfarr @nikhil153) all missed that it was not defined for the `derivative` datasets.  Here me and claude are addressing that:

- Add rawbids as an optional opaque subdirectory of the derivative DatasetType in src/schema/rules/directories.yaml.
- Update the derivative example in common-principles.md to use rawbids/ instead of sourcedata/raw/.
- Clarify that rawbids/ is reserved for raw BIDS datasets in both study and derivative cases, and that derivatives of derivatives MUST place their source derivative under sourcedata/ (not rawbids/).

Marking it for the same milestone as the #2191