### PR TITLE
[FIX] Uniformize DICOM tag formatting, URLs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
                 --ignore-url 'https://github.com/[^/]*' \
                 --ignore-url 'https://github.com/bids-standard/bids-specification/(pull|tree)/.*' \
                 --ignore-url 'https://www.incf.org' \
-                --ignore-url 'http://www.dicomlookup.com/dicomtags/.*' \
+                --ignore-url 'https://www.dicomlookup.com/dicomtags/.*' \
                 --ignore-url 'https://www.instagram.com/bidsstandard/' \
                 --ignore-url 'https://jsoneditoronline.org' \
                 --ignore-url 'https://rrid.site.*' \

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -498,9 +498,9 @@ additional meta information extracted from DICOM files in a sidecar JSON file
 (with the same filename as the `.nii[.gz]` file, but with a `.json` extension).
 Currently defined metadata fields are listed in the [Glossary](./glossary.md).
 Where possible, DICOM Tags are adopted directly as BIDS metadata terms and
-indicated with "**Corresponds to** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
+indicated with "**Corresponds to** DICOM Tag (####,####) `<Attribute Name>`".
 When harmonization has been deemed necessary, this is indicated in the
-BIDS term description with "**Based on** DICOM Tag ID1, ID2 `DICOM Tag Name`.".
+BIDS term description with "**Based on** DICOM Tag (####,####) `<Attribute Name>`".
 Extraction of BIDS compatible metadata can be performed using
 [DICOM to NIfTI converters](https://bids.neuroimaging.io/tools/converters.html)
 such as [dcm2niix](https://github.com/rordenlab/dcm2niix).

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -81,8 +81,7 @@ A guide for using macros can be found at
 "BandwidthPerPixelPhaseEncode" in DICOM Tag (0019,1028) (a private, Siemens-specific DICOM tag)
 and `ReconMatrixPE` is the size of the actual reconstructed data in the phase direction (which is
 NOT reflected in a single DICOM Tag for all possible aforementioned scan
-manipulations). See [Acquiring and using field maps -
-LCNI](https://web.archive.org/web/20240709020334/https://lcni.uoregon.edu/wiki/acquiring-and-using-field-maps/)
+manipulations). See [Acquiring and using field maps - LCNI](https://web.archive.org/web/20240709020334/https://lcni.uoregon.edu/wiki/acquiring-and-using-field-maps/)
 and [TotalReadoutTime - dcm\_qa](https://github.com/neurolabusc/dcm_qa/tree/master/In/TotalReadoutTime).
 
 <sup>3</sup>We use the time between the center of the first "effective" echo

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -77,12 +77,12 @@ A guide for using macros can be found at
 {{ MACROS___make_sidecar_table(["mri.MRISpatialEncoding", "mri.PhaseEncodingDirectionRec"]) }}
 
 <sup>2</sup>Conveniently, for Siemens data, this value is easily obtained as
-`1 / (BWPPPE * ReconMatrixPE)`, where BWPPPE is the
-"BandwidthPerPixelPhaseEncode" in [DICOM Tag 0019, 1028](http://www.dicomlookup.com/dicomtags/(0019,1028)) and ReconMatrixPE is
-the size of the actual reconstructed data in the phase direction (which is NOT
-reflected in a single DICOM Tag for all possible aforementioned scan
-manipulations). See
-[Acquiring and using field maps - LCNI](https://web.archive.org/web/20240709020334/https://lcni.uoregon.edu/wiki/acquiring-and-using-field-maps/)
+`1 / (BWPPPE * ReconMatrixPE)`, where `BWPPPE` is the
+"BandwidthPerPixelPhaseEncode" in DICOM Tag (0019,1028) (a private, Siemens-specific DICOM tag)
+and `ReconMatrixPE` is the size of the actual reconstructed data in the phase direction (which is
+NOT reflected in a single DICOM Tag for all possible aforementioned scan
+manipulations). See [Acquiring and using field maps -
+LCNI](https://web.archive.org/web/20240709020334/https://lcni.uoregon.edu/wiki/acquiring-and-using-field-maps/)
 and [TotalReadoutTime - dcm\_qa](https://github.com/neurolabusc/dcm_qa/tree/master/In/TotalReadoutTime).
 
 <sup>3</sup>We use the time between the center of the first "effective" echo
@@ -268,7 +268,7 @@ and a guide for using macros can be found at
 The [`part-<label>`](../appendices/entities.md#part) entity is
 used to indicate which component of the complex representation of the MRI
 signal is represented in voxel data.
-This entity is associated with the DICOM Tag `0008, 9208`.
+This entity is associated with the DICOM Tag (0008,9208).
 Allowed label values for this entity are `phase`, `mag`, `real` and `imag`,
 which are typically used in `part-mag`/`part-phase` or `part-real`/`part-imag`
 pairs of files.
@@ -952,7 +952,7 @@ accompanied by two ancillary files: `*_asl.json` and `*_aslcontext.tsv`.
 
 The `*_aslcontext.tsv` table consists of a single column of labels identifying the
 `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.
-Volume types are defined in the following table, based on [DICOM Tag 0018, 9257](http://www.dicomlookup.com/dicomtags/(0018,9257)) `ASL Context`.
+Volume types are defined in the following table, based on [DICOM Tag (0018,9257)](http://www.dicomlookup.com/dicomtags/(0018,9257)) `ASL Context`.
 Note that the volume_types `control` and  `label` within BIDS only serve
 to specify the magnetization state of the blood and thus the ASL subtraction order.
 See the [ASL Appendix](../appendices/arterial-spin-labeling.md#which-image-is-control-and-which-is-label)

--- a/src/modality-specific-files/magnetic-resonance-imaging-data.md
+++ b/src/modality-specific-files/magnetic-resonance-imaging-data.md
@@ -951,7 +951,7 @@ accompanied by two ancillary files: `*_asl.json` and `*_aslcontext.tsv`.
 
 The `*_aslcontext.tsv` table consists of a single column of labels identifying the
 `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.
-Volume types are defined in the following table, based on [DICOM Tag (0018,9257)](http://www.dicomlookup.com/dicomtags/(0018,9257)) `ASL Context`.
+Volume types are defined in the following table, based on [DICOM Tag (0018,9257)](https://www.dicomlookup.com/dicomtags/(0018,9257)) `ASL Context`.
 Note that the volume_types `control` and  `label` within BIDS only serve
 to specify the magnetization state of the blood and thus the ASL subtraction order.
 See the [ASL Appendix](../appendices/arterial-spin-labeling.md#which-image-is-control-and-which-is-label)

--- a/src/modality-specific-files/magnetic-resonance-spectroscopy.md
+++ b/src/modality-specific-files/magnetic-resonance-spectroscopy.md
@@ -123,8 +123,8 @@ Each `<label>` in the table above MAY be combined with another to better describ
 For example, `megaspecial`, `jpress`, `dwslaser`, `mcdwsteam`, and so on.
 
 The OPTIONAL `nuc-<label>` entity can be used to distinguish acquisitions tuned to detect different nuclei.
-The label is the name of the nucleus or nuclei, which corresponds to [DICOM Tag
-(0018,9100)](https://www.dicomlookup.com/#/tags?q=(0018%2C9100)&field=number) `Resonant Nucleus`.
+The label is the name of the nucleus or nuclei, which corresponds to [DICOM Tag (0018,9100)](https://www.dicomlookup.com/#/tags?q=(0018%2C9100)&field=number)
+`Resonant Nucleus`.
 For example, `nuc-1H`, `nuc-31P`, `nuc-1H13C`.
 If used, the field `ResonantNucleus` MUST also be included in the corresponding sidecar JSON file, using the same label.
 

--- a/src/modality-specific-files/magnetic-resonance-spectroscopy.md
+++ b/src/modality-specific-files/magnetic-resonance-spectroscopy.md
@@ -123,7 +123,8 @@ Each `<label>` in the table above MAY be combined with another to better describ
 For example, `megaspecial`, `jpress`, `dwslaser`, `mcdwsteam`, and so on.
 
 The OPTIONAL `nuc-<label>` entity can be used to distinguish acquisitions tuned to detect different nuclei.
-The label is the name of the nucleus or nuclei, which corresponds to DICOM Tag 0018, 9100.
+The label is the name of the nucleus or nuclei, which corresponds to [DICOM Tag
+(0018,9100)](https://www.dicomlookup.com/#/tags?q=(0018%2C9100)&field=number) `Resonant Nucleus`.
 For example, `nuc-1H`, `nuc-31P`, `nuc-1H13C`.
 If used, the field `ResonantNucleus` MUST also be included in the corresponding sidecar JSON file, using the same label.
 

--- a/src/modality-specific-files/magnetic-resonance-spectroscopy.md
+++ b/src/modality-specific-files/magnetic-resonance-spectroscopy.md
@@ -123,7 +123,7 @@ Each `<label>` in the table above MAY be combined with another to better describ
 For example, `megaspecial`, `jpress`, `dwslaser`, `mcdwsteam`, and so on.
 
 The OPTIONAL `nuc-<label>` entity can be used to distinguish acquisitions tuned to detect different nuclei.
-The label is the name of the nucleus or nuclei, which corresponds to [DICOM Tag (0018,9100)](https://www.dicomlookup.com/#/tags?q=(0018%2C9100)&field=number)
+The label is the name of the nucleus or nuclei, which corresponds to [DICOM Tag (0018,9100)](https://www.dicomlookup.com/dicomtags/(0018,9100))
 `Resonant Nucleus`.
 For example, `nuc-1H`, `nuc-31P`, `nuc-1H13C`.
 If used, the field `ResonantNucleus` MUST also be included in the corresponding sidecar JSON file, using the same label.

--- a/src/schema/objects/entities.yaml
+++ b/src/schema/objects/entities.yaml
@@ -220,7 +220,7 @@ nucleus:
   description: |
     The `nuc-<label>` entity can be used to distinguish acquisitions tuned
     to detect different nuclei.
-    The label is the name of the nucleus or nuclei, which corresponds to DICOM Tag `0018, 9100`.
+    The label is the name of the nucleus or nuclei, which corresponds to DICOM Tag (0018,9100).
     If present in the filename, `"ResonantNucleus"` MUST also be included in
     the associated metadata.
   type: string
@@ -232,7 +232,7 @@ part:
     This entity is used to indicate which component of the complex
     representation of the MRI signal is represented in voxel data.
     The `part-<label>` entity is associated with the DICOM Tag
-    `0008, 9208`.
+    (0008,9208).
     Allowed label values for this entity are `phase`, `mag`, `real` and `imag`,
     which are typically used in `part-mag`/`part-phase` or
     `part-real`/`part-imag` pairs of files.

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -40,7 +40,7 @@ AcquisitionDuration:
   display_name: Acquisition Duration
   description: |
     Duration (in seconds) of scan acquisition, including all volumes for multi-volume scans.
-    Corresponds to [DICOM Tag (0018,9073)](http://www.dicomlookup.com/dicomtags/(0018,9073))
+    Corresponds to [DICOM Tag (0018,9073)](https://www.dicomlookup.com/dicomtags/(0018,9073))
     `Acquisition Duration`.
   type: number
   exclusiveMinimum: 0
@@ -230,7 +230,7 @@ AttenuationCorrection:
   display_name: Attenuation Correction
   description: |
     Short description of the attenuation correction method used.
-    Corresponds to [DICOM Tag (0054,1101)](http://www.dicomlookup.com/dicomtags/(0054,1101))
+    Corresponds to [DICOM Tag (0054,1101)](https://www.dicomlookup.com/dicomtags/(0054,1101))
     `Attenuation Correction Method`.
   type: string
 AttenuationCorrectionMethodReference:
@@ -365,7 +365,7 @@ BodyPart:
   display_name: Body Part
   description: |
     Body part of the organ / body region scanned.
-    Corresponds to [DICOM Tag (0018,0015)](http://www.dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
+    Corresponds to [DICOM Tag (0018,0015)](https://www.dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
   type: string
 BodyPartDetails:
   name: BodyPartDetails
@@ -392,7 +392,7 @@ BolusCutOffDelayTime:
     cut-off saturation pulses.
     For Q2TIPS, only the values for the first and last bolus cut-off saturation
     pulses are provided.
-    Based on [DICOM Tag (0018,925F)](http://www.dicomlookup.com/dicomtags/(0018,925F))
+    Based on [DICOM Tag (0018,925F)](https://www.dicomlookup.com/dicomtags/(0018,925F))
     `ASL Bolus Cut-off Delay Time`.
   anyOf:
     - type: number
@@ -408,7 +408,7 @@ BolusCutOffFlag:
   display_name: Bolus Cut Off Flag
   description: |
     Boolean indicating if a bolus cut-off technique is used.
-    Corresponds to [DICOM Tag (0018,925C)](http://www.dicomlookup.com/dicomtags/(0018,925C))
+    Corresponds to [DICOM Tag (0018,925C)](https://www.dicomlookup.com/dicomtags/(0018,925C))
     `ASLBolusCutoffFlag`.
   type: boolean
 BolusCutOffTechnique:
@@ -416,7 +416,7 @@ BolusCutOffTechnique:
   display_name: Bolus Cut Off Technique
   description: |
     Name of the technique used, for example `"Q2TIPS"`, `"QUIPSS"`, `"QUIPSSII"`.
-    Corresponds to [DICOM Tag (0018,925E)](http://www.dicomlookup.com/dicomtags/(0018,925E))
+    Corresponds to [DICOM Tag (0018,925E)](https://www.dicomlookup.com/dicomtags/(0018,925E))
     `ASLBolusCutoffTechnique`.
   type: string
 BrainLocation:
@@ -515,7 +515,7 @@ ChemicalShiftReference:
   display_name: Chemical Shift Reference
   description: |
     The chemical shift at the transmitter frequency, specified in ppm (for example, `2.68`).
-    Corresponds to [DICOM Tag (0018,9053)](http://www.dicomlookup.com/dicomtags/(0018,9053))
+    Corresponds to [DICOM Tag (0018,9053)](https://www.dicomlookup.com/dicomtags/(0018,9053))
     `Chemical Shift Reference`.
   type: number
   unit: ppm
@@ -577,7 +577,7 @@ CodeValue:
   description: |
     An identifier that is unambiguous within the Coding Scheme
     denoted by Coding Scheme Designator and Coding Scheme Version.
-    Corresponds to [DICOM Tag (0008,0100)](http://www.dicomlookup.com/dicomtags/(0008,0100))
+    Corresponds to [DICOM Tag (0008,0100)](https://www.dicomlookup.com/dicomtags/(0008,0100))
     `Code Value`.
   type: string
 CodeMeaning:
@@ -585,7 +585,7 @@ CodeMeaning:
   display_name: Code Meaning
   description: |
     Text that has meaning to a human and conveys the meaning of the term
-    Corresponds to [DICOM Tag (0008,0104)](http://www.dicomlookup.com/dicomtags/(0008,0104))
+    Corresponds to [DICOM Tag (0008,0104)](https://www.dicomlookup.com/dicomtags/(0008,0104))
     `Code Meaning`.
   type: string
 CodingSchemeDesignator:
@@ -593,7 +593,7 @@ CodingSchemeDesignator:
   display_name: Coding Scheme Designator
   description: |
     The identifier of the coding scheme in which the coded entry is defined.
-    Corresponds to [DICOM Tag (0008,0102)](http://www.dicomlookup.com/dicomtags/(0008,0102))
+    Corresponds to [DICOM Tag (0008,0102)](https://www.dicomlookup.com/dicomtags/(0008,0102))
     `Coding Scheme Designator`.
   type: string
 CodingSchemeVersion:
@@ -601,7 +601,7 @@ CodingSchemeVersion:
   display_name: Coding Scheme version
   description: |
     An identifier of the version of the coding scheme if necessary to resolve ambiguity.
-    Corresponds to [DICOM Tag (0008,0103)](http://www.dicomlookup.com/dicomtags/(0008,0103))
+    Corresponds to [DICOM Tag (0008,0103)](https://www.dicomlookup.com/dicomtags/(0008,0103))
     `Coding Scheme Version`.
   type: string
 CodeURL:
@@ -695,7 +695,7 @@ ContrastBolusIngredient:
   display_name: Contrast Bolus Ingredient
   description: |
     Active ingredient of agent.
-    Corresponds to [DICOM Tag (0018,1048)](http://www.dicomlookup.com/dicomtags/(0018,1048))
+    Corresponds to [DICOM Tag (0018,1048)](https://www.dicomlookup.com/dicomtags/(0018,1048))
     `Contrast/Bolus Ingredient`.
   type: string
   enum:
@@ -790,7 +790,7 @@ DecayCorrectionFactor:
   display_name: Decay Correction Factor
   description: |
     Decay correction factor for each frame.
-    Corresponds to [DICOM Tag (0054,1321)](http://www.dicomlookup.com/dicomtags/(0054,1321)) `Decay Factor`.
+    Corresponds to [DICOM Tag (0054,1321)](https://www.dicomlookup.com/dicomtags/(0054,1321)) `Decay Factor`.
   type: array
   items:
     type: number
@@ -799,7 +799,7 @@ DeidentificationMethod:
   display_name: Deidentification Method
   description: |
     A description of the mechanism or method used to remove the Patient's identity.
-    Corresponds to [DICOM Tag (0012,0063)](http://www.dicomlookup.com/dicomtags/(0012,0063))
+    Corresponds to [DICOM Tag (0012,0063)](https://www.dicomlookup.com/dicomtags/(0012,0063))
     `De-identification Method`.
   type: array
   items:
@@ -809,7 +809,7 @@ DeidentificationMethodCodeSequence:
   display_name: Deidentification Method Code Sequence
   description: |
     A sequence of code objects describing the mechanism or method use to remove the Patient's identity.
-    Corresponds to [DICOM Tag (0012,0064)](http://www.dicomlookup.com/dicomtags/(0012,0064))
+    Corresponds to [DICOM Tag (0012,0064)](https://www.dicomlookup.com/dicomtags/(0012,0064))
     `De-identification Method Code Sequence`.
   type: array
   items:
@@ -1029,7 +1029,7 @@ DoseCalibrationFactor:
   display_name: Dose Calibration Factor
   description: |
     Multiplication factor used to transform raw data (in counts/sec) to meaningful unit (Bq/ml).
-    Corresponds to [DICOM Tag (0054,1322)](http://www.dicomlookup.com/dicomtags/(0054,1322))
+    Corresponds to [DICOM Tag (0054,1322)](https://www.dicomlookup.com/dicomtags/(0054,1322))
     `Dose Calibration Factor`.
   type: number
 DwellTime:
@@ -1262,7 +1262,7 @@ EchoTime:
   display_name: Echo Time
   description: |
     The echo time (TE) for the acquisition, specified in seconds.
-    Corresponds to [DICOM Tag (0018,0081)](http://www.dicomlookup.com/dicomtags/(0018,0081))
+    Corresponds to [DICOM Tag (0018,0081)](https://www.dicomlookup.com/dicomtags/(0018,0081))
     `Echo Time`
     (please note that the DICOM term is in milliseconds not seconds).
     The data type number may apply to files from any MRI modality concerned with
@@ -1530,7 +1530,7 @@ FlipAngle:
   display_name: Flip Angle
   description: |
     Flip angle (FA) for the acquisition, specified in degrees.
-    Corresponds to: [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
+    Corresponds to: [DICOM Tag (0018,1314)](https://www.dicomlookup.com/dicomtags/(0018,1314))
     `Flip Angle`.
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
@@ -1603,7 +1603,7 @@ FrameDuration:
   display_name: Frame Duration
   description: |
     Time duration of each frame in default unit seconds.
-    This corresponds to [DICOM Tag (0018,1242)](http://www.dicomlookup.com/dicomtags/(0018,1242))
+    This corresponds to [DICOM Tag (0018,1242)](https://www.dicomlookup.com/dicomtags/(0018,1242))
     `Actual Frame Duration` converted to seconds.
   type: array
   items:
@@ -1752,7 +1752,7 @@ HardcopyDeviceSoftwareVersion:
   description: |
     Manufacturer's designation of the software of the device that created this
     Hardcopy Image (the printer).
-    Corresponds to [DICOM Tag (0018,101A)](http://www.dicomlookup.com/dicomtags/(0018,101A))
+    Corresponds to [DICOM Tag (0018,101A)](https://www.dicomlookup.com/dicomtags/(0018,101A))
     `Hardcopy Device Software Version`.
   type: string
 HardwareFilters:
@@ -1975,7 +1975,7 @@ InjectedRadioactivity:
     Total amount of radioactivity injected into the patient (for example, `400`).
     For bolus-infusion experiments, this value should be the sum of all injected
     radioactivity originating from both bolus and infusion.
-    Corresponds to [DICOM Tag (0018,1074)](http://www.dicomlookup.com/dicomtags/(0018,1074))
+    Corresponds to [DICOM Tag (0018,1074)](https://www.dicomlookup.com/dicomtags/(0018,1074))
     `Radionuclide Total Dose`.
   type: number
 InjectedRadioactivityUnits:
@@ -1997,7 +1997,7 @@ InjectionEnd:
   display_name: Injection End
   description: |
     Time of end of injection with respect to `"TimeZero"`, in seconds.
-    Corresponds to [DICOM Tag (0018,1073)](http://www.dicomlookup.com/dicomtags/(0018,1073))
+    Corresponds to [DICOM Tag (0018,1073)](https://www.dicomlookup.com/dicomtags/(0018,1073))
     `Radiopharmaceutical Stop Time` converted to seconds relative to TimeZero.
   type: number
   unit: s
@@ -2006,7 +2006,7 @@ InjectionStart:
   display_name: Injection Start
   description: |
     Time of start of injection with respect to `"TimeZero"`, in seconds.
-    This corresponds to [DICOM Tag (0018,1072)](http://www.dicomlookup.com/dicomtags/(0018,1072))
+    This corresponds to [DICOM Tag (0018,1072)](https://www.dicomlookup.com/dicomtags/(0018,1072))
     `Contrast/Bolus Start Time` converted to seconds relative to `"TimeZero"`.
   type: number
   unit: s
@@ -2099,7 +2099,7 @@ InversionTime:
     The inversion time (TI) for the acquisition, specified in seconds.
     Inversion time is the time after the middle of inverting RF pulse to middle
     of excitation pulse to detect the amount of longitudinal magnetization.
-    Corresponds to [DICOM Tag (0018,0082)](http://www.dicomlookup.com/dicomtags/(0018,0082))
+    Corresponds to [DICOM Tag (0018,0082)](https://www.dicomlookup.com/dicomtags/(0018,0082))
     `Inversion Time`
     (please note that the DICOM term is in milliseconds not seconds).
   type: number
@@ -2148,7 +2148,7 @@ LabelingDuration:
     In case an array of numbers is provided,
     its length should be equal to the number of volumes specified in
     `*_aslcontext.tsv`.
-    Corresponds to [DICOM Tag (0018,9258)](http://www.dicomlookup.com/dicomtags/(0018,9258))
+    Corresponds to [DICOM Tag (0018,9258)](https://www.dicomlookup.com/dicomtags/(0018,9258))
     `ASL Pulse Train Duration`.
   anyOf:
     - type: number
@@ -2186,7 +2186,7 @@ LabelingOrientation:
     Orientation of the labeling plane (`(P)CASL`) or slab (`PASL`).
     The direction cosines of a normal vector perpendicular to the ASL labeling
     slab or plane with respect to the patient.
-    Corresponds to [DICOM Tag (0018,9255)](http://www.dicomlookup.com/dicomtags/(0018,9255))
+    Corresponds to [DICOM Tag (0018,9255)](https://www.dicomlookup.com/dicomtags/(0018,9255))
     `ASL Slab Orientation`.
   type: array
   items:
@@ -2249,7 +2249,7 @@ LabelingSlabThickness:
   description: |
     Thickness of the labeling slab in millimeters.
     For non-selective FAIR a zero is entered.
-    Corresponds to [DICOM Tag (0018,9254)](http://www.dicomlookup.com/dicomtags/(0018,9254))
+    Corresponds to [DICOM Tag (0018,9254)](https://www.dicomlookup.com/dicomtags/(0018,9254))
     `ASL Slab Thickness`.
   type: number
   exclusiveMinimum: 0
@@ -2410,7 +2410,7 @@ MRAcquisitionType:
   display_name: MR Acquisition Type
   description: |
     Type of sequence readout.
-    Corresponds to [DICOM Tag (0018,0023)](http://www.dicomlookup.com/dicomtags/(0018,0023))
+    Corresponds to [DICOM Tag (0018,0023)](https://www.dicomlookup.com/dicomtags/(0018,0023))
     `MR Acquisition Type`.
   type: string
   enum:
@@ -2422,7 +2422,7 @@ MRTransmitCoilSequence:
   display_name: MR Transmit Coil Sequence
   description: |
     This is a relevant field if a non-standard transmit coil is used.
-    Corresponds to [DICOM Tag (0018,9049)](http://www.dicomlookup.com/dicomtags/(0018,9049))
+    Corresponds to [DICOM Tag (0018,9049)](https://www.dicomlookup.com/dicomtags/(0018,9049))
     `MR Transmit Coil Sequence`.
   type: string
 MTNumberOfPulses:
@@ -2475,7 +2475,7 @@ MTState:
   display_name: MT State
   description: |
     Boolean stating whether the magnetization transfer pulse is applied.
-    Corresponds to [DICOM Tag (0018,9020)](http://www.dicomlookup.com/dicomtags/(0018,9020))
+    Corresponds to [DICOM Tag (0018,9020)](https://www.dicomlookup.com/dicomtags/(0018,9020))
     `Magnetization Transfer`.
   type: boolean
 MagneticFieldStrength:
@@ -2483,7 +2483,7 @@ MagneticFieldStrength:
   display_name: Magnetic Field Strength
   description: |
     Nominal field strength of MR magnet in Tesla.
-    Corresponds to [DICOM Tag (0018,0087)](http://www.dicomlookup.com/dicomtags/(0018,0087))
+    Corresponds to [DICOM Tag (0018,0087)](https://www.dicomlookup.com/dicomtags/(0018,0087))
     `Magnetic Field Strength`.
   type: number
 Magnification:
@@ -2638,7 +2638,7 @@ MolarActivity:
   display_name: Molar Activity
   description: |
     Molar activity of compound injected.
-    Corresponds to [DICOM Tag (0018,1077)](http://www.dicomlookup.com/dicomtags/(0018,1077))
+    Corresponds to [DICOM Tag (0018,1077)](https://www.dicomlookup.com/dicomtags/(0018,1077))
     `Radiopharmaceutical Specific Activity`.
   type: number
 MolarActivityMeasTime:
@@ -2911,7 +2911,7 @@ ParallelAcquisitionTechnique:
   display_name: Parallel Acquisition Technique
   description: |
     The type of parallel imaging used (for example `"GRAPPA"`, `"SENSE"`).
-    Corresponds to [DICOM Tag (0018,9078)](http://www.dicomlookup.com/dicomtags/(0018,9078))
+    Corresponds to [DICOM Tag (0018,9078)](https://www.dicomlookup.com/dicomtags/(0018,9078))
     `Parallel Acquisition Technique`.
   type: string
 ParallelReductionFactorInPlane:
@@ -2921,7 +2921,7 @@ ParallelReductionFactorInPlane:
     The parallel imaging (for instance, GRAPPA) factor in plane.
     Use the denominator of the fraction of k-space encoded for each slice.
     For example, 2 means half of k-space is encoded.
-    Corresponds to [DICOM Tag (0018,9069)](http://www.dicomlookup.com/dicomtags/(0018,9069))
+    Corresponds to [DICOM Tag (0018,9069)](https://www.dicomlookup.com/dicomtags/(0018,9069))
     `Parallel Reduction Factor In-plane`.
   type: number
 ParallelReductionFactorOutOfPlane:
@@ -2934,7 +2934,7 @@ ParallelReductionFactorOutOfPlane:
     Will typically be 1 for 2D sequences, as each slice in a 2D acquisition is usually fully encoded.
     `ParallelReductionFactorOutOfPlane` should not be confused with `MultibandAccelerationFactor`,
     as they imply different methods of accelerating the acquisition.
-    Corresponds to [DICOM Tag (0018,9155)](http://www.dicomlookup.com/dicomtags/(0018,9155))
+    Corresponds to [DICOM Tag (0018,9155)](https://www.dicomlookup.com/dicomtags/(0018,9155))
     `Parallel Reduction Factor out-of-plane`.
   type: number
 ParentCoordinateSystem:
@@ -2955,7 +2955,7 @@ PartialFourierDirection:
   display_name: Partial Fourier Direction
   description: |
     The direction where only partial Fourier information was collected.
-    Corresponds to [DICOM Tag (0018,9036)](http://www.dicomlookup.com/dicomtags/(0018,9036))
+    Corresponds to [DICOM Tag (0018,9036)](https://www.dicomlookup.com/dicomtags/(0018,9036))
     `Partial Fourier Direction`.
   type: string
 PharmaceuticalDoseAmount:
@@ -2963,7 +2963,7 @@ PharmaceuticalDoseAmount:
   display_name: Pharmaceutical Dose Amount
   description: |
     Dose amount of administered pharmaceutical.
-    Corresponds to [DICOM Tag (0018,0028)](http://www.dicomlookup.com/dicomtags/(0018,0028)) `Intervention Drug Dose`.
+    Corresponds to [DICOM Tag (0018,0028)](https://www.dicomlookup.com/dicomtags/(0018,0028)) `Intervention Drug Dose`.
   anyOf:
     - type: number
     - type: array
@@ -2988,8 +2988,8 @@ PharmaceuticalDoseTime:
     interpretation of `"PharmaceuticalDoseTime"`.
     Unit format of the specified pharmaceutical dose time MUST be seconds.
     Corresponds to a combination of
-    [DICOM Tag (0018,0027)](http://www.dicomlookup.com/dicomtags/(0018,0027)) `Intervention Drug Stop Time` and
-    [DICOM Tag (0018,0035)](http://www.dicomlookup.com/dicomtags/(0018,0035)) `Intervention Drug Start Time`.
+    [DICOM Tag (0018,0027)](https://www.dicomlookup.com/dicomtags/(0018,0027)) `Intervention Drug Stop Time` and
+    [DICOM Tag (0018,0035)](https://www.dicomlookup.com/dicomtags/(0018,0035)) `Intervention Drug Start Time`.
   anyOf:
     - type: number
       unit: s
@@ -3011,7 +3011,7 @@ PharmaceuticalName:
   description: |
     Name of administered pharmaceutical.
     Note that this is distinct from any radiotracer or contrast agent used in the scan protocol.
-    This partly matches [DICOM Tag (0018,0034)](http://www.dicomlookup.com/dicomtags/(0018,0034))
+    This partly matches [DICOM Tag (0018,0034)](https://www.dicomlookup.com/dicomtags/(0018,0034))
     `Intervention Drug Name`.
   type: string
 PhaseEncodingDirection:
@@ -3275,7 +3275,7 @@ ReceiveCoilName:
   display_name: Receive Coil Name
   description: |
     Information describing the receiver coil.
-    Corresponds to [DICOM Tag (0018,1250)](http://www.dicomlookup.com/dicomtags/(0018,1250))
+    Corresponds to [DICOM Tag (0018,1250)](https://www.dicomlookup.com/dicomtags/(0018,1250))
     `Receive Coil Name`,
     although not all vendors populate that DICOM Tag,
     in which case this field can be derived from an appropriate
@@ -3298,7 +3298,7 @@ ReconFilterSize:
   display_name: Recon Filter Size
   description: |
     Kernel size of post-recon filter (FWHM) in default units `"mm"`.
-    This partly matches the [DICOM Tag (0018,1210)](http://www.dicomlookup.com/dicomtags/(0018,1210))
+    This partly matches the [DICOM Tag (0018,1210)](https://www.dicomlookup.com/dicomtags/(0018,1210))
     `Convolution Kernel`.
   anyOf:
     - type: number
@@ -3312,7 +3312,7 @@ ReconFilterType:
   display_name: Recon Filter Type
   description: |
     Type of post-recon smoothing (for example, `["Shepp"]`).
-    This partly matches the [DICOM Tag (0018,1210)](http://www.dicomlookup.com/dicomtags/(0018,1210))
+    This partly matches the [DICOM Tag (0018,1210)](https://www.dicomlookup.com/dicomtags/(0018,1210))
     `Convolution Kernel`.
   anyOf:
     - type: string
@@ -3330,7 +3330,7 @@ ReconMethodName:
   display_name: Recon Method Name
   description: |
     Reconstruction method or algorithm (for example, `"3d-op-osem"`).
-    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](https://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: string
 ReconMethodParameterLabels:
@@ -3338,7 +3338,7 @@ ReconMethodParameterLabels:
   display_name: Recon Method Parameter Labels
   description: |
     Names of reconstruction parameters (for example, `["subsets", "iterations"]`).
-    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](https://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: array
   items:
@@ -3348,7 +3348,7 @@ ReconMethodParameterUnits:
   display_name: Recon Method Parameter Units
   description: |
     Unit of reconstruction parameters (for example, `["none", "none"]`).
-    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](https://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: array
   items:
@@ -3359,7 +3359,7 @@ ReconMethodParameterValues:
   display_name: Recon Method Parameter Values
   description: |
     Values of reconstruction parameters (for example, `[21, 3]`).
-    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](https://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: array
   items:
@@ -3427,10 +3427,10 @@ RepetitionTime:
     and the beginning of acquisition of the volume following it (TR).
     When used in the context of functional acquisitions this parameter best
     corresponds to
-    [DICOM Tag (0020,0110)](http://www.dicomlookup.com/dicomtags/(0020,0110)):
+    [DICOM Tag (0020,0110)](https://www.dicomlookup.com/dicomtags/(0020,0110)):
     the "time delta between images in a
     dynamic of functional set of images" but may also be found in
-    [DICOM Tag (0018,0080)](http://www.dicomlookup.com/dicomtags/(0018,0080)):
+    [DICOM Tag (0018,0080)](https://www.dicomlookup.com/dicomtags/(0018,0080)):
     "the period of time in msec between the beginning
     of a pulse sequence and the beginning of the succeeding
     (essentially identical) pulse sequence".
@@ -3447,7 +3447,7 @@ RepetitionTimeExcitation:
   display_name: Repetition Time Excitation
   description: |
     The interval, in seconds, between two successive excitations.
-    [DICOM Tag (0018,0080)](http://www.dicomlookup.com/dicomtags/(0018,0080))
+    [DICOM Tag (0018,0080)](https://www.dicomlookup.com/dicomtags/(0018,0080))
     best refers to this parameter.
     This field may be used together with the `"RepetitionTimePreparation"` for
     certain use cases, such as
@@ -3504,7 +3504,7 @@ ResonantNucleus:
     The isotope of interest of an MR experiment (for example, `"1H"`, `"13C"`, `"31P"`).
     For multi-nuclei experiments such as <sup>1</sup>H-[<sup>13</sup>C] MR,
     an array can be used: `["1H", "13C"]`.
-    Corresponds to [DICOM Tag (0018,9100)](http://www.dicomlookup.com/dicomtags/(0018,9100))
+    Corresponds to [DICOM Tag (0018,9100)](https://www.dicomlookup.com/dicomtags/(0018,9100))
     `Resonant Nucleus`.
   anyOf:
     - type: string
@@ -3705,7 +3705,7 @@ ScanDate:
   display_name: Scan Date
   description: |
     Date of scan in the format `"YYYY-MM-DD[Z]"`.
-    Corresponds to [DICOM Tag (0008,0022)](http://www.dicomlookup.com/dicomtags/(0008,0022)) `Acquisition Date`.
+    Corresponds to [DICOM Tag (0008,0022)](https://www.dicomlookup.com/dicomtags/(0008,0022)) `Acquisition Date`.
     This field is DEPRECATED, and this metadata SHOULD be recorded in the `acq_time` column of the
     corresponding [Scans file](SPEC_ROOT/modality-agnostic-files/data-summary-files.md#scans-file).
   type: string
@@ -3715,7 +3715,7 @@ ScanOptions:
   display_name: Scan Options
   description: |
     Parameters of ScanningSequence.
-    Corresponds to [DICOM Tag (0018,0022)](http://www.dicomlookup.com/dicomtags/(0018,0022))
+    Corresponds to [DICOM Tag (0018,0022)](https://www.dicomlookup.com/dicomtags/(0018,0022))
     `Scan Options`.
   anyOf:
     - type: string
@@ -3734,7 +3734,7 @@ ScanningSequence:
   display_name: Scanning Sequence
   description: |
     Description of the type of data acquired.
-    Corresponds to [DICOM Tag (0018,0020)](http://www.dicomlookup.com/dicomtags/(0018,0020))
+    Corresponds to [DICOM Tag (0018,0020)](https://www.dicomlookup.com/dicomtags/(0018,0020))
     `Scanning Sequence`.
   anyOf:
     - type: string
@@ -3756,7 +3756,7 @@ ScatterFraction:
   display_name: Scatter Fraction
   description: |
     Scatter fraction for each frame (Units: 0-100%).
-    Corresponds to [DICOM Tag (0054,1323)](http://www.dicomlookup.com/dicomtags/(0054,1323))
+    Corresponds to [DICOM Tag (0054,1323)](https://www.dicomlookup.com/dicomtags/(0054,1323))
     `Scatter Fraction Factor`.
   type: array
   items:
@@ -3850,7 +3850,7 @@ SequenceName:
   display_name: Sequence Name
   description: |
     Manufacturer's designation of the sequence name.
-    Corresponds to [DICOM Tag (0018,0024)](http://www.dicomlookup.com/dicomtags/(0018,0024))
+    Corresponds to [DICOM Tag (0018,0024)](https://www.dicomlookup.com/dicomtags/(0018,0024))
     `Sequence Name`.
   type: string
 SequenceVariant:
@@ -3858,7 +3858,7 @@ SequenceVariant:
   display_name: Sequence Variant
   description: |
     Variant of the ScanningSequence.
-    Corresponds to [DICOM Tag (0018,0021)](http://www.dicomlookup.com/dicomtags/(0018,0021))
+    Corresponds to [DICOM Tag (0018,0021)](https://www.dicomlookup.com/dicomtags/(0018,0021))
     `Sequence Variant`.
   anyOf:
     - type: string
@@ -4124,7 +4124,7 @@ SpectralWidth:
   display_name: Spectral Width
   description: |
     The spectral bandwidth of the MR signal that is sampled, specified in Hz.
-    Corresponds to [DICOM Tag (0018,9052)](http://www.dicomlookup.com/dicomtags/(0018,9052))
+    Corresponds to [DICOM Tag (0018,9052)](https://www.dicomlookup.com/dicomtags/(0018,9052))
     `Spectral Width`.
   type: number
   unit: Hz
@@ -4366,11 +4366,11 @@ TracerName:
   display_name: Tracer Name
   description: |
     Name of the tracer compound used (for example, `"CIMBI-36"`)
-    Corresponds to [DICOM Tag (0054,0300)](http://www.dicomlookup.com/dicomtags/(0054,0300))
+    Corresponds to [DICOM Tag (0054,0300)](https://www.dicomlookup.com/dicomtags/(0054,0300))
     `Radionuclide Code Sequence`,
-    extracted from the fields [0008, 0122](http://www.dicomlookup.com/dicomtags/(0008,0122))
+    extracted from the fields [0008, 0122](https://www.dicomlookup.com/dicomtags/(0008,0122))
     `Mapping Resource Name`
-    and/or [0008, 0105](http://www.dicomlookup.com/dicomtags/(0008,0105)) `Mapping Resource`.
+    and/or [0008, 0105](https://www.dicomlookup.com/dicomtags/(0008,0105)) `Mapping Resource`.
   type: string
 TracerRadLex:
   name: TracerRadLex
@@ -4383,10 +4383,10 @@ TracerRadionuclide:
   display_name: Tracer Radionuclide
   description: |
     Radioisotope labeling tracer (for example, `"C11"`).
-    Corresponds to [DICOM Tag (0054,0300)](http://www.dicomlookup.com/dicomtags/(0054,0300))
+    Corresponds to [DICOM Tag (0054,0300)](https://www.dicomlookup.com/dicomtags/(0054,0300))
     `Radionuclide Code Sequence`,
-    extracted from the fields [0008, 0100](http://www.dicomlookup.com/dicomtags/(0008,0100)) `Code Value`
-    and/or [0008, 0104](http://www.dicomlookup.com/dicomtags/(0008,0104)) `Code Meaning`.
+    extracted from the fields [0008, 0100](https://www.dicomlookup.com/dicomtags/(0008,0100)) `Code Value`
+    and/or [0008, 0104](https://www.dicomlookup.com/dicomtags/(0008,0104)) `Code Meaning`.
   type: string
 TracerSNOMED:
   name: TracerSNOMED
@@ -4469,7 +4469,7 @@ VascularCrushing:
   display_name: Vascular Crushing
   description: |
     Boolean indicating if Vascular Crushing is used.
-    Corresponds to [DICOM Tag (0018,9259)](http://www.dicomlookup.com/dicomtags/(0018,9259))
+    Corresponds to [DICOM Tag (0018,9259)](https://www.dicomlookup.com/dicomtags/(0018,9259))
     `ASL Crusher Flag`.
   type: boolean
 VascularCrushingVENC:
@@ -4480,7 +4480,7 @@ VascularCrushingVENC:
     Specify either one number for the total time-series, or provide an array of
     numbers, for example when using QUASAR, using the value zero to identify
     volumes for which `VascularCrushing` was turned off.
-    Corresponds to [DICOM Tag (0018,925A)](http://www.dicomlookup.com/dicomtags/(0018,925A))
+    Corresponds to [DICOM Tag (0018,925A)](https://www.dicomlookup.com/dicomtags/(0018,925A))
     `ASL Crusher Flow Limit`.
   anyOf:
     - type: number

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -4368,9 +4368,9 @@ TracerName:
     Name of the tracer compound used (for example, `"CIMBI-36"`)
     Corresponds to [DICOM Tag (0054,0300)](https://www.dicomlookup.com/dicomtags/(0054,0300))
     `Radionuclide Code Sequence`,
-    extracted from the fields [0008, 0122](https://www.dicomlookup.com/dicomtags/(0008,0122))
+    extracted from the fields [(0008,0122)](https://www.dicomlookup.com/dicomtags/(0008,0122))
     `Mapping Resource Name`
-    and/or [0008, 0105](https://www.dicomlookup.com/dicomtags/(0008,0105)) `Mapping Resource`.
+    and/or [(0008,0105)](https://www.dicomlookup.com/dicomtags/(0008,0105)) `Mapping Resource`.
   type: string
 TracerRadLex:
   name: TracerRadLex
@@ -4385,8 +4385,9 @@ TracerRadionuclide:
     Radioisotope labeling tracer (for example, `"C11"`).
     Corresponds to [DICOM Tag (0054,0300)](https://www.dicomlookup.com/dicomtags/(0054,0300))
     `Radionuclide Code Sequence`,
-    extracted from the fields [0008, 0100](https://www.dicomlookup.com/dicomtags/(0008,0100)) `Code Value`
-    and/or [0008, 0104](https://www.dicomlookup.com/dicomtags/(0008,0104)) `Code Meaning`.
+    extracted from the fields
+    [(0008,0100)](https://www.dicomlookup.com/dicomtags/(0008,0100)) `Code Value`
+    and/or [(0008,0104)](https://www.dicomlookup.com/dicomtags/(0008,0104)) `Code Meaning`.
   type: string
 TracerSNOMED:
   name: TracerSNOMED

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -409,7 +409,7 @@ BolusCutOffFlag:
   description: |
     Boolean indicating if a bolus cut-off technique is used.
     Corresponds to [DICOM Tag (0018,925C)](https://www.dicomlookup.com/dicomtags/(0018,925C))
-    `ASLBolusCutoffFlag`.
+    `ASL Bolus Cut-off Flag`.
   type: boolean
 BolusCutOffTechnique:
   name: BolusCutOffTechnique
@@ -417,7 +417,7 @@ BolusCutOffTechnique:
   description: |
     Name of the technique used, for example `"Q2TIPS"`, `"QUIPSS"`, `"QUIPSSII"`.
     Corresponds to [DICOM Tag (0018,925E)](https://www.dicomlookup.com/dicomtags/(0018,925E))
-    `ASLBolusCutoffTechnique`.
+    `ASL Bolus Cut-off Technique`.
   type: string
 BrainLocation:
   name: BrainLocation
@@ -3125,7 +3125,7 @@ PostLabelingDelay:
     Any image within the time-series without a PLD, for example an `m0scan`,
     is indicated by a zero.
     Based on DICOM Tags (0018,9079) `Inversion Times` and (0018,0082)
-    `InversionTime`.
+    `Inversion Time`.
   anyOf:
     - type: number
       minimum: 0

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -265,7 +265,7 @@ B0FieldIdentifier:
     particular instance of the *B<sub>0</sub> field* estimation.
     It is RECOMMENDED to derive this identifier from DICOM Tags, for example,
     DICOM Tag (0018,1030) `Protocol Name`, or DICOM Tag (0018,0024) `Sequence Name`
-    when the former is not defined (for example, in GE devices.)
+    when the former is not defined (for example, on GE devices).
   anyOf:
     - type: string
     - type: array

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -40,7 +40,7 @@ AcquisitionDuration:
   display_name: Acquisition Duration
   description: |
     Duration (in seconds) of scan acquisition, including all volumes for multi-volume scans.
-    Corresponds to [DICOM Tag 0018, 9073](http://www.dicomlookup.com/dicomtags/(0018,9073))
+    Corresponds to [DICOM Tag (0018,9073)](http://www.dicomlookup.com/dicomtags/(0018,9073))
     `Acquisition Duration`.
   type: number
   exclusiveMinimum: 0
@@ -230,7 +230,7 @@ AttenuationCorrection:
   display_name: Attenuation Correction
   description: |
     Short description of the attenuation correction method used.
-    Corresponds to [DICOM Tag 0054, 1101](http://www.dicomlookup.com/dicomtags/(0054,1101))
+    Corresponds to [DICOM Tag (0054,1101)](http://www.dicomlookup.com/dicomtags/(0054,1101))
     `Attenuation Correction Method`.
   type: string
 AttenuationCorrectionMethodReference:
@@ -264,7 +264,7 @@ B0FieldIdentifier:
     shared only by the images meant to be used as inputs for the estimation of a
     particular instance of the *B<sub>0</sub> field* estimation.
     It is RECOMMENDED to derive this identifier from DICOM Tags, for example,
-    DICOM tag 0018, 1030 `Protocol Name`, or DICOM tag 0018, 0024 `Sequence Name`
+    DICOM Tag (0018,1030) `Protocol Name`, or DICOM Tag (0018,0024) `Sequence Name`
     when the former is not defined (for example, in GE devices.)
   anyOf:
     - type: string
@@ -365,7 +365,7 @@ BodyPart:
   display_name: Body Part
   description: |
     Body part of the organ / body region scanned.
-    Corresponds to [DICOM Tag 0018, 0015](http://www.dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
+    Corresponds to [DICOM Tag (0018,0015)](http://www.dicomlookup.com/dicomtags/(0018,0015)) `Body Part Examined`.
   type: string
 BodyPartDetails:
   name: BodyPartDetails
@@ -392,7 +392,7 @@ BolusCutOffDelayTime:
     cut-off saturation pulses.
     For Q2TIPS, only the values for the first and last bolus cut-off saturation
     pulses are provided.
-    Based on [DICOM Tag 0018, 925F](http://www.dicomlookup.com/dicomtags/(0018,925F))
+    Based on [DICOM Tag (0018,925F)](http://www.dicomlookup.com/dicomtags/(0018,925F))
     `ASL Bolus Cut-off Delay Time`.
   anyOf:
     - type: number
@@ -408,16 +408,16 @@ BolusCutOffFlag:
   display_name: Bolus Cut Off Flag
   description: |
     Boolean indicating if a bolus cut-off technique is used.
-    Corresponds to [DICOM Tag 0018, 925C](http://www.dicomlookup.com/dicomtags/(0018,925C))
-    `ASL Bolus Cut-off Flag`.
+    Corresponds to [DICOM Tag (0018,925C)](http://www.dicomlookup.com/dicomtags/(0018,925C))
+    `ASLBolusCutoffFlag`.
   type: boolean
 BolusCutOffTechnique:
   name: BolusCutOffTechnique
   display_name: Bolus Cut Off Technique
   description: |
     Name of the technique used, for example `"Q2TIPS"`, `"QUIPSS"`, `"QUIPSSII"`.
-    Corresponds to [DICOM Tag 0018, 925E](http://www.dicomlookup.com/dicomtags/(0018,925E))
-    `ASL Bolus Cut-off Technique`.
+    Corresponds to [DICOM Tag (0018,925E)](http://www.dicomlookup.com/dicomtags/(0018,925E))
+    `ASLBolusCutoffTechnique`.
   type: string
 BrainLocation:
   name: BrainLocation
@@ -515,7 +515,7 @@ ChemicalShiftReference:
   display_name: Chemical Shift Reference
   description: |
     The chemical shift at the transmitter frequency, specified in ppm (for example, `2.68`).
-    Corresponds to [DICOM Tag 0018, 9053](http://www.dicomlookup.com/dicomtags/(0018,9053))
+    Corresponds to [DICOM Tag (0018,9053)](http://www.dicomlookup.com/dicomtags/(0018,9053))
     `Chemical Shift Reference`.
   type: number
   unit: ppm
@@ -577,7 +577,7 @@ CodeValue:
   description: |
     An identifier that is unambiguous within the Coding Scheme
     denoted by Coding Scheme Designator and Coding Scheme Version.
-    Corresponds to [DICOM Tag 0008, 0100](http://www.dicomlookup.com/dicomtags/(0008,0100))
+    Corresponds to [DICOM Tag (0008,0100)](http://www.dicomlookup.com/dicomtags/(0008,0100))
     `Code Value`.
   type: string
 CodeMeaning:
@@ -585,7 +585,7 @@ CodeMeaning:
   display_name: Code Meaning
   description: |
     Text that has meaning to a human and conveys the meaning of the term
-    Corresponds to [DICOM Tag 0008, 0104](http://www.dicomlookup.com/dicomtags/(0008,0104))
+    Corresponds to [DICOM Tag (0008,0104)](http://www.dicomlookup.com/dicomtags/(0008,0104))
     `Code Meaning`.
   type: string
 CodingSchemeDesignator:
@@ -593,7 +593,7 @@ CodingSchemeDesignator:
   display_name: Coding Scheme Designator
   description: |
     The identifier of the coding scheme in which the coded entry is defined.
-    Corresponds to [DICOM Tag 0008, 0102](http://www.dicomlookup.com/dicomtags/(0008,0102))
+    Corresponds to [DICOM Tag (0008,0102)](http://www.dicomlookup.com/dicomtags/(0008,0102))
     `Coding Scheme Designator`.
   type: string
 CodingSchemeVersion:
@@ -601,7 +601,7 @@ CodingSchemeVersion:
   display_name: Coding Scheme version
   description: |
     An identifier of the version of the coding scheme if necessary to resolve ambiguity.
-    Corresponds to [DICOM Tag 0008, 0103](http://www.dicomlookup.com/dicomtags/(0008,0103))
+    Corresponds to [DICOM Tag (0008,0103)](http://www.dicomlookup.com/dicomtags/(0008,0103))
     `Coding Scheme Version`.
   type: string
 CodeURL:
@@ -695,7 +695,7 @@ ContrastBolusIngredient:
   display_name: Contrast Bolus Ingredient
   description: |
     Active ingredient of agent.
-    Corresponds to [DICOM Tag 0018, 1048](http://www.dicomlookup.com/dicomtags/(0018,1048))
+    Corresponds to [DICOM Tag (0018,1048)](http://www.dicomlookup.com/dicomtags/(0018,1048))
     `Contrast/Bolus Ingredient`.
   type: string
   enum:
@@ -790,7 +790,7 @@ DecayCorrectionFactor:
   display_name: Decay Correction Factor
   description: |
     Decay correction factor for each frame.
-    Corresponds to [DICOM Tag 0054, 1321](http://www.dicomlookup.com/dicomtags/(0054,1321)) `Decay Factor`.
+    Corresponds to [DICOM Tag (0054,1321)](http://www.dicomlookup.com/dicomtags/(0054,1321)) `Decay Factor`.
   type: array
   items:
     type: number
@@ -799,7 +799,7 @@ DeidentificationMethod:
   display_name: Deidentification Method
   description: |
     A description of the mechanism or method used to remove the Patient's identity.
-    Corresponds to [DICOM Tag 0012, 0063](http://www.dicomlookup.com/dicomtags/(0012,0063))
+    Corresponds to [DICOM Tag (0012,0063)](http://www.dicomlookup.com/dicomtags/(0012,0063))
     `De-identification Method`.
   type: array
   items:
@@ -809,7 +809,7 @@ DeidentificationMethodCodeSequence:
   display_name: Deidentification Method Code Sequence
   description: |
     A sequence of code objects describing the mechanism or method use to remove the Patient's identity.
-    Corresponds to [DICOM Tag 0012, 0064](http://www.dicomlookup.com/dicomtags/(0012,0064))
+    Corresponds to [DICOM Tag (0012,0064)](http://www.dicomlookup.com/dicomtags/(0012,0064))
     `De-identification Method Code Sequence`.
   type: array
   items:
@@ -1029,7 +1029,7 @@ DoseCalibrationFactor:
   display_name: Dose Calibration Factor
   description: |
     Multiplication factor used to transform raw data (in counts/sec) to meaningful unit (Bq/ml).
-    Corresponds to [DICOM Tag 0054, 1322](http://www.dicomlookup.com/dicomtags/(0054,1322))
+    Corresponds to [DICOM Tag (0054,1322)](http://www.dicomlookup.com/dicomtags/(0054,1322))
     `Dose Calibration Factor`.
   type: number
 DwellTime:
@@ -1262,7 +1262,7 @@ EchoTime:
   display_name: Echo Time
   description: |
     The echo time (TE) for the acquisition, specified in seconds.
-    Corresponds to [DICOM Tag 0018, 0081](http://www.dicomlookup.com/dicomtags/(0018,0081))
+    Corresponds to [DICOM Tag (0018,0081)](http://www.dicomlookup.com/dicomtags/(0018,0081))
     `Echo Time`
     (please note that the DICOM term is in milliseconds not seconds).
     The data type number may apply to files from any MRI modality concerned with
@@ -1530,7 +1530,7 @@ FlipAngle:
   display_name: Flip Angle
   description: |
     Flip angle (FA) for the acquisition, specified in degrees.
-    Corresponds to: [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
+    Corresponds to: [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
     `Flip Angle`.
     The data type number may apply to files from any MRI modality concerned with
     a single value for this field, or to the files in a
@@ -1594,7 +1594,7 @@ FrameAcquisitionDuration:
   display_name: Frame Acquisition Duration
   description: |
     Duration (in seconds) of volume acquisition.
-    Corresponds to DICOM Tag 0018, 9220 `Frame Acquisition Duration`.
+    Corresponds to DICOM Tag (0018,9220) `Frame Acquisition Duration`.
   type: number
   exclusiveMinimum: 0
   unit: s
@@ -1603,7 +1603,7 @@ FrameDuration:
   display_name: Frame Duration
   description: |
     Time duration of each frame in default unit seconds.
-    This corresponds to [DICOM Tag 0018, 1242](http://www.dicomlookup.com/dicomtags/(0018,1242))
+    This corresponds to [DICOM Tag (0018,1242)](http://www.dicomlookup.com/dicomtags/(0018,1242))
     `Actual Frame Duration` converted to seconds.
   type: array
   items:
@@ -1752,7 +1752,7 @@ HardcopyDeviceSoftwareVersion:
   description: |
     Manufacturer's designation of the software of the device that created this
     Hardcopy Image (the printer).
-    Corresponds to [DICOM Tag 0018, 101A](http://www.dicomlookup.com/dicomtags/(0018,101A))
+    Corresponds to [DICOM Tag (0018,101A)](http://www.dicomlookup.com/dicomtags/(0018,101A))
     `Hardcopy Device Software Version`.
   type: string
 HardwareFilters:
@@ -1975,7 +1975,7 @@ InjectedRadioactivity:
     Total amount of radioactivity injected into the patient (for example, `400`).
     For bolus-infusion experiments, this value should be the sum of all injected
     radioactivity originating from both bolus and infusion.
-    Corresponds to [DICOM Tag 0018, 1074](http://www.dicomlookup.com/dicomtags/(0018,1074))
+    Corresponds to [DICOM Tag (0018,1074)](http://www.dicomlookup.com/dicomtags/(0018,1074))
     `Radionuclide Total Dose`.
   type: number
 InjectedRadioactivityUnits:
@@ -1997,7 +1997,7 @@ InjectionEnd:
   display_name: Injection End
   description: |
     Time of end of injection with respect to `"TimeZero"`, in seconds.
-    Corresponds to [DICOM Tag 0018, 1073](http://www.dicomlookup.com/dicomtags/(0018,1073))
+    Corresponds to [DICOM Tag (0018,1073)](http://www.dicomlookup.com/dicomtags/(0018,1073))
     `Radiopharmaceutical Stop Time` converted to seconds relative to TimeZero.
   type: number
   unit: s
@@ -2006,7 +2006,7 @@ InjectionStart:
   display_name: Injection Start
   description: |
     Time of start of injection with respect to `"TimeZero"`, in seconds.
-    This corresponds to [DICOM Tag 0018, 1072](http://www.dicomlookup.com/dicomtags/(0018,1072))
+    This corresponds to [DICOM Tag (0018,1072)](http://www.dicomlookup.com/dicomtags/(0018,1072))
     `Contrast/Bolus Start Time` converted to seconds relative to `"TimeZero"`.
   type: number
   unit: s
@@ -2099,7 +2099,7 @@ InversionTime:
     The inversion time (TI) for the acquisition, specified in seconds.
     Inversion time is the time after the middle of inverting RF pulse to middle
     of excitation pulse to detect the amount of longitudinal magnetization.
-    Corresponds to [DICOM Tag 0018, 0082](http://www.dicomlookup.com/dicomtags/(0018,0082))
+    Corresponds to [DICOM Tag (0018,0082)](http://www.dicomlookup.com/dicomtags/(0018,0082))
     `Inversion Time`
     (please note that the DICOM term is in milliseconds not seconds).
   type: number
@@ -2148,7 +2148,7 @@ LabelingDuration:
     In case an array of numbers is provided,
     its length should be equal to the number of volumes specified in
     `*_aslcontext.tsv`.
-    Corresponds to [DICOM Tag 0018, 9258](http://www.dicomlookup.com/dicomtags/(0018,9258))
+    Corresponds to [DICOM Tag (0018,9258)](http://www.dicomlookup.com/dicomtags/(0018,9258))
     `ASL Pulse Train Duration`.
   anyOf:
     - type: number
@@ -2186,7 +2186,7 @@ LabelingOrientation:
     Orientation of the labeling plane (`(P)CASL`) or slab (`PASL`).
     The direction cosines of a normal vector perpendicular to the ASL labeling
     slab or plane with respect to the patient.
-    Corresponds to [DICOM Tag 0018, 9255](http://www.dicomlookup.com/dicomtags/(0018,9255))
+    Corresponds to [DICOM Tag (0018,9255)](http://www.dicomlookup.com/dicomtags/(0018,9255))
     `ASL Slab Orientation`.
   type: array
   items:
@@ -2249,7 +2249,7 @@ LabelingSlabThickness:
   description: |
     Thickness of the labeling slab in millimeters.
     For non-selective FAIR a zero is entered.
-    Corresponds to [DICOM Tag 0018, 9254](http://www.dicomlookup.com/dicomtags/(0018,9254))
+    Corresponds to [DICOM Tag (0018,9254)](http://www.dicomlookup.com/dicomtags/(0018,9254))
     `ASL Slab Thickness`.
   type: number
   exclusiveMinimum: 0
@@ -2410,7 +2410,7 @@ MRAcquisitionType:
   display_name: MR Acquisition Type
   description: |
     Type of sequence readout.
-    Corresponds to [DICOM Tag 0018, 0023](http://www.dicomlookup.com/dicomtags/(0018,0023))
+    Corresponds to [DICOM Tag (0018,0023)](http://www.dicomlookup.com/dicomtags/(0018,0023))
     `MR Acquisition Type`.
   type: string
   enum:
@@ -2422,7 +2422,7 @@ MRTransmitCoilSequence:
   display_name: MR Transmit Coil Sequence
   description: |
     This is a relevant field if a non-standard transmit coil is used.
-    Corresponds to [DICOM Tag 0018, 9049](http://www.dicomlookup.com/dicomtags/(0018,9049))
+    Corresponds to [DICOM Tag (0018,9049)](http://www.dicomlookup.com/dicomtags/(0018,9049))
     `MR Transmit Coil Sequence`.
   type: string
 MTNumberOfPulses:
@@ -2475,7 +2475,7 @@ MTState:
   display_name: MT State
   description: |
     Boolean stating whether the magnetization transfer pulse is applied.
-    Corresponds to [DICOM Tag 0018, 9020](http://www.dicomlookup.com/dicomtags/(0018,9020))
+    Corresponds to [DICOM Tag (0018,9020)](http://www.dicomlookup.com/dicomtags/(0018,9020))
     `Magnetization Transfer`.
   type: boolean
 MagneticFieldStrength:
@@ -2483,7 +2483,7 @@ MagneticFieldStrength:
   display_name: Magnetic Field Strength
   description: |
     Nominal field strength of MR magnet in Tesla.
-    Corresponds to [DICOM Tag 0018, 0087](http://www.dicomlookup.com/dicomtags/(0018,0087))
+    Corresponds to [DICOM Tag (0018,0087)](http://www.dicomlookup.com/dicomtags/(0018,0087))
     `Magnetic Field Strength`.
   type: number
 Magnification:
@@ -2638,7 +2638,7 @@ MolarActivity:
   display_name: Molar Activity
   description: |
     Molar activity of compound injected.
-    Corresponds to [DICOM Tag 0018, 1077](http://www.dicomlookup.com/dicomtags/(0018,1077))
+    Corresponds to [DICOM Tag (0018,1077)](http://www.dicomlookup.com/dicomtags/(0018,1077))
     `Radiopharmaceutical Specific Activity`.
   type: number
 MolarActivityMeasTime:
@@ -2911,7 +2911,7 @@ ParallelAcquisitionTechnique:
   display_name: Parallel Acquisition Technique
   description: |
     The type of parallel imaging used (for example `"GRAPPA"`, `"SENSE"`).
-    Corresponds to [DICOM Tag 0018, 9078](http://www.dicomlookup.com/dicomtags/(0018,9078))
+    Corresponds to [DICOM Tag (0018,9078)](http://www.dicomlookup.com/dicomtags/(0018,9078))
     `Parallel Acquisition Technique`.
   type: string
 ParallelReductionFactorInPlane:
@@ -2921,7 +2921,7 @@ ParallelReductionFactorInPlane:
     The parallel imaging (for instance, GRAPPA) factor in plane.
     Use the denominator of the fraction of k-space encoded for each slice.
     For example, 2 means half of k-space is encoded.
-    Corresponds to [DICOM Tag 0018, 9069](http://www.dicomlookup.com/dicomtags/(0018,9069))
+    Corresponds to [DICOM Tag (0018,9069)](http://www.dicomlookup.com/dicomtags/(0018,9069))
     `Parallel Reduction Factor In-plane`.
   type: number
 ParallelReductionFactorOutOfPlane:
@@ -2934,7 +2934,7 @@ ParallelReductionFactorOutOfPlane:
     Will typically be 1 for 2D sequences, as each slice in a 2D acquisition is usually fully encoded.
     `ParallelReductionFactorOutOfPlane` should not be confused with `MultibandAccelerationFactor`,
     as they imply different methods of accelerating the acquisition.
-    Corresponds to [DICOM Tag 0018, 9155](http://www.dicomlookup.com/dicomtags/(0018,9155))
+    Corresponds to [DICOM Tag (0018,9155)](http://www.dicomlookup.com/dicomtags/(0018,9155))
     `Parallel Reduction Factor out-of-plane`.
   type: number
 ParentCoordinateSystem:
@@ -2955,7 +2955,7 @@ PartialFourierDirection:
   display_name: Partial Fourier Direction
   description: |
     The direction where only partial Fourier information was collected.
-    Corresponds to [DICOM Tag 0018, 9036](http://www.dicomlookup.com/dicomtags/(0018,9036))
+    Corresponds to [DICOM Tag (0018,9036)](http://www.dicomlookup.com/dicomtags/(0018,9036))
     `Partial Fourier Direction`.
   type: string
 PharmaceuticalDoseAmount:
@@ -2963,7 +2963,7 @@ PharmaceuticalDoseAmount:
   display_name: Pharmaceutical Dose Amount
   description: |
     Dose amount of administered pharmaceutical.
-    Corresponds to [DICOM Tag 0018, 0028](http://www.dicomlookup.com/dicomtags/(0018,0028)) `Intervention Drug Dose`.
+    Corresponds to [DICOM Tag (0018,0028)](http://www.dicomlookup.com/dicomtags/(0018,0028)) `Intervention Drug Dose`.
   anyOf:
     - type: number
     - type: array
@@ -2987,9 +2987,9 @@ PharmaceuticalDoseTime:
     the regimen description should be complete enough to enable unambiguous
     interpretation of `"PharmaceuticalDoseTime"`.
     Unit format of the specified pharmaceutical dose time MUST be seconds.
-    Corresponds to a combination of DICOM Tags
-    [0018, 0027](http://www.dicomlookup.com/dicomtags/(0018,0027)) `Intervention Drug Stop Time` and
-    [0018, 0035](http://www.dicomlookup.com/dicomtags/(0018,0035)) `Intervention Drug Start Time`.
+    Corresponds to a combination of
+    [DICOM Tag (0018,0027)](http://www.dicomlookup.com/dicomtags/(0018,0027)) `Intervention Drug Stop Time` and
+    [DICOM Tag (0018,0035)](http://www.dicomlookup.com/dicomtags/(0018,0035)) `Intervention Drug Start Time`.
   anyOf:
     - type: number
       unit: s
@@ -3011,7 +3011,7 @@ PharmaceuticalName:
   description: |
     Name of administered pharmaceutical.
     Note that this is distinct from any radiotracer or contrast agent used in the scan protocol.
-    This partly matches [DICOM Tag 0018, 0034](http://www.dicomlookup.com/dicomtags/(0018,0034))
+    This partly matches [DICOM Tag (0018,0034)](http://www.dicomlookup.com/dicomtags/(0018,0034))
     `Intervention Drug Name`.
   type: string
 PhaseEncodingDirection:
@@ -3124,7 +3124,7 @@ PostLabelingDelay:
     namely each `control` and `label`, in the acquisition order.
     Any image within the time-series without a PLD, for example an `m0scan`,
     is indicated by a zero.
-    Based on DICOM Tags 0018, 9079 `Inversion Times` and 0018, 0082
+    Based on DICOM Tags (0018,9079) `Inversion Times` and (0018,0082)
     `InversionTime`.
   anyOf:
     - type: number
@@ -3275,7 +3275,7 @@ ReceiveCoilName:
   display_name: Receive Coil Name
   description: |
     Information describing the receiver coil.
-    Corresponds to [DICOM Tag 0018, 1250](http://www.dicomlookup.com/dicomtags/(0018,1250))
+    Corresponds to [DICOM Tag (0018,1250)](http://www.dicomlookup.com/dicomtags/(0018,1250))
     `Receive Coil Name`,
     although not all vendors populate that DICOM Tag,
     in which case this field can be derived from an appropriate
@@ -3298,7 +3298,7 @@ ReconFilterSize:
   display_name: Recon Filter Size
   description: |
     Kernel size of post-recon filter (FWHM) in default units `"mm"`.
-    This partly matches the [DICOM Tag 0018, 1210](http://www.dicomlookup.com/dicomtags/(0018,1210))
+    This partly matches the [DICOM Tag (0018,1210)](http://www.dicomlookup.com/dicomtags/(0018,1210))
     `Convolution Kernel`.
   anyOf:
     - type: number
@@ -3312,7 +3312,7 @@ ReconFilterType:
   display_name: Recon Filter Type
   description: |
     Type of post-recon smoothing (for example, `["Shepp"]`).
-    This partly matches the [DICOM Tag 0018, 1210](http://www.dicomlookup.com/dicomtags/(0018,1210))
+    This partly matches the [DICOM Tag (0018,1210)](http://www.dicomlookup.com/dicomtags/(0018,1210))
     `Convolution Kernel`.
   anyOf:
     - type: string
@@ -3330,7 +3330,7 @@ ReconMethodName:
   display_name: Recon Method Name
   description: |
     Reconstruction method or algorithm (for example, `"3d-op-osem"`).
-    This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: string
 ReconMethodParameterLabels:
@@ -3338,7 +3338,7 @@ ReconMethodParameterLabels:
   display_name: Recon Method Parameter Labels
   description: |
     Names of reconstruction parameters (for example, `["subsets", "iterations"]`).
-    This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: array
   items:
@@ -3348,7 +3348,7 @@ ReconMethodParameterUnits:
   display_name: Recon Method Parameter Units
   description: |
     Unit of reconstruction parameters (for example, `["none", "none"]`).
-    This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: array
   items:
@@ -3359,7 +3359,7 @@ ReconMethodParameterValues:
   display_name: Recon Method Parameter Values
   description: |
     Values of reconstruction parameters (for example, `[21, 3]`).
-    This partly matches the [DICOM Tag 0054, 1103](http://www.dicomlookup.com/dicomtags/(0054,1103))
+    This partly matches the [DICOM Tag (0054,1103)](http://www.dicomlookup.com/dicomtags/(0054,1103))
     `Reconstruction Method`.
   type: array
   items:
@@ -3427,10 +3427,10 @@ RepetitionTime:
     and the beginning of acquisition of the volume following it (TR).
     When used in the context of functional acquisitions this parameter best
     corresponds to
-    [DICOM Tag 0020, 0110](http://www.dicomlookup.com/dicomtags/(0020,0110)):
+    [DICOM Tag (0020,0110)](http://www.dicomlookup.com/dicomtags/(0020,0110)):
     the "time delta between images in a
     dynamic of functional set of images" but may also be found in
-    [DICOM Tag 0018, 0080](http://www.dicomlookup.com/dicomtags/(0018,0080)):
+    [DICOM Tag (0018,0080)](http://www.dicomlookup.com/dicomtags/(0018,0080)):
     "the period of time in msec between the beginning
     of a pulse sequence and the beginning of the succeeding
     (essentially identical) pulse sequence".
@@ -3447,7 +3447,7 @@ RepetitionTimeExcitation:
   display_name: Repetition Time Excitation
   description: |
     The interval, in seconds, between two successive excitations.
-    [DICOM Tag 0018, 0080](http://www.dicomlookup.com/dicomtags/(0018,0080))
+    [DICOM Tag (0018,0080)](http://www.dicomlookup.com/dicomtags/(0018,0080))
     best refers to this parameter.
     This field may be used together with the `"RepetitionTimePreparation"` for
     certain use cases, such as
@@ -3504,7 +3504,7 @@ ResonantNucleus:
     The isotope of interest of an MR experiment (for example, `"1H"`, `"13C"`, `"31P"`).
     For multi-nuclei experiments such as <sup>1</sup>H-[<sup>13</sup>C] MR,
     an array can be used: `["1H", "13C"]`.
-    Corresponds to [DICOM Tag 0018, 9100](http://www.dicomlookup.com/dicomtags/(0018,9100))
+    Corresponds to [DICOM Tag (0018,9100)](http://www.dicomlookup.com/dicomtags/(0018,9100))
     `Resonant Nucleus`.
   anyOf:
     - type: string
@@ -3705,7 +3705,7 @@ ScanDate:
   display_name: Scan Date
   description: |
     Date of scan in the format `"YYYY-MM-DD[Z]"`.
-    Corresponds to [DICOM Tag 0008, 0022](http://www.dicomlookup.com/dicomtags/(0008,0022)) `Acquisition Date`.
+    Corresponds to [DICOM Tag (0008,0022)](http://www.dicomlookup.com/dicomtags/(0008,0022)) `Acquisition Date`.
     This field is DEPRECATED, and this metadata SHOULD be recorded in the `acq_time` column of the
     corresponding [Scans file](SPEC_ROOT/modality-agnostic-files/data-summary-files.md#scans-file).
   type: string
@@ -3715,7 +3715,7 @@ ScanOptions:
   display_name: Scan Options
   description: |
     Parameters of ScanningSequence.
-    Corresponds to [DICOM Tag 0018, 0022](http://www.dicomlookup.com/dicomtags/(0018,0022))
+    Corresponds to [DICOM Tag (0018,0022)](http://www.dicomlookup.com/dicomtags/(0018,0022))
     `Scan Options`.
   anyOf:
     - type: string
@@ -3734,7 +3734,7 @@ ScanningSequence:
   display_name: Scanning Sequence
   description: |
     Description of the type of data acquired.
-    Corresponds to [DICOM Tag 0018, 0020](http://www.dicomlookup.com/dicomtags/(0018,0020))
+    Corresponds to [DICOM Tag (0018,0020)](http://www.dicomlookup.com/dicomtags/(0018,0020))
     `Scanning Sequence`.
   anyOf:
     - type: string
@@ -3756,7 +3756,7 @@ ScatterFraction:
   display_name: Scatter Fraction
   description: |
     Scatter fraction for each frame (Units: 0-100%).
-    Corresponds to [DICOM Tag 0054, 1323](http://www.dicomlookup.com/dicomtags/(0054,1323))
+    Corresponds to [DICOM Tag (0054,1323)](http://www.dicomlookup.com/dicomtags/(0054,1323))
     `Scatter Fraction Factor`.
   type: array
   items:
@@ -3850,7 +3850,7 @@ SequenceName:
   display_name: Sequence Name
   description: |
     Manufacturer's designation of the sequence name.
-    Corresponds to [DICOM Tag 0018, 0024](http://www.dicomlookup.com/dicomtags/(0018,0024))
+    Corresponds to [DICOM Tag (0018,0024)](http://www.dicomlookup.com/dicomtags/(0018,0024))
     `Sequence Name`.
   type: string
 SequenceVariant:
@@ -3858,7 +3858,7 @@ SequenceVariant:
   display_name: Sequence Variant
   description: |
     Variant of the ScanningSequence.
-    Corresponds to [DICOM Tag 0018, 0021](http://www.dicomlookup.com/dicomtags/(0018,0021))
+    Corresponds to [DICOM Tag (0018,0021)](http://www.dicomlookup.com/dicomtags/(0018,0021))
     `Sequence Variant`.
   anyOf:
     - type: string
@@ -4124,7 +4124,7 @@ SpectralWidth:
   display_name: Spectral Width
   description: |
     The spectral bandwidth of the MR signal that is sampled, specified in Hz.
-    Corresponds to [DICOM Tag 0018, 9052](http://www.dicomlookup.com/dicomtags/(0018,9052))
+    Corresponds to [DICOM Tag (0018,9052)](http://www.dicomlookup.com/dicomtags/(0018,9052))
     `Spectral Width`.
   type: number
   unit: Hz
@@ -4366,7 +4366,7 @@ TracerName:
   display_name: Tracer Name
   description: |
     Name of the tracer compound used (for example, `"CIMBI-36"`)
-    Corresponds to [DICOM Tag 0054, 0300](http://www.dicomlookup.com/dicomtags/(0054,0300))
+    Corresponds to [DICOM Tag (0054,0300)](http://www.dicomlookup.com/dicomtags/(0054,0300))
     `Radionuclide Code Sequence`,
     extracted from the fields [0008, 0122](http://www.dicomlookup.com/dicomtags/(0008,0122))
     `Mapping Resource Name`
@@ -4383,7 +4383,7 @@ TracerRadionuclide:
   display_name: Tracer Radionuclide
   description: |
     Radioisotope labeling tracer (for example, `"C11"`).
-    Corresponds to [DICOM Tag 0054, 0300](http://www.dicomlookup.com/dicomtags/(0054,0300))
+    Corresponds to [DICOM Tag (0054,0300)](http://www.dicomlookup.com/dicomtags/(0054,0300))
     `Radionuclide Code Sequence`,
     extracted from the fields [0008, 0100](http://www.dicomlookup.com/dicomtags/(0008,0100)) `Code Value`
     and/or [0008, 0104](http://www.dicomlookup.com/dicomtags/(0008,0104)) `Code Meaning`.
@@ -4469,7 +4469,7 @@ VascularCrushing:
   display_name: Vascular Crushing
   description: |
     Boolean indicating if Vascular Crushing is used.
-    Corresponds to [DICOM Tag 0018, 9259](http://www.dicomlookup.com/dicomtags/(0018,9259))
+    Corresponds to [DICOM Tag (0018,9259)](http://www.dicomlookup.com/dicomtags/(0018,9259))
     `ASL Crusher Flag`.
   type: boolean
 VascularCrushingVENC:
@@ -4480,7 +4480,7 @@ VascularCrushingVENC:
     Specify either one number for the total time-series, or provide an array of
     numbers, for example when using QUASAR, using the value zero to identify
     volumes for which `VascularCrushing` was turned off.
-    Corresponds to [DICOM Tag 0018, 925A](http://www.dicomlookup.com/dicomtags/(0018,925A))
+    Corresponds to [DICOM Tag (0018,925A)](http://www.dicomlookup.com/dicomtags/(0018,925A))
     `ASL Crusher Flow Limit`.
   anyOf:
     - type: number

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -15,7 +15,7 @@ ASLLabelingDurationNiftiLength:
       an array of numbers must be specified, for which any `m0scan` in the timeseries has a `LabelingDuration` of
       zero.
       In case an array of numbers is provided, its length should be equal to the number of volumes specified in
-      the associated `aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
+      the associated `aslcontext.tsv`. Corresponds to DICOM Tag (0018,9258) `ASL Pulse Train Duration`.
     level: error
   selectors:
     - suffix == "asl"
@@ -47,7 +47,7 @@ ASLFlipAngleNiftiLength:
     message: |
       The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
+      Corresponds to: [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
       `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
@@ -71,7 +71,7 @@ ASLFlipAngleASLContextLength:
       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
       associated 'aslcontext.tsv'.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
+      Corresponds to: [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
       `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
@@ -100,7 +100,7 @@ ASLPostLabelingDelayNiftiLength:
       (that is, each 'control' and 'label')
       in the acquisition order. Any image within the time-series without a PLD (for example, an 'm0scan') is
       indicated by a zero.
-      Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
+      Based on DICOM Tags (0018,9079) `Inversion Times` and (0018,0082) `InversionTime`.
     level: error
   selectors:
     - suffix == "asl"
@@ -125,7 +125,7 @@ ASLPostLabelingDelayASLContextLength:
       (that is, each 'control' and 'label')
       in the acquisition order.
       Any image within the time-series without a PLD (for example, an 'm0scan') is indicated by a zero.
-      Based on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.
+      Based on DICOM Tags (0018,9079) `Inversion Times` and (0018,0082) `Inversion Time`.
     level: error
   selectors:
     - suffix == "asl"
@@ -150,7 +150,7 @@ ASLLabelingDurationASLContextLength:
       `LabelingDuration` of zero.
       In case an array of numbers is provided, its length should be equal to the number of volumes
       specified in the associated `aslcontext.tsv`.
-      Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.
+      Corresponds to DICOM Tag (0018,9258) `ASL Pulse Train Duration`.
     level: error
   selectors:
     - suffix == "asl"

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -100,7 +100,7 @@ ASLPostLabelingDelayNiftiLength:
       (that is, each 'control' and 'label')
       in the acquisition order. Any image within the time-series without a PLD (for example, an 'm0scan') is
       indicated by a zero.
-      Based on DICOM Tags (0018,9079) `Inversion Times` and (0018,0082) `InversionTime`.
+      Based on DICOM Tags (0018,9079) `Inversion Times` and (0018,0082) `Inversion Time`.
     level: error
   selectors:
     - suffix == "asl"

--- a/src/schema/rules/checks/asl.yaml
+++ b/src/schema/rules/checks/asl.yaml
@@ -47,7 +47,7 @@ ASLFlipAngleNiftiLength:
     message: |
       The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
+      Corresponds to: [DICOM Tag (0018,1314)](https://www.dicomlookup.com/dicomtags/(0018,1314))
       `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.
@@ -71,7 +71,7 @@ ASLFlipAngleASLContextLength:
       The number of values for 'FlipAngle' for this file does not match the number of volumes in the
       associated 'aslcontext.tsv'.
       'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.
-      Corresponds to: [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
+      Corresponds to: [DICOM Tag (0018,1314)](https://www.dicomlookup.com/dicomtags/(0018,1314))
       `Flip Angle`.
       The data type number may apply to files from any MRI modality concerned with a single value for this field,
       or to the files in a file collection where the value of this field is iterated using the flip entity.

--- a/src/schema/rules/sidecars/asl.yaml
+++ b/src/schema/rules/sidecars/asl.yaml
@@ -176,7 +176,7 @@ MRIASLPaslSpecificBolusCutOffFlagTrue:
           monotonically increasing, depending on the number of bolus cut-off
           saturation pulses. For Q2TIPS, only the values for the first and last
           bolus cut-off saturation pulses are provided. Based on DICOM Tag
-          (0018,925F) ASL Bolus Cut-off Delay Time.
+          (0018,925F) `ASL Bolus Cut-off Delay Time`.
     BolusCutOffTechnique:
       level: required
       issue:

--- a/src/schema/rules/sidecars/asl.yaml
+++ b/src/schema/rules/sidecars/asl.yaml
@@ -176,7 +176,7 @@ MRIASLPaslSpecificBolusCutOffFlagTrue:
           monotonically increasing, depending on the number of bolus cut-off
           saturation pulses. For Q2TIPS, only the values for the first and last
           bolus cut-off saturation pulses are provided. Based on DICOM Tag
-          0018,925F ASL Bolus Cut-off Delay Time.
+          (0018,925F) ASL Bolus Cut-off Delay Time.
     BolusCutOffTechnique:
       level: required
       issue:
@@ -186,7 +186,7 @@ MRIASLPaslSpecificBolusCutOffFlagTrue:
           when `BolusCutOffFlag` is set to `true`. `BolusCutOffTechnique`,
           is the name of the technique used
           (for example, Q2TIPS, QUIPSS or QUIPSSII).
-          Corresponds to DICOM Tag 0018,925E `ASL Bolus Cut-off Technique`.
+          Corresponds to DICOM Tag (0018,925E) `ASL Bolus Cut-off Technique`.
 
 # m0scan metadata fields
 MRIASLM0Scan:

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -14,27 +14,27 @@ MRIHardware:
     Manufacturer:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0070](http://www.dicomlookup.com/dicomtags/(0008,0070))
+        Corresponds to [DICOM Tag (0008,0070)](http://www.dicomlookup.com/dicomtags/(0008,0070))
         `Manufacturer`.
     ManufacturersModelName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1090](http://www.dicomlookup.com/dicomtags/(0008,1090))
+        Corresponds to [DICOM Tag (0008,1090)](http://www.dicomlookup.com/dicomtags/(0008,1090))
         `Manufacturers Model Name`.
     DeviceSerialNumber:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1000](http://www.dicomlookup.com/dicomtags/(0018,1000))
+        Corresponds to [DICOM Tag (0018,1000)](http://www.dicomlookup.com/dicomtags/(0018,1000))
         `DeviceSerialNumber`.
     StationName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1010](http://www.dicomlookup.com/dicomtags/(0008,1010))
+        Corresponds to [DICOM Tag (0008,1010)](http://www.dicomlookup.com/dicomtags/(0008,1010))
         `Station Name`.
     SoftwareVersions:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 1020](http://www.dicomlookup.com/dicomtags/(0018,1020))
+        Corresponds to [DICOM Tag (0018,1020)](http://www.dicomlookup.com/dicomtags/(0018,1020))
         `Software Versions`.
     HardcopyDeviceSoftwareVersion: deprecated
     MagneticFieldStrength:
@@ -73,7 +73,7 @@ MRISample:
     BodyPart:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](http://www.dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag (0018,0015)](http://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
@@ -100,7 +100,7 @@ MRISequenceSpecifics:
     ScanningSequence:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0020](http://www.dicomlookup.com/dicomtags/(0018,0020))
+        Corresponds to [DICOM Tag (0018,0020)](http://www.dicomlookup.com/dicomtags/(0018,0020))
         `Scanning Sequence`.
     SequenceVariant: recommended
     ScanOptions: optional
@@ -371,7 +371,7 @@ MRIFlipAngleLookLockerTrue:
           You should define 'FlipAngle' for this file, in
           case of a LookLocker acquisition. 'FlipAngle' is the
           flip angle (FA) for the acquisition, specified in degrees.
-          Corresponds to [DICOM Tag 0018, 1314](http://www.dicomlookup.com/dicomtags/(0018,1314))
+          Corresponds to [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
           `Flip Angle`.
           The data type number may apply to files from any MRI modality
           concerned with a single value for this field,
@@ -422,17 +422,17 @@ MRIInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0080](http://www.dicomlookup.com/dicomtags/(0008,0080))
+        Corresponds to [DICOM Tag (0008,0080)](http://www.dicomlookup.com/dicomtags/(0008,0080))
         `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0081](http://www.dicomlookup.com/dicomtags/(0008,0081))
+        Corresponds to [DICOM Tag (0008,0081)](http://www.dicomlookup.com/dicomtags/(0008,0081))
         `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1040](http://www.dicomlookup.com/dicomtags/(0008,1040))
+        Corresponds to [DICOM Tag (0008,1040)](http://www.dicomlookup.com/dicomtags/(0008,1040))
         `Institutional Department Name`.
 
 DeidentificationMethod:
@@ -443,10 +443,10 @@ DeidentificationMethod:
     DeidentificationMethod:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0012, 0063](http://www.dicomlookup.com/dicomtags/(0012,0063))
+        Corresponds to [DICOM Tag (0012,0063)](http://www.dicomlookup.com/dicomtags/(0012,0063))
         `De-identification Method`.
     DeidentificationMethodCodeSequence:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag 0012, 0064](http://www.dicomlookup.com/dicomtags/(0012,0064))
+        Corresponds to [DICOM Tag (0012,0064)](http://www.dicomlookup.com/dicomtags/(0012,0064))
         `De-identification Method Code Sequence`.

--- a/src/schema/rules/sidecars/mri.yaml
+++ b/src/schema/rules/sidecars/mri.yaml
@@ -14,27 +14,27 @@ MRIHardware:
     Manufacturer:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,0070)](http://www.dicomlookup.com/dicomtags/(0008,0070))
+        Corresponds to [DICOM Tag (0008,0070)](https://www.dicomlookup.com/dicomtags/(0008,0070))
         `Manufacturer`.
     ManufacturersModelName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,1090)](http://www.dicomlookup.com/dicomtags/(0008,1090))
+        Corresponds to [DICOM Tag (0008,1090)](https://www.dicomlookup.com/dicomtags/(0008,1090))
         `Manufacturers Model Name`.
     DeviceSerialNumber:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0018,1000)](http://www.dicomlookup.com/dicomtags/(0018,1000))
+        Corresponds to [DICOM Tag (0018,1000)](https://www.dicomlookup.com/dicomtags/(0018,1000))
         `DeviceSerialNumber`.
     StationName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,1010)](http://www.dicomlookup.com/dicomtags/(0008,1010))
+        Corresponds to [DICOM Tag (0008,1010)](https://www.dicomlookup.com/dicomtags/(0008,1010))
         `Station Name`.
     SoftwareVersions:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0018,1020)](http://www.dicomlookup.com/dicomtags/(0018,1020))
+        Corresponds to [DICOM Tag (0018,1020)](https://www.dicomlookup.com/dicomtags/(0018,1020))
         `Software Versions`.
     HardcopyDeviceSoftwareVersion: deprecated
     MagneticFieldStrength:
@@ -73,7 +73,7 @@ MRISample:
     BodyPart:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag (0018,0015)](http://www.dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag (0018,0015)](https://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
     BodyPartDetails: optional
     BodyPartDetailsOntology: optional
@@ -100,7 +100,7 @@ MRISequenceSpecifics:
     ScanningSequence:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0018,0020)](http://www.dicomlookup.com/dicomtags/(0018,0020))
+        Corresponds to [DICOM Tag (0018,0020)](https://www.dicomlookup.com/dicomtags/(0018,0020))
         `Scanning Sequence`.
     SequenceVariant: recommended
     ScanOptions: optional
@@ -371,7 +371,7 @@ MRIFlipAngleLookLockerTrue:
           You should define 'FlipAngle' for this file, in
           case of a LookLocker acquisition. 'FlipAngle' is the
           flip angle (FA) for the acquisition, specified in degrees.
-          Corresponds to [DICOM Tag (0018,1314)](http://www.dicomlookup.com/dicomtags/(0018,1314))
+          Corresponds to [DICOM Tag (0018,1314)](https://www.dicomlookup.com/dicomtags/(0018,1314))
           `Flip Angle`.
           The data type number may apply to files from any MRI modality
           concerned with a single value for this field,
@@ -422,17 +422,17 @@ MRIInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,0080)](http://www.dicomlookup.com/dicomtags/(0008,0080))
+        Corresponds to [DICOM Tag (0008,0080)](https://www.dicomlookup.com/dicomtags/(0008,0080))
         `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,0081)](http://www.dicomlookup.com/dicomtags/(0008,0081))
+        Corresponds to [DICOM Tag (0008,0081)](https://www.dicomlookup.com/dicomtags/(0008,0081))
         `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,1040)](http://www.dicomlookup.com/dicomtags/(0008,1040))
+        Corresponds to [DICOM Tag (0008,1040)](https://www.dicomlookup.com/dicomtags/(0008,1040))
         `Institutional Department Name`.
 
 DeidentificationMethod:
@@ -443,10 +443,10 @@ DeidentificationMethod:
     DeidentificationMethod:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag (0012,0063)](http://www.dicomlookup.com/dicomtags/(0012,0063))
+        Corresponds to [DICOM Tag (0012,0063)](https://www.dicomlookup.com/dicomtags/(0012,0063))
         `De-identification Method`.
     DeidentificationMethodCodeSequence:
       level: optional
       description_addendum: |
-        Corresponds to [DICOM Tag (0012,0064)](http://www.dicomlookup.com/dicomtags/(0012,0064))
+        Corresponds to [DICOM Tag (0012,0064)](https://www.dicomlookup.com/dicomtags/(0012,0064))
         `De-identification Method Code Sequence`.

--- a/src/schema/rules/sidecars/mrs.yaml
+++ b/src/schema/rules/sidecars/mrs.yaml
@@ -40,7 +40,7 @@ MRSSample:
       level: optional
       level_addendum: required if `voi` entity is present
       description_addendum: |
-        Corresponds to [DICOM Tag (0018,0015)](http://www.dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag (0018,0015)](https://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
     BodyPartDetails:
       level: optional

--- a/src/schema/rules/sidecars/mrs.yaml
+++ b/src/schema/rules/sidecars/mrs.yaml
@@ -40,7 +40,7 @@ MRSSample:
       level: optional
       level_addendum: required if `voi` entity is present
       description_addendum: |
-        Corresponds to [DICOM Tag 0018, 0015](http://www.dicomlookup.com/dicomtags/(0018,0015))
+        Corresponds to [DICOM Tag (0018,0015)](http://www.dicomlookup.com/dicomtags/(0018,0015))
         `Body Part Examined`.
     BodyPartDetails:
       level: optional

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -8,18 +8,18 @@ PETHardware:
     Manufacturer:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0070](http://www.dicomlookup.com/dicomtags/(0008,0070))
+        Corresponds to [DICOM Tag (0008,0070)](http://www.dicomlookup.com/dicomtags/(0008,0070))
         `Manufacturer`.
     ManufacturersModelName:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1090](http://www.dicomlookup.com/dicomtags/(0008,1090))
+        Corresponds to [DICOM Tag (0008,1090)](http://www.dicomlookup.com/dicomtags/(0008,1090))
         `Manufacturers Model Name`.
     Units:
       level: required
       description_addendum: |
         SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL").
-        Corresponds to [DICOM Tag 0054, 1001](http://www.dicomlookup.com/dicomtags/(0054,1001)) `Units`.
+        Corresponds to [DICOM Tag (0054,1001)](http://www.dicomlookup.com/dicomtags/(0054,1001)) `Units`.
 
 PETInstitutionInformation:
   selectors:
@@ -29,17 +29,17 @@ PETInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0080](http://www.dicomlookup.com/dicomtags/(0008,0080))
+        Corresponds to [DICOM Tag (0008,0080)](http://www.dicomlookup.com/dicomtags/(0008,0080))
         `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 0081](http://www.dicomlookup.com/dicomtags/(0008,0081))
+        Corresponds to [DICOM Tag (0008,0081)](http://www.dicomlookup.com/dicomtags/(0008,0081))
         `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag 0008, 1040](http://www.dicomlookup.com/dicomtags/(0008,1040))
+        Corresponds to [DICOM Tag (0008,1040)](http://www.dicomlookup.com/dicomtags/(0008,1040))
         `Institutional Department Name`.
 
 PETSample:

--- a/src/schema/rules/sidecars/pet.yaml
+++ b/src/schema/rules/sidecars/pet.yaml
@@ -8,18 +8,18 @@ PETHardware:
     Manufacturer:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,0070)](http://www.dicomlookup.com/dicomtags/(0008,0070))
+        Corresponds to [DICOM Tag (0008,0070)](https://www.dicomlookup.com/dicomtags/(0008,0070))
         `Manufacturer`.
     ManufacturersModelName:
       level: required
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,1090)](http://www.dicomlookup.com/dicomtags/(0008,1090))
+        Corresponds to [DICOM Tag (0008,1090)](https://www.dicomlookup.com/dicomtags/(0008,1090))
         `Manufacturers Model Name`.
     Units:
       level: required
       description_addendum: |
         SI unit for radioactivity (Becquerel) should be used (for example, "Bq/mL").
-        Corresponds to [DICOM Tag (0054,1001)](http://www.dicomlookup.com/dicomtags/(0054,1001)) `Units`.
+        Corresponds to [DICOM Tag (0054,1001)](https://www.dicomlookup.com/dicomtags/(0054,1001)) `Units`.
 
 PETInstitutionInformation:
   selectors:
@@ -29,17 +29,17 @@ PETInstitutionInformation:
     InstitutionName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,0080)](http://www.dicomlookup.com/dicomtags/(0008,0080))
+        Corresponds to [DICOM Tag (0008,0080)](https://www.dicomlookup.com/dicomtags/(0008,0080))
         `InstitutionName`.
     InstitutionAddress:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,0081)](http://www.dicomlookup.com/dicomtags/(0008,0081))
+        Corresponds to [DICOM Tag (0008,0081)](https://www.dicomlookup.com/dicomtags/(0008,0081))
         `InstitutionAddress`.
     InstitutionalDepartmentName:
       level: recommended
       description_addendum: |
-        Corresponds to [DICOM Tag (0008,1040)](http://www.dicomlookup.com/dicomtags/(0008,1040))
+        Corresponds to [DICOM Tag (0008,1040)](https://www.dicomlookup.com/dicomtags/(0008,1040))
         `Institutional Department Name`.
 
 PETSample:


### PR DESCRIPTION
This pull request standardizes the format for referencing DICOM tags throughout the documentation and schema files. The main change is to consistently use the format `DICOM Tag (####,####)` instead of variations like `DICOM Tag ####, ####` or inline code, improving clarity and consistency for users and developers working with DICOM metadata in BIDS.

This supersedes PR #1758.

**Standardization of DICOM Tag References:**

* Updated all DICOM tag references in documentation files (e.g., `src/common-principles.md`, `src/modality-specific-files/magnetic-resonance-imaging-data.md`, `src/modality-specific-files/magnetic-resonance-spectroscopy.md`) to use the format `DICOM Tag (####,####)`, sometimes with explicit attribute names, and updated hyperlinks accordingly. [[1]](diffhunk://#diff-38cc3c29d8cceeb219373964b67b2286b204e420aedb3029bb9344e5dad02956L501-R503) [[2]](diffhunk://#diff-c2e6acb3e26ee9df9adf3aa36bfa14ad677fcc889cbfc18acebbf9f66a913133L80-R85) [[3]](diffhunk://#diff-c2e6acb3e26ee9df9adf3aa36bfa14ad677fcc889cbfc18acebbf9f66a913133L271-R271) [[4]](diffhunk://#diff-c2e6acb3e26ee9df9adf3aa36bfa14ad677fcc889cbfc18acebbf9f66a913133L955-R955) [[5]](diffhunk://#diff-f54d659551230f8987bea969304e7f92f4bd11f74bea667d3009ec235a4624daL126-R127)

**Schema and Metadata Consistency:**

* Updated all DICOM tag references in entity and metadata schema files (`src/schema/objects/entities.yaml`, `src/schema/objects/metadata.yaml`) to use the standardized format, including both descriptions and display names. [[1]](diffhunk://#diff-b2ff216a7b94882e7d1d45af322955cc874f5176a75cf0cab41245b7bd75e595L223-R223) [[2]](diffhunk://#diff-b2ff216a7b94882e7d1d45af322955cc874f5176a75cf0cab41245b7bd75e595L235-R235) [[3]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L43-R43) [[4]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L233-R233) [[5]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L267-R267) [[6]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L368-R368) [[7]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L395-R395) [[8]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L411-R420) [[9]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L518-R518) [[10]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L580-R604) [[11]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L698-R698) [[12]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L793-R793) [[13]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L802-R802) [[14]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L812-R812) [[15]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L1032-R1032) [[16]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L1265-R1265) [[17]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L1533-R1533) [[18]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L1597-R1597) [[19]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L1606-R1606) [[20]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L1755-R1755) [[21]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L1978-R1978) [[22]](diffhunk://#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844L2000-R2000)