### PR TITLE
[INFRA] Skip link check for encodeproject.org URLs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
                 --ignore-url 'https://jsoneditoronline.org' \
                 --ignore-url 'https://rrid.site.*' \
                 --ignore-url 'https://jsr.io/.*' \
+                --ignore-url 'https://www.encodeproject.org/.*' \
                 ~/project/site/*html ~/project/site/*/*.html
             else
               echo "Release PR - do nothing"


### PR DESCRIPTION
Captcha added, so links cannot be visited by an automated tool.

LLM scraping has a wide blast radius, and maybe not every web page needs to be dynamically generated.