### PR TITLE
enh(metaschema): require and constrain `inherit` in associations + provide it for atlas _description.json

### DIFF
--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -47,8 +47,43 @@
                   "type": "boolean"
                 }
               },
-              "required": ["target"],
-              "additionalProperties": false
+              "required": ["target", "inherit"],
+              "additionalProperties": false,
+              "if": {
+                "properties": {
+                  "target": {
+                    "properties": {
+                      "extension": {
+                        "oneOf": [
+                          {
+                            "enum": [".json", ".tsv", ".bval", ".bvec"]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "enum": [".json", ".tsv", ".bval", ".bvec"]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "inherit": {
+                    "const": true
+                  }
+                }
+              },
+              "else": {
+                "properties": {
+                  "inherit": {
+                    "const": false
+                  }
+                }
+              }
             }
           },
           "additionalProperties": false

--- a/src/metaschema.json
+++ b/src/metaschema.json
@@ -47,7 +47,7 @@
                   "type": "boolean"
                 }
               },
-              "required": ["target", "inherit"],
+              "required": ["selectors", "target", "inherit"],
               "additionalProperties": false,
               "if": {
                 "properties": {

--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -128,3 +128,4 @@ atlas_description:
   target:
     suffix: description
     extension: .json
+  inherit: true


### PR DESCRIPTION
Enforce that every entry under `meta.associations` declares `inherit`, and that its value is `true` when the target extension is `.json`, `.tsv`, `.bval`, or `.bvec` and `false` otherwise. Also add the previously-missing `inherit: true` to `atlas_description`.

This is an alternative to a pure human product of
- #2478 
