### PR TITLE
[SCHEMA][BUG] add error handling for non-existent schema dir

### DIFF
--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -247,10 +247,9 @@ def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
         return Namespace.from_json(schema_path.read_text())
 
     # YAML directory: load, dereference and set versions
-    if Path(schema_path).exists() and Path(schema_path).is_dir():
-        schema = Namespace.from_directory(schema_path)
-    else:
+    if not schema_path.is_dir():
         raise FileNotFoundError(f"schema path {schema_path} is not a folder or does not exist")
+    schema = Namespace.from_directory(schema_path)
     if not schema.objects:
         raise ValueError(f"objects subdirectory path not found in {schema_path}")
     if not schema.rules:

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -248,7 +248,7 @@ def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
 
     # YAML directory: load, dereference and set versions
     if not schema_path.is_dir():
-        raise FileNotFoundError(f"schema path {schema_path} is not a folder or does not exist")
+        raise FileNotFoundError(f"schema path {schema_path} is not a directory or does not exist")
     schema = Namespace.from_directory(schema_path)
     if not schema.objects:
         raise ValueError(f"objects subdirectory path not found in {schema_path}")

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -247,7 +247,10 @@ def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
         return Namespace.from_json(schema_path.read_text())
 
     # YAML directory: load, dereference and set versions
-    schema = Namespace.from_directory(schema_path)
+    if Path(schema_path).exists() and Path(schema_path).is_dir():
+        schema = Namespace.from_directory(schema_path)
+    else:
+        raise FileNotFoundError(f"schema path {schema_path} is not a folder or does not exist")
     if not schema.objects:
         raise ValueError(f"objects subdirectory path not found in {schema_path}")
     if not schema.rules:

--- a/tools/schemacode/src/bidsschematools/schema.py
+++ b/tools/schemacode/src/bidsschematools/schema.py
@@ -248,7 +248,7 @@ def load_schema(schema_path: lt.Traversable | str | None = None) -> Namespace:
 
     # YAML directory: load, dereference and set versions
     if not schema_path.is_dir():
-        raise FileNotFoundError(f"schema path {schema_path} is not a directory or does not exist")
+        raise FileNotFoundError(f"schema path {schema_path} is not a file or directory")
     schema = Namespace.from_directory(schema_path)
     if not schema.objects:
         raise ValueError(f"objects subdirectory path not found in {schema_path}")


### PR DESCRIPTION
Caught this while trying to retrieve the schema from a non-existence source with pybids, but it should be handled here too.

```python
 self = HTTPPath('https://bids-specification.readthedocs.io/en/v99.99.99/schema.json', protocol='https')
  
      def iterdir(self) -> Iterator[Self]:
          """Yield path objects of the directory contents.
      
          Examples
          --------
          >>> from upath import UPath
          >>> p = UPath("memory:///foo/")
          >>> p.joinpath("bar.txt").touch()
          >>> p.joinpath("baz.txt").touch()
          >>> for child in p.iterdir():
          ...     print(child)
          MemoryPath('memory:///foo/bar.txt')
          MemoryPath('memory:///foo/baz.txt')
      
          """
          sep = self.parser.sep
          base = self
          if self.parts[-1:] == ("",):
              base = self.parent
          fs = base.fs
          base_path = base.path
          if not fs.isdir(base_path):
  >           raise NotADirectoryError(str(self))
  E           NotADirectoryError: https://bids-specification.readthedocs.io/en/v99.99.99/schema.json
  
  .tox/py312-full/lib/python3.12/site-packages/upath/core.py:1228: NotADirectoryError
  
  During handling of the above exception, another exception occurred:
  
  self = <bids.layout.tests.test_schema_config.TestSchemaConfig object at 0x10a39b530>
  
      def test_invalid_schema_version(self):
          """Test that loading invalid schema version raises appropriate error."""
          # Test with a non-existent version
          with pytest.raises(ValueError):
  >           Config.load({'schema_version': '99.99.99'})
  
  src/bids/layout/tests/test_schema_config.py:74: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  src/bids/layout/models.py:230: in load
      return cls._from_schema(
  src/bids/layout/models.py:283: in _from_schema
      bids_schema = collect_schema(bids_version=bids_version)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  src/bids/utils.py:394: in collect_schema
      schema = load_schema(Path(uri))
               ^^^^^^^^^^^^^^^^^^^^^^
  .tox/py312-full/lib/python3.12/site-packages/bidsschematools/schema.py:250: in load_schema
      schema = Namespace.from_directory(schema_path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  .tox/py312-full/lib/python3.12/site-packages/bidsschematools/types/namespace.py:265: in from_directory
      return cls.build(_read_yaml_dir(path))
                       ^^^^^^^^^^^^^^^^^^^^
  .tox/py312-full/lib/python3.12/site-packages/bidsschematools/types/namespace.py:278: in _read_yaml_dir
      for subpath in sorted(path.iterdir(), key=lambda p: p.name):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  self = HTTPPath('https://bids-specification.readthedocs.io/en/v99.99.99/schema.json', protocol='https')
  
      def iterdir(self) -> Iterator[Self]:
          it = iter(super().iterdir())
          try:
              item0 = next(it)
          except (StopIteration, NotADirectoryError):
  >           raise NotADirectoryError(str(self))
  E           NotADirectoryError: https://bids-specification.readthedocs.io/en/v99.99.99/schema.json
  
  .tox/py312-full/lib/python3.12/site-packages/upath/implementations/http.py:87: NotADirectoryError
```
