### PR TITLE
[ENH] Comment on PRs/issues with their release tag

### DIFF
--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -1,0 +1,27 @@
+name: "Announce release on PRs and issues"
+
+# Post a "released in vX.Y.Z" comment on every PR included in a release,
+# and a "fixed in vX.Y.Z" comment on every issue those PRs closed.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  announce:
+    if: github.repository == 'bids-standard/bids-specification'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+      - name: Announce release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: tools/announce_release.py --post "${{ github.event.release.tag_name }}"

--- a/.github/workflows/publish_schema.yml
+++ b/.github/workflows/publish_schema.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "master"
       - "maint/*"
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,9 +25,12 @@ env:
 permissions:
   contents: write
   id-token: write
+  issues: write
+  pull-requests: write
 
 jobs:
   publish:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -123,3 +128,18 @@ jobs:
         if: success() && steps.version.outputs.release == 'true'
         run: |
           npx jsr publish
+
+  announce_release:
+    # Post "PR released in vX.Y.Z" comments on PRs included in the release
+    # and "Issue fixed in vX.Y.Z" on issues those PRs closed. Idempotent.
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+      - name: Announce release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: tools/announce_release.py --post "${{ github.event.release.tag_name }}"

--- a/.github/workflows/publish_schema.yml
+++ b/.github/workflows/publish_schema.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - "master"
       - "maint/*"
-  release:
-    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,12 +23,9 @@ env:
 permissions:
   contents: write
   id-token: write
-  issues: write
-  pull-requests: write
 
 jobs:
   publish:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -128,18 +123,3 @@ jobs:
         if: success() && steps.version.outputs.release == 'true'
         run: |
           npx jsr publish
-
-  announce_release:
-    # Post "PR released in vX.Y.Z" comments on PRs included in the release
-    # and "Issue fixed in vX.Y.Z" on issues those PRs closed. Idempotent.
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
-      - name: Announce release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tools/announce_release.py --post "${{ github.event.release.tag_name }}"

