### PR TITLE
[SCHEMA] Warn when *_beh.tsv contains onset and duration

### DIFF
--- a/src/schema/rules/checks/events.yaml
+++ b/src/schema/rules/checks/events.yaml
@@ -23,8 +23,8 @@ BehavioralOnsetAndDuration:
   issue:
     code: BEH_ONSET_DURATION
     message: |
-      A '*_beh.tsv' file contains both 'onset' and 'duration' columns.
-      Rename this file to use the '*_events.tsv' suffix.
+      This behavioral file contains onset and duration columns.
+      Consider renaming to use the `events` suffix.
     level: warning
   selectors:
     - suffix == "beh"

--- a/src/schema/rules/checks/events.yaml
+++ b/src/schema/rules/checks/events.yaml
@@ -19,6 +19,19 @@ EventsMissing:
   checks:
     - '"events" in associations'
 
+BehavioralOnsetAndDuration:
+  issue:
+    code: BEH_ONSET_DURATION
+    message: |
+      A '*_beh.tsv' file contains both 'onset' and 'duration' columns.
+      Rename this file to use the '*_events.tsv' suffix.
+    level: warning
+  selectors:
+    - suffix == "beh"
+    - extension == ".tsv"
+  checks:
+    - columns.onset == null || columns.duration == null
+
 StimulusFileMissing:
   issue:
     code: STIMULUS_FILE_MISSING


### PR DESCRIPTION
## Summary

Add a schema warning when a `*_beh.tsv` file contains both `onset` and `duration`. A file containing only one of these columns does not trigger the warning.

The check uses direct column access because `columns` is exposed as a mapping in the current validator, so `intersects(columns, ...)` does not inspect the column names.

Closes #2213

## Checks

- `yamllint` passes
- full `bidsschematools` test suite: 81 passed, 1 skipped
- checked with the current Deno validator against five small cases: both columns, onset only, duration only, neither, and a valid `events.tsv`
- checked two existing BIDS example datasets for false positives
