### PR TITLE
[INFRA] Add Bluesky social link, drop Twitter

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,8 +93,8 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/bids-standard/bids-specification/
-    - icon: fontawesome/brands/x-twitter
-      link: https://x.com/BIDSstandard/
+    - icon: fontawesome/brands/bluesky
+      link: https://bsky.app/profile/bidsstandard.bsky.social
     - icon: fontawesome/brands/mastodon
       link: https://fosstodon.org/@bidsstandard
     - icon: fontawesome/brands/google


### PR DESCRIPTION
We squat a twitter handle, but do not post, so we should stop advertising it. We do post updates to bluesky.