### PR TITLE
[FIX] Bump pymdown-extensions to >=10.21.2 to restore code-block rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [
   "bidsschematools[render]",
   "mkdocs>=1.1.0",
   "mkdocs-material>=5.4",
-  "pymdown-extensions>=9.2.0",
+  "pymdown-extensions>=10.21.2",
   "mkdocs-branchcustomization-plugin~=0.1.3",
   "mkdocs-macros-plugin",
   "mkdocs-redirects",

--- a/tools/schemacode/pyproject.toml
+++ b/tools/schemacode/pyproject.toml
@@ -39,7 +39,7 @@ render = [
   "numpy>=1.26",
   "pandas>=2.0",
   "markdown-it-py>=3.0",
-  "pymdown-extensions>=9.2",
+  "pymdown-extensions>=10.21.2",
 ]
 validation = [
   "jsonschema[format]>=4.22",

--- a/tools/schemacode/uv.lock
+++ b/tools/schemacode/uv.lock
@@ -110,7 +110,7 @@ requires-dist = [
     { name = "markdown-it-py", marker = "extra == 'render'", specifier = ">=3.0" },
     { name = "numpy", marker = "extra == 'render'", specifier = ">=1.26" },
     { name = "pandas", marker = "extra == 'render'", specifier = ">=2.0" },
-    { name = "pymdown-extensions", marker = "extra == 'render'", specifier = ">=9.2" },
+    { name = "pymdown-extensions", marker = "extra == 'render'", specifier = ">=10.21.2" },
     { name = "pyparsing", marker = "extra == 'expressions'", specifier = ">=3.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tabulate", marker = "extra == 'render'", specifier = ">=0.9" },
@@ -1150,15 +1150,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ requires-dist = [
     { name = "mkdocs-material", specifier = ">=5.4" },
     { name = "mkdocs-redirects" },
     { name = "numpy" },
-    { name = "pymdown-extensions", specifier = ">=9.2.0" },
+    { name = "pymdown-extensions", specifier = ">=10.21.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -305,7 +305,7 @@ requires-dist = [
     { name = "markdown-it-py", marker = "extra == 'render'", specifier = ">=3.0" },
     { name = "numpy", marker = "extra == 'render'", specifier = ">=1.26" },
     { name = "pandas", marker = "extra == 'render'", specifier = ">=2.0" },
-    { name = "pymdown-extensions", marker = "extra == 'render'", specifier = ">=9.2" },
+    { name = "pymdown-extensions", marker = "extra == 'render'", specifier = ">=10.21.2" },
     { name = "pyparsing", marker = "extra == 'expressions'", specifier = ">=3.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tabulate", marker = "extra == 'render'", specifier = ">=0.9" },
@@ -1712,15 +1712,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #2421.

Restores fenced code-block rendering for blocks nested inside list items
(e.g. the `Plain` examples in "Storage of derived datasets" and the
`make_filetree_example` tree in "Study dataset"). On the current
`latest` build these collapsed to inline `<code>` with the language tag
visible as literal text (`Plain <dataset>/derivatives/…`).

## Root cause

<details>
<summary>Pygments 2.20.0 + pymdownx ≤10.21 interaction</summary>

* Pygments 2.20.0 (2026-03-29) tightened `HtmlFormatter.__init__` to
  call `html.escape()` on the `filename` option. With a `None` value
  this now raises `AttributeError: 'NoneType' object has no attribute
  'replace'`.
* `pymdownx.highlight` ≤10.21 passes `filename=title` and `title`
  defaults to `None` when the code block has no title.
* `pymdownx.superfences` catches the exception and silently abandons
  the fence. Python-Markdown's own `fenced_code` doesn't process
  fences nested inside list items, so the ` ```Plain … ``` ` block
  ends up parsed as inline code: `<p><code>Plain …</code></p>`.

`pymdown-extensions` 10.21.2 fixes the upstream defect (release notes:
"Latest Pygments versions cannot handle a 'filename' for code block
titles of `None`."). 10.21.3 adds an unrelated snippets security fix.

</details>

## Change

* `pyproject.toml`: `pymdown-extensions>=9.2.0` → `>=10.21.2`
* `tools/schemacode/pyproject.toml` (`[render]` extra): same bump
* `uv.lock`: pins to 10.21.3 (current latest)

Floor is set to 10.21.2 (the minimum that fixes #2421); the lockfile
picks up 10.21.3, superseding the open dependabot PR for the same bump.

## Verification

Built locally on this branch (`mkdocs build`) and confirmed:

* "Storage of derived datasets" `Plain` blocks now emit
  `<div class="highlight"><pre>…</pre></div>` (matches `stable`).
* "Study dataset" filetree macro output also renders as a proper code
  block.
* No literal "Plain" text leaks into the rendered HTML.
