### PR TITLE
[SCHEMA] Restrict sidecar-keyed MRI rules to .nii/.nii.gz files

### DIFF
--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -151,6 +151,8 @@ ASLMRISequenceSpecifics:
 
 MTParameters:
   selectors:
+    - modality == "mri"
+    - match(extension, "^\.nii(\.gz)?$")
     - sidecar.MTState == true
   fields:
     MTOffsetFrequency: recommended
@@ -161,18 +163,24 @@ MTParameters:
 
 SpoilingType:
   selectors:
+    - modality == "mri"
+    - match(extension, "^\.nii(\.gz)?$")
     - sidecar.SpoilingState == true
   fields:
     SpoilingType: recommended
 
 SpoilingRF:
   selectors:
+    - modality == "mri"
+    - match(extension, "^\.nii(\.gz)?$")
     - intersects([sidecar.SpoilingType], ["RF", "COMBINED"])
   fields:
     SpoilingRFPhaseIncrement: recommended
 
 SpoilingGradient:
   selectors:
+    - modality == "mri"
+    - match(extension, "^\.nii(\.gz)?$")
     - intersects([sidecar.SpoilingType], ["GRADIENT", "COMBINED"])
   fields:
     SpoilingGradientMoment: recommended


### PR DESCRIPTION
[PR1016](https://github.com/bids-standard/bids-specification/pull/1016) introduced MTParameters, SpoilingType, SpoilingRF, and SpoilingGradient in mri.yaml. However, they have no modality or extension filters. As a result every file in a group that inherits the sidecar trips the rule. For example, a DWI group with .nii.gz + .bval + .bvec emits the same SIDECAR_KEY_RECOMMENDED warning three times for one missing field. This is particularly unfortunate, as while these parameters may be relevant for qMRI they are not relevant for DWI.

This PR adopts the minimal solution by adding `modality == "mri"` + `match(extension, "^\.nii(\.gz)?$")` to each of the four rules, matching the filter used by similar rules such as MRISequenceSpecifics.

One could further reduce the number of false positives generated by the bids-validator by restricting these recommendations for qmri images. For example:

```
SpoilingType:
  selectors:
    - modality == "mri"
    - match(extension, "^\.nii(\.gz)?$")
    - intersects([suffix], ["VFA", "IRT1", "MP2RAGE", "MESE", "MEGRE",
                            "MTR", "MTS", "MPM",
                            "TB1DAM", "TB1EPI", "TB1AFI", "TB1SRGE"])
    - sidecar.SpoilingState == true
  fields:
    SpoilingType: recommended
  ```