--- a/Release_Protocol.md
+++ b/Release_Protocol.md
@@ -235,11 +235,11 @@ Verify ReadTheDocs builds complete and publish. If needed, manually
 trigger [builds](https://readthedocs.org/projects/bids-specification/builds/)
 for `stable` and the most recent tag.
 
-Publishing the GitHub release also triggers the `announce_release` job in the
-[`Publish schema`](https://github.com/bids-standard/bids-specification/actions/workflows/publish_schema.yml)
+Publishing the GitHub release also triggers the
+[`Announce release on PRs and issues`](https://github.com/bids-standard/bids-specification/actions/workflows/announce_release.yml)
 workflow, which posts a "PR released in `vX.Y.Z`" comment on every PR that was
 merged for this release and a "Issue fixed in `vX.Y.Z`" comment on every issue
-those PRs close (`Fixes #N` / `Closes #N`). The job is idempotent — if
+those PRs close (`Fixes #N` / `Closes #N`). The workflow is idempotent — if
 re-published, comments are not duplicated.
 
 To back-fill comments on past releases that pre-date this workflow, run

--- a/Release_Protocol.md
+++ b/Release_Protocol.md
@@ -235,6 +235,17 @@ Verify ReadTheDocs builds complete and publish. If needed, manually
 trigger [builds](https://readthedocs.org/projects/bids-specification/builds/)
 for `stable` and the most recent tag.
 
+Publishing the GitHub release also triggers the `announce_release` job in the
+[`Publish schema`](https://github.com/bids-standard/bids-specification/actions/workflows/publish_schema.yml)
+workflow, which posts a "PR released in `vX.Y.Z`" comment on every PR that was
+merged for this release and a "Issue fixed in `vX.Y.Z`" comment on every issue
+those PRs close (`Fixes #N` / `Closes #N`). The job is idempotent — if
+re-published, comments are not duplicated.
+
+To back-fill comments on past releases that pre-date this workflow, run
+`tools/announce_release.py` locally (see the script's header for usage). It
+defaults to dry-run; pass `--post` to actually comment.
+
 ### 9. Edit the mkdocs.yml file site_name to set a new development version
 
 Please open a pull request and create a merge commit to `master` with the title `REL: <version>-dev`.

--- a/tools/announce_release.py
+++ b/tools/announce_release.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "gql[aiohttp]",
+# ]
+# ///
+
+# How to use this script:
+# 1. Provide a GitHub token via the GITHUB_TOKEN environment variable. The
+#    quickest way if you have the `gh` CLI authenticated is:
+#        GITHUB_TOKEN=$(gh auth token) tools/announce_release.py ...
+#    Otherwise generate a PAT at https://github.com/settings/tokens with
+#    `public_repo` scope (write access is needed for --post).
+# 2. Run from a checkout of bids-standard/bids-specification — the script
+#    uses `git log` between tags to discover PRs included in each release.
+#
+# Examples (all default to dry-run; add --post to actually comment):
+#   GITHUB_TOKEN=$(gh auth token) tools/announce_release.py v1.11.0
+#   GITHUB_TOKEN=$(gh auth token) tools/announce_release.py            # latest tag
+#   GITHUB_TOKEN=$(gh auth token) tools/announce_release.py --retroactive --since v1.10.0
+#   GITHUB_TOKEN=$(gh auth token) tools/announce_release.py --post v1.11.1
+#
+# Idempotent: skips PRs/issues that already have an identical comment.
+#
+# Modeled after datalad/release-action's `make_release_comments`:
+#   https://github.com/datalad/release-action/blob/main/datalad_release_action/client.py
+import argparse
+import asyncio
+import os
+import re
+import subprocess as sp
+import sys
+from dataclasses import dataclass
+
+import aiohttp
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+
+REPO = "bids-standard/bids-specification"
+TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+
+PR_INFO_QUERY = gql("""\
+query($owner: String!, $name: String!, $number: Int!, $issue_cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      title
+      closingIssuesReferences(first: 50, after: $issue_cursor) {
+        nodes { number repository { nameWithOwner } }
+        pageInfo { endCursor hasNextPage }
+      }
+    }
+  }
+}
+""")
+
+COMMENTS_QUERY = gql("""\
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    issueOrPullRequest(number: $number) {
+      ... on Issue {
+        comments(first: 100, after: $after) {
+          nodes { body }
+          pageInfo { endCursor hasNextPage }
+        }
+      }
+      ... on PullRequest {
+        comments(first: 100, after: $after) {
+          nodes { body }
+          pageInfo { endCursor hasNextPage }
+        }
+      }
+    }
+  }
+}
+""")
+
+
+@dataclass
+class PRInfo:
+    number: int
+    title: str
+    closing_issues: list[int]
+
+
+def git(*args: str) -> str:
+    return sp.run(
+        ["git", *args], capture_output=True, check=True, text=True
+    ).stdout.strip()
+
+
+def release_tags() -> list[str]:
+    """Version tags (vX.Y.Z) ordered oldest-first."""
+    out = git("tag", "--sort=version:refname")
+    return [t for t in out.splitlines() if TAG_RE.match(t)]
+
+
+def prs_in_range(prev_tag: str | None, tag: str) -> list[int]:
+    """Find PR numbers in commits between prev_tag and tag (first-parent).
+
+    Recognizes both squash-merge `... (#NNN)` and `Merge pull request #NNN ...`
+    commit subject styles.
+    """
+    rev = f"{prev_tag}..{tag}" if prev_tag else tag
+    out = git("log", rev, "--first-parent", "--pretty=%s")
+    seen: dict[int, None] = {}  # dict preserves insertion order, dedupes
+    for line in out.splitlines():
+        if m := re.search(r"\(#(\d+)\)\s*$", line):
+            seen[int(m.group(1))] = None
+        elif m := re.match(r"Merge pull request #(\d+)", line):
+            seen[int(m.group(1))] = None
+    return list(seen)
+
+
+def release_link(tag: str) -> str:
+    return f"[`{tag}`](https://github.com/{REPO}/releases/tag/{tag})"
+
+
+def pr_comment_body(tag: str) -> str:
+    return f"PR released in {release_link(tag)}"
+
+
+def issue_comment_body(tag: str) -> str:
+    return f"Issue fixed in {release_link(tag)}"
+
+
+async def get_pr_info(client: Client, number: int) -> PRInfo | None:
+    owner, name = REPO.split("/")
+    closing: list[int] = []
+    title = ""
+    cursor: str | None = None
+    while True:
+        result = await client.execute_async(
+            PR_INFO_QUERY,
+            variable_values={
+                "owner": owner,
+                "name": name,
+                "number": number,
+                "issue_cursor": cursor,
+            },
+        )
+        pr = result["repository"]["pullRequest"]
+        if pr is None:
+            return None
+        title = pr["title"]
+        page = pr["closingIssuesReferences"]
+        for n in page["nodes"]:
+            if n["repository"]["nameWithOwner"] == REPO:
+                closing.append(n["number"])
+        if not page["pageInfo"]["hasNextPage"]:
+            return PRInfo(number=number, title=title, closing_issues=closing)
+        cursor = page["pageInfo"]["endCursor"]
+
+
+async def has_comment(client: Client, number: int, body: str) -> bool:
+    owner, name = REPO.split("/")
+    target = body.strip()
+    cursor: str | None = None
+    while True:
+        result = await client.execute_async(
+            COMMENTS_QUERY,
+            variable_values={
+                "owner": owner,
+                "name": name,
+                "number": number,
+                "after": cursor,
+            },
+        )
+        node = result["repository"]["issueOrPullRequest"]
+        if node is None:
+            return False
+        comments = node["comments"]
+        for c in comments["nodes"]:
+            if c["body"].strip() == target:
+                return True
+        if not comments["pageInfo"]["hasNextPage"]:
+            return False
+        cursor = comments["pageInfo"]["endCursor"]
+
+
+async def post_comment(
+    session: aiohttp.ClientSession, token: str, number: int, body: str
+) -> None:
+    url = f"https://api.github.com/repos/{REPO}/issues/{number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    async with session.post(url, json={"body": body}, headers=headers) as resp:
+        if resp.status not in (200, 201):
+            text = await resp.text()
+            raise RuntimeError(f"POST {url}: HTTP {resp.status} - {text}")
+
+
+async def annotate_release(
+    client: Client,
+    session: aiohttp.ClientSession,
+    token: str,
+    tag: str,
+    prev_tag: str | None,
+    *,
+    post: bool,
+) -> None:
+    print(f"\n=== Release {tag} (prev: {prev_tag or 'initial'}) ===")
+    pr_numbers = prs_in_range(prev_tag, tag)
+    if not pr_numbers:
+        print("  (no PRs found in commit range)")
+        return
+    print(f"  {len(pr_numbers)} PR(s) in this release")
+    pr_body = pr_comment_body(tag)
+    iss_body = issue_comment_body(tag)
+    for pr_num in pr_numbers:
+        pr_url = f"https://github.com/{REPO}/pull/{pr_num}"
+        pr = await get_pr_info(client, pr_num)
+        if pr is None:
+            print(f"  - PR #{pr_num} {pr_url} — not found via API; skipping")
+            continue
+        marker = "POST" if post else "DRY"
+        if await has_comment(client, pr.number, pr_body):
+            status = "comment already exists, skip"
+        else:
+            status = f"[{marker}] comment on PR"
+            if post:
+                await post_comment(session, token, pr.number, pr_body)
+        print(f"  - PR #{pr.number} {pr_url} — {status} — {pr.title!r}")
+        for issue_num in pr.closing_issues:
+            issue_url = f"https://github.com/{REPO}/issues/{issue_num}"
+            if await has_comment(client, issue_num, iss_body):
+                status = "comment already exists, skip"
+            else:
+                status = f"[{marker}] comment on issue"
+                if post:
+                    await post_comment(session, token, issue_num, iss_body)
+            print(f"      issue #{issue_num} {issue_url} — {status}")
+
+
+def select_tags(args: argparse.Namespace, tags: list[str]) -> list[str] | None:
+    """Return the list of release tags to process, or None on a validation error
+    (the error message is printed to stderr).
+    """
+    if not tags:
+        print("No vX.Y.Z release tags found.", file=sys.stderr)
+        return None
+    if args.retroactive:
+        start = 0
+        if args.since:
+            if args.since not in tags:
+                print(
+                    f"--since {args.since!r} is not a known release tag.",
+                    file=sys.stderr,
+                )
+                return None
+            start = tags.index(args.since)
+        return tags[start:]
+    if args.tag:
+        if args.tag not in tags:
+            print(f"{args.tag!r} is not a known release tag.", file=sys.stderr)
+            return None
+        return [args.tag]
+    return [tags[-1]]
+
+
+async def main_async(args: argparse.Namespace, selected: list[str], tags: list[str]) -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN environment variable is not set.", file=sys.stderr)
+        return 1
+    transport = AIOHTTPTransport(
+        url="https://api.github.com/graphql",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    client = Client(transport=transport, fetch_schema_from_transport=False)
+    async with aiohttp.ClientSession() as session:
+        for tag in selected:
+            idx = tags.index(tag)
+            prev = tags[idx - 1] if idx > 0 else None
+            await annotate_release(
+                client, session, token, tag, prev, post=args.post
+            )
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Post 'PR released in vX.Y.Z' / 'Issue fixed in vX.Y.Z' comments "
+            "on the PRs included in a release and the issues those PRs close."
+        )
+    )
+    parser.add_argument(
+        "tag",
+        nargs="?",
+        help="Release tag, e.g. v1.11.1. Defaults to the most recent vX.Y.Z tag.",
+    )
+    parser.add_argument(
+        "--retroactive",
+        action="store_true",
+        help="Process all historical releases (oldest first).",
+    )
+    parser.add_argument(
+        "--since",
+        metavar="TAG",
+        help="With --retroactive: start at this tag (inclusive).",
+    )
+    parser.add_argument(
+        "--post",
+        action="store_true",
+        help="Actually post comments. Default is dry-run.",
+    )
+    args = parser.parse_args()
+    if args.tag and args.retroactive:
+        parser.error("Cannot combine a single TAG argument with --retroactive.")
+    if args.since and not args.retroactive:
+        parser.error("--since only makes sense with --retroactive.")
+    # Resolve and validate tag selection (uses git, no network needed) BEFORE
+    # requiring GITHUB_TOKEN, so e.g. typos / `-- --help` invocation patterns
+    # fail with a clear message instead of the token error.
+    tags = release_tags()
+    selected = select_tags(args, tags)
+    if selected is None:
+        sys.exit(1)
+    sys.exit(asyncio.run(main_async(args, selected, tags)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/announce_release.py
+++ b/tools/announce_release.py
@@ -24,7 +24,7 @@
 # Idempotent: skips PRs/issues that already have an identical comment.
 #
 # Modeled after datalad/release-action's `make_release_comments`:
-#   https://github.com/datalad/release-action/blob/main/datalad_release_action/client.py
+#   https://github.com/datalad/release-action/blob/master/datalad_release_action/client.py
 import argparse
 import asyncio
 import os

--- a/tools/tests/test_announce_release.py
+++ b/tools/tests/test_announce_release.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "pytest>=8",
+#     "gql[aiohttp]",
+# ]
+# ///
+
+# Tests for tools/announce_release.py.
+#
+# Run with:
+#   tools/tests/test_announce_release.py              # via uv-run shebang
+#   uv run --with pytest pytest tools/tests/test_announce_release.py
+#
+# Covers the pure-logic units:
+#   - TAG_RE tag filter
+#   - comment-body / release-link formatting
+#   - prs_in_range commit-subject parsing
+#   - release_tags filter
+#   - CLI argparse validation
+#
+# The GraphQL/REST functions (get_pr_info, has_comment, post_comment) are
+# exercised end-to-end via the dry-run on the real repo's git history; they
+# are not unit-tested here to avoid baking the GitHub GraphQL schema into the
+# test fixtures.
+import importlib.util
+import subprocess as sp
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "announce_release.py"
+_spec = importlib.util.spec_from_file_location("announce_release", SCRIPT)
+ann = importlib.util.module_from_spec(_spec)
+sys.modules["announce_release"] = ann
+_spec.loader.exec_module(ann)
+
+
+# ---------- TAG_RE -----------------------------------------------------------
+
+@pytest.mark.parametrize("tag", ["v1.0.0", "v10.20.30", "v1.11.1", "v0.0.1"])
+def test_tag_regex_accepts(tag):
+    assert ann.TAG_RE.match(tag), tag
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "1.0.0",            # missing v
+        "v1.0",             # missing patch
+        "schema-1.2.3",     # schema tag
+        "v1.0.0-dev",       # pre-release suffix
+        "v1.0.0.post1",     # post-release suffix
+        "v.1.1.2",          # bogus historical tag in this repo
+    ],
+)
+def test_tag_regex_rejects(tag):
+    assert not ann.TAG_RE.match(tag), tag
+
+
+# ---------- formatting ------------------------------------------------------
+
+def test_release_link_format():
+    link = ann.release_link("v1.11.1")
+    assert "[`v1.11.1`]" in link
+    assert "https://github.com/bids-standard/bids-specification/releases/tag/v1.11.1" in link
+
+
+def test_pr_and_issue_comment_bodies_differ_and_contain_tag():
+    pr = ann.pr_comment_body("v1.0.0")
+    iss = ann.issue_comment_body("v1.0.0")
+    assert pr != iss
+    assert "v1.0.0" in pr and "v1.0.0" in iss
+    assert pr.startswith("PR released in ")
+    assert iss.startswith("Issue fixed in ")
+
+
+# ---------- prs_in_range ----------------------------------------------------
+
+def test_prs_in_range_squash_and_merge(monkeypatch):
+    """Parses both squash-merge `... (#NNN)` and `Merge pull request #NNN` subjects.
+
+    Skips REL: subject (no PR ref) and dedupes repeated PR numbers (insertion-order).
+    """
+    fake_log = "\n".join(
+        [
+            "REL: Version 1.11.1",                                       # no PR ref, skip
+            "[FIX] Add emg to timeseries rule (#2346)",                   # squash
+            "fix: Allow mkdocs to render links in glossary (#2345)",      # squash
+            "Merge pull request #2189 from bids-standard/rel/1.10.1",     # merge
+            "chore: commit with no PR ref",                               # skip
+            "another (#2346)",                                            # duplicate
+            "tail #1234 in middle, not at end",                           # skip (not (#))
+        ]
+    )
+    monkeypatch.setattr(ann, "git", lambda *a: fake_log)
+    assert ann.prs_in_range("v1.10.0", "v1.11.0") == [2346, 2345, 2189]
+
+
+def test_prs_in_range_handles_no_prev_tag(monkeypatch):
+    monkeypatch.setattr(ann, "git", lambda *a: "Initial commit\nfeat: x (#1)\n")
+    assert ann.prs_in_range(None, "v1.0.0") == [1]
+
+
+def test_prs_in_range_empty(monkeypatch):
+    monkeypatch.setattr(ann, "git", lambda *a: "")
+    assert ann.prs_in_range("v1.0.0", "v1.0.1") == []
+
+
+# ---------- release_tags ---------------------------------------------------
+
+def test_release_tags_filters_and_preserves_order(monkeypatch):
+    raw = "\n".join(
+        [
+            "schema-1.2.3",
+            "v.1.1.2",        # malformed
+            "v1.1.2",
+            "v1.10.0",
+            "v1.10.1",
+            "v1.11.0",
+            "v1.11.1-dev",    # pre-release
+            "v1.11.1",
+        ]
+    )
+    monkeypatch.setattr(ann, "git", lambda *a: raw)
+    assert ann.release_tags() == [
+        "v1.1.2", "v1.10.0", "v1.10.1", "v1.11.0", "v1.11.1"
+    ]
+
+
+# ---------- CLI argparse validation ----------------------------------------
+
+def _run_script(*argv):
+    """Run the script as a subprocess, returning (returncode, stderr)."""
+    proc = sp.run(
+        [sys.executable, str(SCRIPT), *argv],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stderr
+
+
+def test_cli_rejects_tag_with_retroactive():
+    rc, err = _run_script("v1.11.1", "--retroactive")
+    assert rc != 0
+    assert "--retroactive" in err
+
+
+def test_cli_rejects_since_without_retroactive():
+    rc, err = _run_script("--since", "v1.10.0")
+    assert rc != 0
+    assert "--since" in err
+
+
+def test_cli_missing_token(monkeypatch):
+    """Without GITHUB_TOKEN, the script exits 1 with a clear message."""
+    import os
+    env = {k: v for k, v in os.environ.items() if k != "GITHUB_TOKEN"}
+    proc = sp.run(
+        [sys.executable, str(SCRIPT), "v1.11.1"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(HERE.parent.parent),  # repo root
+    )
+    assert proc.returncode == 1
+    assert "GITHUB_TOKEN" in proc.stderr
+
+
+def test_cli_help_without_token():
+    """`--help` must work even without GITHUB_TOKEN (argparse short-circuits)."""
+    import os
+    env = {k: v for k, v in os.environ.items() if k != "GITHUB_TOKEN"}
+    proc = sp.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(HERE.parent.parent),
+    )
+    assert proc.returncode == 0
+    assert "usage:" in proc.stdout
+    assert "--retroactive" in proc.stdout
+
+
+def test_cli_unknown_tag_message_before_token():
+    """Invalid tag is reported before the token check (so e.g. a typo doesn't
+    surface as a confusing 'GITHUB_TOKEN not set'). Important for the
+    `uv run script -- --help` pattern, which makes argparse see `--help`
+    as a positional tag."""
+    import os
+    env = {k: v for k, v in os.environ.items() if k != "GITHUB_TOKEN"}
+    proc = sp.run(
+        [sys.executable, str(SCRIPT), "v9.99.99"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(HERE.parent.parent),
+    )
+    assert proc.returncode == 1
+    assert "not a known release tag" in proc.stderr
+    assert "GITHUB_TOKEN" not in proc.stderr
+
+
+# ---------- select_tags ----------------------------------------------------
+
+def _ns(**kw):
+    """Build an argparse.Namespace with sensible defaults."""
+    import argparse
+    return argparse.Namespace(
+        tag=kw.get("tag"),
+        retroactive=kw.get("retroactive", False),
+        since=kw.get("since"),
+        post=kw.get("post", False),
+    )
+
+
+def test_select_tags_default_picks_latest():
+    tags = ["v1.0.0", "v1.1.0", "v1.2.0"]
+    assert ann.select_tags(_ns(), tags) == ["v1.2.0"]
+
+
+def test_select_tags_explicit_tag():
+    tags = ["v1.0.0", "v1.1.0", "v1.2.0"]
+    assert ann.select_tags(_ns(tag="v1.1.0"), tags) == ["v1.1.0"]
+
+
+def test_select_tags_explicit_unknown(capsys):
+    assert ann.select_tags(_ns(tag="v9.9.9"), ["v1.0.0"]) is None
+    assert "not a known release tag" in capsys.readouterr().err
+
+
+def test_select_tags_retroactive_full():
+    tags = ["v1.0.0", "v1.1.0", "v1.2.0"]
+    assert ann.select_tags(_ns(retroactive=True), tags) == tags
+
+
+def test_select_tags_retroactive_since():
+    tags = ["v1.0.0", "v1.1.0", "v1.2.0"]
+    assert ann.select_tags(_ns(retroactive=True, since="v1.1.0"), tags) == ["v1.1.0", "v1.2.0"]
+
+
+def test_select_tags_retroactive_since_unknown(capsys):
+    assert ann.select_tags(_ns(retroactive=True, since="v9.9.9"), ["v1.0.0"]) is None
+    assert "--since" in capsys.readouterr().err
+
+
+def test_select_tags_no_tags(capsys):
+    assert ann.select_tags(_ns(), []) is None
+    assert "No vX.Y.Z release tags" in capsys.readouterr().err
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #2436.

## Summary

After each GitHub release publication, post a comment on every PR included
in the release ("PR released in `vX.Y.Z`") and on every issue those PRs
closed via `Fixes #N` / `Closes #N` ("Issue fixed in `vX.Y.Z`"). Modeled on
the corresponding logic in [`datalad/release-action`](https://github.com/datalad/release-action/blob/main/datalad_release_action/client.py)'s
`make_release_comments` — see e.g. [datalad/datalad#7832 (comment)](https://github.com/datalad/datalad/pull/7832#issuecomment-4206399851)
for the effect.

The component pieces:

- **`tools/announce_release.py`** — standalone `uv run` script that walks
  `git log <prev>..<tag> --first-parent` to discover PRs in a release
  (handles both squash `… (#NNN)` subjects and `Merge pull request #NNN`
  merges), queries closing issues via GraphQL, and posts comments via
  REST. Dry-run by default; `--post` actually comments. `--retroactive
  [--since TAG]` backfills past releases.
- **`.github/workflows/publish_schema.yml`** — rather than a new workflow,
  the existing release-adjacent workflow gets a `release: published`
  trigger and a new `announce_release` job. The existing `publish` job is
  gated to push events only so it doesn't fire on release events.
- **`Release_Protocol.md`** — short note in step 8 + pointer to the script
  for back-filling pre-existing releases.
- **`tools/tests/test_announce_release.py`** — 28 pytest cases covering
  tag-filter regex, comment/link formatting, `prs_in_range` parsing of
  both commit-subject styles, `release_tags` filtering, `select_tags`
  selection logic, and CLI behaviour (argparse rejections, `--help`
  without token, missing-token error, unknown-tag reported before token).
  Runs standalone via its own `# /// script` uv-run header.

## Idempotency, live-tested

Before posting, the script checks for an existing comment with the exact
target body via GraphQL pagination, so re-runs (workflow or hand-run) do
not duplicate. I exercised this on `v1.11.1` — the first run was
interrupted partway through, the second one cleanly skipped the
already-annotated PRs/issues and processed the rest:

<details><summary>Live-test output (after interrupted initial run)</summary>

```
tools/announce_release.py v1.11.1 --post

=== Release v1.11.1 (prev: v1.11.0) ===
  10 PR(s) in this release
  - PR #2346 https://github.com/bids-standard/bids-specification/pull/2346 — comment already exists, skip — '[FIX] Add emg to timeseries rule for physio/stim files'
  - PR #2345 https://github.com/bids-standard/bids-specification/pull/2345 — comment already exists, skip — 'fix: Allow mkdocs to render links in glossary'
      issue #2242 https://github.com/bids-standard/bids-specification/issues/2242 — comment already exists, skip
  - PR #2344 https://github.com/bids-standard/bids-specification/pull/2344 — [POST] comment on PR — '[FIX] Use http://www.dicomlookup.com for DICOM tags'
  - PR #2331 https://github.com/bids-standard/bids-specification/pull/2331 — [POST] comment on PR — '[FIX] Minor syntax updates on microscopy page'
  - PR #2347 https://github.com/bids-standard/bids-specification/pull/2347 — [POST] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #2337 https://github.com/bids-standard/bids-specification/pull/2337 — [POST] comment on PR — 'chore(deps): bump aiohttp from 3.12.15 to 3.13.3'
  - PR #2336 https://github.com/bids-standard/bids-specification/pull/2336 — [POST] comment on PR — 'chore(deps): bump urllib3 from 2.5.0 to 2.6.3'
  - PR #2335 https://github.com/bids-standard/bids-specification/pull/2335 — [POST] comment on PR — 'chore(deps): bump the build-dependencies group with 8 updates'
  - PR #2323 https://github.com/bids-standard/bids-specification/pull/2323 — [POST] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #2318 https://github.com/bids-standard/bids-specification/pull/2318 — [POST] comment on PR — 'chore(deps): bump lodash from 4.17.21 to 4.17.23'
```

</details>

so can see the effect on e.g.
- https://github.com/bids-standard/bids-specification/pull/2345#issuecomment-4595303056
- https://github.com/bids-standard/bids-specification/issues/2242#issuecomment-4595303198

## How to dry-run / backfill manually

```bash
# Dry-run one release
GITHUB_TOKEN=$(gh auth token) tools/announce_release.py v1.11.1

# Dry-run all historical releases since a starting point
GITHUB_TOKEN=$(gh auth token) tools/announce_release.py --retroactive --since v1.10.0

# Actually post (write-scoped token required)
GITHUB_TOKEN=$(gh auth token) tools/announce_release.py --post v1.11.1
```

URLs are inlined next to each `#NNN` so terminals autolink them.


<details>
<summary>Here is what I get if I run it for prior release</summary> 

```shell
> tools/announce_release.py v1.11.0

=== Release v1.11.0 (prev: v1.10.1) ===
  58 PR(s) in this release
  - PR #2325 https://github.com/bids-standard/bids-specification/pull/2325 — [DRY] comment on PR — 'REL: 1.11.0'
  - PR #2334 https://github.com/bids-standard/bids-specification/pull/2334 — [DRY] comment on PR — 'chore(deps): bump prettier from 3.7.4 to 3.8.0 in the node-utilities group'
  - PR #2322 https://github.com/bids-standard/bids-specification/pull/2322 — [DRY] comment on PR — 'fix(schema): Check SpatialReference for space, template entities'
  - PR #2019 https://github.com/bids-standard/bids-specification/pull/2019 — [DRY] comment on PR — '[ENH] Add another example to inheritance principle for .json without entities'
  - PR #2210 https://github.com/bids-standard/bids-specification/pull/2210 — [DRY] comment on PR — '[ENH] Clarify that "raw dataset" source data in example layout is a raw BIDS dataset'
  - PR #2315 https://github.com/bids-standard/bids-specification/pull/2315 — [DRY] comment on PR — '[FIX] Update and render schema definition of dataset_description.json'
  - PR #2306 https://github.com/bids-standard/bids-specification/pull/2306 — [DRY] comment on PR — 'Add pre-commit invoked checker to spot bad JSON in .md and also fix detected bad JSONs'
  - PR #2321 https://github.com/bids-standard/bids-specification/pull/2321 — [DRY] comment on PR — '[FIX] Update `Diffusion data in FSL` link'
  - PR #2319 https://github.com/bids-standard/bids-specification/pull/2319 — [DRY] comment on PR — 'Fix a single use of ManufacturerModelName in qmri.md (should be ManufacturersModelName)'
  - PR #2281 https://github.com/bids-standard/bids-specification/pull/2281 — [DRY] comment on PR — '[FIX] Add desc- entity name into descriptions.tsv example'
  - PR #2297 https://github.com/bids-standard/bids-specification/pull/2297 — [DRY] comment on PR — '[FIX] Update navigation with respect to the `bids-starter-kit`'
  - PR #1915 https://github.com/bids-standard/bids-specification/pull/1915 — [DRY] comment on PR — '[ENH] Add human statement to emphasize that _desc is the last entity'
  - PR #2304 https://github.com/bids-standard/bids-specification/pull/2304 — [DRY] comment on PR — '[FIX] Correct `bval` and clarify `bvec` descriptions'
  - PR #2310 https://github.com/bids-standard/bids-specification/pull/2310 — [DRY] comment on PR — '[Schema][Fix] add checks for multiple frame consistency issues '
  - PR #2316 https://github.com/bids-standard/bids-specification/pull/2316 — [DRY] comment on PR — 'fix: correct schema file path in eye tracking documentation comment'
  - PR #2314 https://github.com/bids-standard/bids-specification/pull/2314 — [DRY] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #2308 https://github.com/bids-standard/bids-specification/pull/2308 — [DRY] comment on PR — '[FIX] Add DWI recommended metadata table'
  - PR #1128 https://github.com/bids-standard/bids-specification/pull/1128 — [DRY] comment on PR — '[ENH] BEP020 - Eye Tracking'
  - PR #2280 https://github.com/bids-standard/bids-specification/pull/2280 — [DRY] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #2294 https://github.com/bids-standard/bids-specification/pull/2294 — [DRY] comment on PR — '[ENH] Make Pharmaceutical metadata terms less PET-specific'
  - PR #1714 https://github.com/bids-standard/bids-specification/pull/1714 — [DRY] comment on PR — '[ENH] BEP038 - Atlases'
  - PR #2291 https://github.com/bids-standard/bids-specification/pull/2291 — [DRY] comment on PR — 'chore(deps): bump the actions-infrastructure group with 3 updates'
  - PR #2292 https://github.com/bids-standard/bids-specification/pull/2292 — [DRY] comment on PR — 'chore(deps): bump the node-utilities group with 2 updates'
  - PR #2288 https://github.com/bids-standard/bids-specification/pull/2288 — [DRY] comment on PR — 'chore: Ignore redirect warnings in link checks'
  - PR #2271 https://github.com/bids-standard/bids-specification/pull/2271 — [DRY] comment on PR — 'chore: Add "serve" rule to Makefile and provide description to what actions available'
  - PR #2237 https://github.com/bids-standard/bids-specification/pull/2237 — [DRY] comment on PR — '[ENH] Updated HED Version to 8.4.0 in examples'
  - PR #2244 https://github.com/bids-standard/bids-specification/pull/2244 — [DRY] comment on PR — 'chore(deps): bump the actions-infrastructure group with 3 updates'
  - PR #1998 https://github.com/bids-standard/bids-specification/pull/1998 — [DRY] comment on PR — '[ENH] BEP042 - extension for electromyography (EMG)'
      issue #1371 https://github.com/bids-standard/bids-specification/issues/1371 — [DRY] comment on issue
  - PR #2270 https://github.com/bids-standard/bids-specification/pull/2270 — [DRY] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #2253 https://github.com/bids-standard/bids-specification/pull/2253 — [DRY] comment on PR — '[FIX] Correct typos and formatting in specification documents'
  - PR #2268 https://github.com/bids-standard/bids-specification/pull/2268 — [DRY] comment on PR — '[FIX] Fixed typo in events.md'
  - PR #2259 https://github.com/bids-standard/bids-specification/pull/2259 — [DRY] comment on PR — 'Adding bclenet as BIDS maintainer'
  - PR #2266 https://github.com/bids-standard/bids-specification/pull/2266 — [DRY] comment on PR — 'chore(deps): bump glob from 10.4.5 to 10.5.0'
  - PR #2265 https://github.com/bids-standard/bids-specification/pull/2265 — [DRY] comment on PR — '[FIX] Allowing to render JSON null type'
      issue #2260 https://github.com/bids-standard/bids-specification/issues/2260 — [DRY] comment on issue
  - PR #2245 https://github.com/bids-standard/bids-specification/pull/2245 — [DRY] comment on PR — 'chore(deps): bump astral-sh/setup-uv from 6 to 7'
  - PR #2140 https://github.com/bids-standard/bids-specification/pull/2140 — [DRY] comment on PR — 'feat(schema): Add meta.templates and allow for composing multiple references'
  - PR #2233 https://github.com/bids-standard/bids-specification/pull/2233 — [DRY] comment on PR — 'DOCS: Add ignore rule for rrid.site in link checker'
  - PR #2232 https://github.com/bids-standard/bids-specification/pull/2232 — [DRY] comment on PR — 'DOCS: Fix HED resources link in hierarchical event descriptors documentation'
  - PR #2229 https://github.com/bids-standard/bids-specification/pull/2229 — [DRY] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #2216 https://github.com/bids-standard/bids-specification/pull/2216 — [DRY] comment on PR — '[INFRA] Use full page width'
  - PR #2178 https://github.com/bids-standard/bids-specification/pull/2178 — [DRY] comment on PR — '[SCHEMA][MISC][WIP] Update schema docs with BEP Google doc to schema examples.'
  - PR #2225 https://github.com/bids-standard/bids-specification/pull/2225 — [DRY] comment on PR — '[MISC]: Fix placement of picture for Benjamin Dichter'
  - PR #2226 https://github.com/bids-standard/bids-specification/pull/2226 — [DRY] comment on PR — '[INFRA] Replace npm-requirements hack with package.json'
  - PR #2223 https://github.com/bids-standard/bids-specification/pull/2223 — [DRY] comment on PR — 'chore(deps): bump the actions-infrastructure group with 2 updates'
  - PR #2203 https://github.com/bids-standard/bids-specification/pull/2203 — [DRY] comment on PR — '[ENH] Clarify that "source datasets" do not have to be BIDS, and provide definitions for DOI and URL'
  - PR #2217 https://github.com/bids-standard/bids-specification/pull/2217 — [DRY] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #1927 https://github.com/bids-standard/bids-specification/pull/1927 — [DRY] comment on PR — '[ENH] Clearly define dual templates (fsaverage, fsaverageSym, and fsLR) in coordinate systems appendix'
      issue #1901 https://github.com/bids-standard/bids-specification/issues/1901 — [DRY] comment on issue
  - PR #2196 https://github.com/bids-standard/bids-specification/pull/2196 — [DRY] comment on PR — '[INFRA] Remove changelog generator CI workflow'
  - PR #2214 https://github.com/bids-standard/bids-specification/pull/2214 — [DRY] comment on PR — 'feat: Add unique() function to schema expression language'
  - PR #2212 https://github.com/bids-standard/bids-specification/pull/2212 — [DRY] comment on PR — '[pre-commit.ci] pre-commit autoupdate'
  - PR #2209 https://github.com/bids-standard/bids-specification/pull/2209 — [DRY] comment on PR — '[ENH] Add entity tables for motion, NIRS and MRS'
  - PR #2207 https://github.com/bids-standard/bids-specification/pull/2207 — [DRY] comment on PR — 'Update current BIDS maintainers list'
  - PR #2205 https://github.com/bids-standard/bids-specification/pull/2205 — [DRY] comment on PR — '[FIX] Update links in common-principles.md'
      issue #2204 https://github.com/bids-standard/bids-specification/issues/2204 — [DRY] comment on issue
  - PR #2201 https://github.com/bids-standard/bids-specification/pull/2201 — [DRY] comment on PR — '[FIX] Update BIDS Starter Kit links'
  - PR #2200 https://github.com/bids-standard/bids-specification/pull/2200 — [DRY] comment on PR — '[SCHEMA] Reorder fields in MRSInstitutionInformation schema'
  - PR #2199 https://github.com/bids-standard/bids-specification/pull/2199 — [DRY] comment on PR — 'fix: Remove Marie Curie from contributors'
  - PR #2190 https://github.com/bids-standard/bids-specification/pull/2190 — [DRY] comment on PR — 'chore(deps): bump the actions-infrastructure group with 2 updates'
  - PR #2177 https://github.com/bids-standard/bids-specification/pull/2177 — [DRY] comment on PR — 'DOC: make mentioning of pipeline_name consistent'

```
</details>

## Test plan

- [x] Dry-run on `v1.11.1` lists the expected 10 PRs + 1 closing issue.
- [x] `--post` on `v1.11.1` actually comments; re-run skips them all (idempotency verified live, see above).
- [x] `pytest tools/tests/test_announce_release.py` — 28 passed.
- [x] `--help` works without `GITHUB_TOKEN`; the `uv run … -- --help` invocation pattern reports "not a known release tag" rather than a misleading token error.
- [ ] On the first `release: published` after merge, confirm the `announce_release` job fires and posts comments. Maintainers can also run the retroactive sweep (`tools/announce_release.py --retroactive --post`) to backfill prior releases.
