### PR TITLE
[ENH] BEP032: Require anatomical_reference_point when stereotaxic coordinates are given

### DIFF
--- a/src/appendices/microelectrode-surgical-coordinates.md
+++ b/src/appendices/microelectrode-surgical-coordinates.md
@@ -14,7 +14,7 @@ There are two major anatomical markers on the dorsal surface of the brain that a
 
 **Lambda**: the meeting point of the sagittal suture (between left and right parietal bones) and the lambdoid suture (between parietal and occipital bones).
 
-Both points serve as standard reference points for stereotaxic coordinates in neuroscience research. `(0,0,0)` is assumed to be Bregma when working with rodents. It may optionally be defined differently using `anatomical_reference_point`, and MUST be defined for other species.
+Both points serve as standard reference points for stereotaxic coordinates in neuroscience research. The point that `(0,0,0)` refers to MUST be stated in the `anatomical_reference_point` column of `*_probes.tsv` whenever stereotaxic coordinates are given, for every species. Bregma is the usual choice for rodents, but it is not assumed.
 
 ## Stereotaxic Coordinate System Conventions
 

--- a/src/modality-specific-files/microelectrode-electrophysiology.md
+++ b/src/modality-specific-files/microelectrode-electrophysiology.md
@@ -373,10 +373,10 @@ probe02	tetrode	-1.2	-2.1	-3.5	0	10	45	R	Neuralynx	TT-12345	4	n/a	n/a	n/a	tip	Br
 **Intracellular electrophysiology example:**
 
 ```tsv
-probe_name	type	AP	ML	DV	AP_angle	ML_angle	rotation_angle	hemisphere	manufacturer	electrode_count	coordinate_reference_point	associated_brain_region	associated_brain_region_id	reference_atlas
-pipette01	patch-pipette	-1.8	0.5	-2.2	30	0	0	L	Sutter	1	tip	Visual Cortex Layer 2/3	VISp2/3	AllenCCFv3
-pipette02	patch-pipette	-1.8	-0.5	-2.2	30	0	0	R	Sutter	1	tip	Visual Cortex Layer 2/3	VISp2/3	AllenCCFv3
-pipette03	sharp-electrode	-3.2	1.2	-3.8	20	5	0	L	WPI	1	tip	Prefrontal Cortex Layer 5	PL5	Franklin-Paxinos
+probe_name	type	AP	ML	DV	AP_angle	ML_angle	rotation_angle	hemisphere	manufacturer	electrode_count	coordinate_reference_point	anatomical_reference_point	associated_brain_region	associated_brain_region_id	reference_atlas
+pipette01	patch-pipette	-1.8	0.5	-2.2	30	0	0	L	Sutter	1	tip	Bregma	Visual Cortex Layer 2/3	VISp2/3	AllenCCFv3
+pipette02	patch-pipette	-1.8	-0.5	-2.2	30	0	0	R	Sutter	1	tip	Bregma	Visual Cortex Layer 2/3	VISp2/3	AllenCCFv3
+pipette03	sharp-electrode	-3.2	1.2	-3.8	20	5	0	L	WPI	1	tip	Bregma	Prefrontal Cortex Layer 5	PL5	Franklin-Paxinos
 ```
 
 For details on the surgical coordinate system used to describe probe placement during surgery (AP, ML, DV, angles, and

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -152,9 +152,10 @@ anatomical_reference_point:
   name: anatomical_reference_point
   display_name: Anatomical reference point
   description: |
-    Anatomical reference point for stereotaxic coordinates (for example, `Bregma`, `Lambda`).
-    If not specified, `Bregma` is assumed for rodents.
-    MUST be defined for species other than rodents.
+    Anatomical reference point from which the stereotaxic coordinates of the probe are
+    measured (for example, `Bregma`, `Lambda`).
+    This column MUST be defined whenever any of the `AP`, `ML`, or `DV` columns are present,
+    for every species, since those coordinates cannot be interpreted without it.
   type: string
 depth__probes:
   name: depth

--- a/src/schema/rules/checks/microephys.yaml
+++ b/src/schema/rules/checks/microephys.yaml
@@ -16,3 +16,21 @@ MicroephysRequiredCoordsystemWithSpace:
     - '"space" in entities'
   checks:
     - associations.coordsystem != null
+
+# Stereotaxic coordinates cannot be interpreted without knowing the point they are
+# measured from, so requiring the reference point is conditioned on their presence.
+MicroephysRequiredAnatomicalReferencePoint:
+  issue:
+    code: MICROEPHYS_ANATOMICAL_REFERENCE_POINT_REQUIRED
+    message: |
+      The `anatomical_reference_point` column MUST be defined in `*_probes.tsv` when
+      stereotaxic coordinates are given, that is, when any of the `AP`, `ML`, or `DV`
+      columns are present.
+    level: error
+  selectors:
+    - intersects([datatype], ["ecephys", "icephys"])
+    - suffix == "probes"
+    - extension == ".tsv"
+    - columns.AP != null || columns.ML != null || columns.DV != null
+  checks:
+    - columns.anatomical_reference_point != null

--- a/src/schema/rules/tabular_data/microephys.yaml
+++ b/src/schema/rules/tabular_data/microephys.yaml
@@ -29,7 +29,9 @@ microephysProbes:
     depth__probes: optional
     rotation_angle: recommended
     coordinate_reference_point: recommended
-    anatomical_reference_point: optional
+    anatomical_reference_point:
+      level: optional
+      level_addendum: required if `AP`, `ML`, or `DV` are present
     hemisphere__probes: recommended
     associated_brain_region: recommended
     associated_brain_region_id: recommended


### PR DESCRIPTION
Implements the decision we reached in the working group meeting on 2026-07-29 about `anatomical_reference_point`, addressing https://github.com/bids-standard/bids-specification/pull/2307#discussion_r3648123067 and following up on https://github.com/bids-standard/bids-specification/pull/2307#issuecomment-5111318962. This targets `bep032-review`, so it merges into #2307 rather than into master.

## The Change

The column previously said that Bregma is assumed for rodents and that the reference point MUST be defined for species other than rodents. It is now required whenever any of the `AP`, `ML`, or `DV` columns are present, for every species, and the Bregma default is dropped.

As @effigies pointed out, the species conditional came with no check and could not be enforced. The validator context exposes only `participant_id` from `participants.tsv`, so a rule evaluating `probes.tsv` cannot read the `species` column at all; `species` is itself only RECOMMENDED and is assumed to be `homo sapiens` when absent; and deciding rodent versus non-rodent would require taxonomic reasoning rather than string comparison. The condition on the coordinates is both the one that actually matters, since stereotaxic coordinates cannot be interpreted without knowing the point they are measured from, and one that can be checked.

Dropping the default follows from the same change: with the coordinates present the column is required, so there is no case left for a default to cover.

## Implementation

`MicroephysRequiredAnatomicalReferencePoint` in `rules/checks/microephys.yaml` selects on the presence of any of the three coordinate columns and checks for the reference point. It follows the form of the existing `RequiredTemplateX` and `RequiredComponent` checks in `rules/checks/nirs.yaml`, which condition one column's requirement on another's contents.

In the columns rule the level stays OPTIONAL with a `level_addendum` of "required if `AP`, `ML`, or `DV` are present", so the rendered table reads "OPTIONAL, but REQUIRED if `AP`, `ML`, or `DV` are present" rather than understating the requirement. The description in `objects/columns.yaml` and the corresponding sentence in the surgical coordinates appendix are updated to match.

I also added the reference point to the intracellular probes example, which gives stereotaxic coordinates and would otherwise stop being valid under the new check.

## Verification

`bidsschematools` tests pass (81 passed, 1 skipped), as do `pre-commit` on the changed files and `npm run remark`. I parsed both new check expressions with `bidsschematools.expressions` to confirm they are well formed, and confirmed the rendered probes table shows the conditional requirement. Both probes examples in the specification now satisfy the check.

## Note on Ordering

This touches the intracellular probes example, which #2481 also edits, so whichever merges second will need a trivial rebase on that one row. Everything else is independent. Happy to rebase whenever it is useful.

@lzehl, this is the third item from the meeting. The first two are #2480 and #2481.
