### PR TITLE
[FIX][SCHEMA] Phenotype subjects are a subset of participants.tsv

### DIFF
--- a/src/schema/rules/checks/phenotype.yaml
+++ b/src/schema/rules/checks/phenotype.yaml
@@ -14,8 +14,9 @@ PhenotypeSubjectsMissing:
     - suffix == '.tsv'
     - type(dataset.subjects.participant_id) != 'null'
   checks:
+    # A∩B == A iff A⊆B
     - |
       allequal(
         sorted(intersects(columns.participant_id, dataset.subjects.participant_id)),
-        sorted(dataset.subjects.participant_id)
+        sorted(columns.participant_id)
       )


### PR DESCRIPTION
The existing check required a superset relation. Probably not frequently hit because equality will be the norm.

Note that the error message implies a subset relation, and that was the intent in #2044.

> A phenotype/ .tsv file lists subjects that were not found in the participant_id column found in the participants.tsv file.

Bug introduced in 1ff73de71f06191b131dc3bc34ea38b1ecdb19b6 when moving away from an aggregated `dataset.subjects.phenotype` field.