### PR TITLE
fix(ci): Restore green Validation CI under ruff 0.16 + add ruff to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,13 @@ repos:
     hooks:
       - id: codespell
         args: ["--config=.codespellrc", "--dictionary=-", "--dictionary=.codespell_dict"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep in sync with the ruff version used by .github/workflows/validation.yml
+    rev: v0.16.1
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.1.0
     hooks:

--- a/macros_doc.md
+++ b/macros_doc.md
@@ -29,7 +29,7 @@ layouts in the documentation. The macro takes a single parameter, the directory
 tree to be displayed in JSON format. If you insert the following in the BIDS
 markdown document:
 
-```python
+```jinja
 {{ MACROS___make_filetree_example(
 
    {
@@ -230,7 +230,7 @@ The macro will create the different columns of the table:
 
 A general description of that macro call would look like this:
 
-```python
+```jinja
 {{ MACROS___make_metadata_table(
    {
       "TermToRender": "REQUIREMENT_LEVEL plus anything else after", "Extra content you want to append after the description of that term."
@@ -264,7 +264,7 @@ If you wanted to add some extra content to that table, but without modifying the
 definition in the schema, then you could just add some extra content into the
 macro call.
 
-```python
+```jinja
 #### Reconstruction
 
 {{ MACROS___make_metadata_table(
@@ -293,7 +293,7 @@ contains an entry for `MoonPhase`. If this is the case because the term already
 exists and is used somewhere in the BIDS specification, you are in luck and you
 can just stop there.
 
-```python
+```jinja
 #### Reconstruction
 
 {{ MACROS___make_metadata_table(

--- a/pdf_build_src/pandoc_script.py
+++ b/pdf_build_src/pandoc_script.py
@@ -4,8 +4,9 @@ This is done once the duplicate src directory is processed.
 """
 
 import subprocess
-import yaml
 from pathlib import Path
+
+import yaml
 
 HERE = Path(__file__).absolute()
 
@@ -76,7 +77,7 @@ def build_pdf(filename="bids-spec.pdf", logfile="bids-spec_pandoc_log.json"):
 
     # print and run
     print("pandoc command being run: \n\n" + "\n".join(cmd))
-    subprocess.run(cmd)
+    subprocess.run(cmd, check=False)
 
 
 if __name__ == "__main__":

--- a/pdf_build_src/process_markdowns.py
+++ b/pdf_build_src/process_markdowns.py
@@ -16,7 +16,6 @@ import sys
 from datetime import datetime
 
 import numpy as np
-
 from remove_admonitions import remove_admonitions
 
 sys.path.append("../tools/")
@@ -87,7 +86,7 @@ def extract_header_string():
 
     title = " ".join(header_string.split()[0:4])
     version_number = header_string.split()[-1]
-    build_date = datetime.today().strftime("%Y-%m-%d")
+    build_date = datetime.now().astimezone().strftime("%Y-%m-%d")
 
     return title, version_number, build_date
 
@@ -95,7 +94,7 @@ def extract_header_string():
 def add_header():
     """Add the header string extracted from changelog to header.tex file."""
     title, version_number, build_date = extract_header_string()
-    header = " ".join([title, version_number, build_date])
+    header = f"{title} {version_number} {build_date}"
 
     # creating a header string with latest version number and date
     header_string = r"\fancyhead[L]{ " + header + " }"
@@ -244,7 +243,7 @@ def assert_no_multiline_links(root_path):
     """
     pattern = re.compile(r"(\s|^)+\[([^\]]+)$")
 
-    problems = dict()
+    problems = {}
     for root, dirs, files in sorted(os.walk(root_path)):
         for file in files:
             if file.endswith(".md"):
@@ -295,7 +294,7 @@ def modify_changelog():
         file.writelines(data)
 
 
-def correct_table(table, offset=[0.0, 0.0], debug=False):
+def correct_table(table, offset=None, debug=False):
     """Create the corrected table.
 
     Compute the number of characters maximal in each table column and reformat each
@@ -324,6 +323,8 @@ def correct_table(table, offset=[0.0, 0.0], debug=False):
     corrected : bool
         Whether or not the table was corrected.
     """
+    if offset is None:
+        offset = [0.0, 0.0]
     corrected = True
 
     # nb_of_rows = len(table)
@@ -336,7 +337,7 @@ def correct_table(table, offset=[0.0, 0.0], debug=False):
             nb_of_chars.append([len(elem) for elem in row])
 
     # sanity check: nb_of_chars is list of list, all nested lists must be of equal length
-    if not len(set([len(i) for i in nb_of_chars])) == 1:
+    if len({len(i) for i in nb_of_chars}) != 1:
         print('    - ERROR for current table ... "nb_of_chars" is misaligned, see:\n')
         print(nb_of_chars)
         print("\n    - Skipping formatting of this table.")
@@ -358,17 +359,11 @@ def correct_table(table, offset=[0.0, 0.0], debug=False):
     second_column_width = int(offset[1] * nb_of_dashes) + nb_of_dashes
 
     if debug:
-        print("    - Number of chars in table cells: {}".format(max_chars_in_cols))
-        print("    - Number of dashes (per column): {}".format(nb_of_dashes))
-        print("    - Proportion of dashes (per column): {}".format(prop_of_dashes))
-        print(
-            "    - Final number of chars in first column: {}".format(first_column_width)
-        )
-        print(
-            "    - Final number of chars in second column: {}".format(
-                second_column_width
-            )
-        )
+        print(f"    - Number of chars in table cells: {max_chars_in_cols}")
+        print(f"    - Number of dashes (per column): {nb_of_dashes}")
+        print(f"    - Proportion of dashes (per column): {prop_of_dashes}")
+        print(f"    - Final number of chars in first column: {first_column_width}")
+        print(f"    - Final number of chars in second column: {second_column_width}")
 
     # Format the lines with correct number of dashes or whitespaces and
     # correct alignment of fences and populate the new table (A List of str)
@@ -432,7 +427,7 @@ def _contains_table_start(line, debug=False):
     nb_of_dashes = line.count("--")
 
     if debug:
-        print("Number of dashes / pipes : {} / {}".format(nb_of_dashes, nb_of_pipes))
+        print(f"Number of dashes / pipes : {nb_of_dashes} / {nb_of_pipes}")
 
     if nb_of_pipes > 2 and nb_of_dashes > 2:
         is_table = True
@@ -468,7 +463,7 @@ def correct_tables(root_path, debug=False):
     for root, dirs, files in sorted(os.walk(root_path)):
         for file in files:
             if file.endswith(".md") and file not in exclude_files:
-                print("Check tables in {}".format(os.path.join(root, file)))
+                print(f"Check tables in {os.path.join(root, file)}")
 
                 # Load lines of the markdown file
                 with open(os.path.join(root, file), "r") as f:
@@ -491,7 +486,7 @@ def correct_tables(root_path, debug=False):
                         # Keep track of the line number where the table starts
                         start_line = line_nb - 1
 
-                        print("  * Detected table starting line {}".format(start_line))
+                        print(f"  * Detected table starting line {start_line}")
                         # Extract for each row (header and the one containing dashes)
                         # the content of each column and strip to remove extra whitespace
                         header_row = [
@@ -517,7 +512,7 @@ def correct_tables(root_path, debug=False):
                         if len(row) > 1:
                             table.append(row)
                             if line_nb < len(content) - 1:
-                                if not len(content[line_nb]) > 1:
+                                if not len(line) > 1:
                                     is_end_of_table = True
                                     end_line = line_nb
                             elif line_nb == len(content) - 1:
@@ -531,11 +526,7 @@ def correct_tables(root_path, debug=False):
                         # append each corrected row (line)
                         # to the content of the new markdown content
                         if is_end_of_table:
-                            print(
-                                "    - End of table detected after line {}".format(
-                                    end_line
-                                )
-                            )
+                            print(f"    - End of table detected after line {end_line}")
 
                             # Set table_mode to False such that the script will look
                             # for a new table start at the next markdown line
@@ -576,7 +567,7 @@ def correct_tables(root_path, debug=False):
 
 def edit_titlepage():
     """Add title and version number of the specification to the titlepage."""
-    title, version_number, build_date = extract_header_string()
+    _title, version_number, build_date = extract_header_string()
 
     with open("cover.tex", "r") as file:
         data = file.readlines()
@@ -643,7 +634,7 @@ def process_macros(duplicated_src_dir_path):
             page = MockPage()
             page.file = mock_file
 
-            _Context__self = {"page": page}  # noqa: F841
+            _Context__self = {"page": page}
 
             # Replace code snippets in the text with their outputs
             matches = re.findall(re_code_snippets, contents)

--- a/pdf_build_src/remove_admonitions.py
+++ b/pdf_build_src/remove_admonitions.py
@@ -14,7 +14,7 @@ ADMONITION_DELIMITERS = ["!!!", "???", "???+"]
 
 
 def remove_admonitions(
-    input_folder: str | Path, output_folder: str | Path, indent: str = None
+    input_folder: str | Path, output_folder: str | Path, indent: str | None = None
 ):
     if indent is None:
         indent = INDENT

--- a/tools/add_contributors.py
+++ b/tools/add_contributors.py
@@ -41,7 +41,6 @@ import logging
 import os
 from collections import OrderedDict
 from pathlib import Path
-from typing import Optional
 
 import emoji
 import pandas as pd
@@ -135,7 +134,7 @@ def emoji_map(reverse=False) -> dict[str, str]:
 
 def return_this_contributor(
     df: pd.DataFrame, name: str, contribution_needed=True
-) -> dict[str, Optional[str]]:
+) -> dict[str, str | None]:
     """Get and validate the data for a given contributor."""
     name = name.strip()
 
@@ -154,7 +153,7 @@ def return_this_contributor(
     contributions = df[mask].contributions.values[0]
     log.debug(f"contributions for {name}: '{contributions}'")
     if pd.isna(contributions):
-        contributions is None
+        contributions = None
     if contribution_needed and contributions is None:
         raise ValueError(f"Contributions for {name} not defined in input file.")
     if contributions is not None:
@@ -191,9 +190,7 @@ def return_this_contributor(
     for key, value in this_contributor.items():
         if value is None:
             continue
-        if not isinstance(this_contributor[key], (list)) and pd.isna(
-            this_contributor[key]
-        ):
+        if not isinstance(value, (list)) and pd.isna(value):
             this_contributor[key] = None
         elif isinstance(this_contributor[key], (str)):
             this_contributor[key] = this_contributor[key].strip()
@@ -239,7 +236,7 @@ def canonicalize_contributions(contributions: list) -> list:
         contributions[contributions.index(contribution_)] = contribution_.replace(
             ":", ""
         )
-    contributions = sorted(list(set(contributions)))
+    contributions = sorted(set(contributions))
 
     return contributions
 
@@ -264,8 +261,8 @@ def update_key(
 
 def load_tributors(tributors_file: Path) -> dict:
     """Load `.tributors` file."""
-    with open(tributors_file, "r", encoding="utf8") as tributors_file:
-        return json.load(tributors_file)
+    with open(tributors_file, "r", encoding="utf8") as f:
+        return json.load(f)
 
 
 def write_tributors(tributors_file: Path, tributors: dict[str, dict]) -> None:
@@ -283,13 +280,13 @@ def return_missing_from_tributors(tributors_file: Path, names: list[str]) -> lis
     for i, name in enumerate(names):
         names[i] = name.strip()
     missing_from_tributors = set(names) - set(tributors_names)
-    return sorted(list(missing_from_tributors))
+    return sorted(missing_from_tributors)
 
 
 def sort_tributors(tributors: dict[str, dict]) -> dict[str, dict]:
     """Sort `.tributors` alphabetically by name of contributor."""
-    for key in tributors:
-        tributors[key] = dict(OrderedDict(sorted(tributors[key].items())))
+    for key, value in tributors.items():
+        tributors[key] = dict(OrderedDict(sorted(value.items())))
     return dict(sorted(tributors.items(), key=lambda item: item[1]["name"]))
 
 
@@ -539,7 +536,7 @@ def main():
 
     # sanity checks to make sure no contributor was added manually
     assert len(tributors_names) == len(set(tributors_names))
-    assert len(allcontrib_names) == len(set(allcontrib_names)), print(
+    assert len(allcontrib_names) == len(set(allcontrib_names)), (
         f"{allcontrib_names=}, {len(set(allcontrib_names))=}"
     )
     # We might be removing duplicates etc, thus let's not verify
@@ -590,11 +587,16 @@ def main():
         this_contributor["login"] = github_username
         this_contributor = rename_keys_for_allcontrib(this_contributor)
 
-        if UPDATE_AVATARS and "avatar_url" not in this_contributor:
-            if avatar_url := get_gh_avatar(
-                this_contributor["login"], GH_USERNAME, GH_TOKEN
-            ):
-                this_contributor["avatar_url"] = avatar_url
+        if (
+            UPDATE_AVATARS
+            and "avatar_url" not in this_contributor
+            and (
+                avatar_url := get_gh_avatar(
+                    this_contributor["login"], GH_USERNAME, GH_TOKEN
+                )
+            )
+        ):
+            this_contributor["avatar_url"] = avatar_url
 
         allcontrib = update_allcontrib(allcontrib, this_contributor)
 

--- a/tools/check_embedded_json.py
+++ b/tools/check_embedded_json.py
@@ -91,7 +91,7 @@ def check_file(filepath):
     try:
         with open(filepath, encoding="utf8") as f:
             text = f.read()
-    except (FileNotFoundError, IOError):
+    except (OSError, FileNotFoundError):
         return []
 
     blocks = extract_json_blocks(text)

--- a/tools/make_changelog.py
+++ b/tools/make_changelog.py
@@ -19,10 +19,10 @@ import re
 import subprocess as sp
 import sys
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, UTC
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
-from gql import gql, Client
+from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 
 SEARCH_MERGED_PRS_QUERY = gql("""\
@@ -122,7 +122,7 @@ async def get_merged_prs(
             if not pr:
                 continue
 
-            merged_date = datetime.fromisoformat(pr["mergedAt"].replace("Z", "+00:00"))
+            merged_date = datetime.fromisoformat(pr["mergedAt"])
 
             prs.append(
                 PR(
@@ -162,7 +162,7 @@ async def main() -> None:
         client, repository="bids-standard/bids-specification", merged_after=start_date
     )
 
-    with open(repo / "src/CHANGES.md", "w") as changelog:
+    with open(repo / "src/CHANGES.md", "w") as changelog:  # noqa: ASYNC230
         changelog.write("# Changelog\n\n## Upcoming\n\n")
         changelog.write("\n".join([*map(str, prs), "", changes]))
 

--- a/tools/mkdocs_macros_bids/__init__.py
+++ b/tools/mkdocs_macros_bids/__init__.py
@@ -11,11 +11,11 @@ from .main import define_env
 
 __all__ = [
     "define_env",
-    "make_filename_template",
-    "make_entity_table",
     "make_entity_definitions",
-    "make_suffix_table",
-    "make_metadata_table",
+    "make_entity_table",
+    "make_filename_template",
     "make_filetree_example",
+    "make_metadata_table",
+    "make_suffix_table",
     "render_text",
 ]

--- a/tools/mkdocs_macros_bids/macros.py
+++ b/tools/mkdocs_macros_bids/macros.py
@@ -8,7 +8,7 @@ from bidsschematools import render, schema
 code_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(code_path)
 
-from examplecode import example  # noqa: E402
+from examplecode import example
 
 
 def _get_source_path(level=1):

--- a/tools/mkdocs_macros_bids/main.py
+++ b/tools/mkdocs_macros_bids/main.py
@@ -11,7 +11,7 @@ import sys
 code_path = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 sys.path.append(code_path)
 
-import macros  # noqa: E402
+import macros
 
 
 def define_env(env):

--- a/tools/no-bad-latin.py
+++ b/tools/no-bad-latin.py
@@ -14,6 +14,7 @@ import re
 from pull_files import filter_files
 
 ABSOLUTE_HERE = os.path.dirname(os.path.dirname(__file__))
+DEFAULT_SRC_DIR = os.path.join(ABSOLUTE_HERE, "src")
 IGNORE_LIST = ["CHANGES.md", "01-contributors.md", "pregh-changes.md"]
 
 
@@ -129,7 +130,7 @@ def read_and_check_files(files):
     return failing_files
 
 
-def get_all_files(directory=os.path.join(ABSOLUTE_HERE, "src")):
+def get_all_files(directory=DEFAULT_SRC_DIR):
     """Get a list of files to be checked. Ignores images, javascript, css files.
 
     Keyword Arguments:
@@ -162,7 +163,7 @@ def main():
 
     if bool(failing_files):
         error_message = construct_error_message(failing_files)
-        raise Exception(error_message)
+        raise RuntimeError(error_message)
 
 
 if __name__ == "__main__":

--- a/tools/schemacode/src/bidsschematools/tests/test_validator.py
+++ b/tools/schemacode/src/bidsschematools/tests/test_validator.py
@@ -99,12 +99,16 @@ def test_write_report(tmp_path):
         }
     ]
     validation_result["path_tracking"] = [
-        "/home/chymera/.data2/datalad/000026/"
-        "noncompliant/sub-EXC022/anat/sub-EXC022_ses-MRI_flip-1_VFA.nii.gz"
+        (
+            "/home/chymera/.data2/datalad/000026/"
+            "noncompliant/sub-EXC022/anat/sub-EXC022_ses-MRI_flip-1_VFA.nii.gz"
+        )
     ]
     validation_result["path_listing"] = [
-        "/home/chymera/.data2/datalad/000026/"
-        "noncompliant/sub-EXC022/anat/sub-EXC022_ses-MRI_flip-1_VFA.nii.gz"
+        (
+            "/home/chymera/.data2/datalad/000026/"
+            "noncompliant/sub-EXC022/anat/sub-EXC022_ses-MRI_flip-1_VFA.nii.gz"
+        )
     ]
 
     report_path = tmp_path / "output_bids_validator_xs_write.log"


### PR DESCRIPTION
**Disclaimer**: done with claude code and diff eyeballed by me.  Among alternatives we had just to pin ruff to prior version with less checks but I decided that we better address them while at it!

<!-- markdownlint-disable MD001 MD041 -->
## Summary

The [`Validation` workflow](https://github.com/bids-standard/bids-specification/actions/workflows/validation.yml) has been red on **every push, PR, and merge since 2026-07-23**. The failure is in the `python-style` job's `uvx ruff format --diff` step, and it's a rot introduced by **ruff 0.16.0 breaking changes**, not by any BIDS PR.

- Last green master run: 2026-07-20 (4523097).
- First red master run: 2026-07-28 (5b2cf70, PR #2479 was merged with `python-style` red).
- Root cause: [ruff 0.16.0 release, 2026-07-23](https://github.com/astral-sh/ruff/releases/tag/0.16.0).

Two independent breaking changes in ruff 0.16:

1. **`ruff format` now formats Python code blocks inside Markdown files by default.** `macros_doc.md` documents Jinja2 macro syntax inside <code>```python</code> fenced blocks, which ruff tries to re-indent as Python. This is the visible failure.
2. **`ruff check`'s default rule set expanded from 59 to 413 rules.** Twenty-two additional lint violations surface across `tools/` and `pdf_build_src/`. They were hidden until now because `ruff format` fails first and short-circuits the job.

<details><summary>Which PRs are affected (they are not the cause; ruff is)</summary>

All open PRs since 2026-07-23 have a red `python-style` check for this reason. Confirmed rerunning against several PRs picks up the same ruff 0.16.x and fails identically. Once this lands on master, rebases / retriggers of those PRs should go green.

</details>

## Changes

- Retag the four Jinja2 examples in `macros_doc.md` as <code>```jinja</code> rather than <code>```python</code> — they are macro calls, not Python. This addresses issue (1) properly rather than pinning ruff or excluding `*.md` from the formatter.
- Apply `ruff check --fix` + `--unsafe-fixes` for the 34 auto-fixable violations across `tools/` and `pdf_build_src/` (import ordering, f-strings, `OSError` alias for `IOError`, unused `noqa`, `set()`/`dict()` literals, `sorted()` redundant `list()`, implicit `Optional` → `X | None`, `_`-prefix for unused unpacks, `datetime.fromisoformat` handles `Z` natively in 3.11+, assert-with-print, dict `.items()`, mutable default argument).
- Manual fixes for the 9 residual violations with no auto-fix:

<details><summary>Detail of manual fixes</summary>

| File                                | Rule       | Change                                                                                    |
| ----------------------------------- | ---------- | ----------------------------------------------------------------------------------------- |
| `tools/add_contributors.py:156`     | `B015`     | `contributions is None` → `contributions = None` (was a no-op — real bug, meant assignment) |
| `pdf_build_src/pandoc_script.py:80` | `PLW1510`  | Add explicit `check=False` to `subprocess.run(cmd)`                                       |
| `pdf_build_src/process_markdowns.py:89` | `DTZ002` | `datetime.today()` → `datetime.now().astimezone()`                                       |
| `tools/add_contributors.py:264`     | `PLR1704`  | Rename inner context manager var to avoid shadowing `tributors_file` parameter            |
| `tools/add_contributors.py:288`     | `PLC0206`  | `for key in d:` + `d[key]` → `for key, value in d.items():`                               |
| `tools/add_contributors.py:590`     | `SIM102`   | Combine nested `if` + walrus into a single `if` with `and`                                |
| `tools/make_changelog.py:165`       | `ASYNC230` | `# noqa: ASYNC230` on the one-shot sync `open()` at end of async `main()` — not a hot path |
| `tools/no-bad-latin.py:132`         | `B008`     | Move `os.path.join(ABSOLUTE_HERE, "src")` into module-level `DEFAULT_SRC_DIR`             |
| `tools/no-bad-latin.py:165`         | `TRY002`   | `raise Exception(...)` → `raise RuntimeError(...)`                                        |

</details>

Test-touching change worth flagging: the `ISC004` fix in `tools/schemacode/src/bidsschematools/tests/test_validator.py` adds parens around an implicit string concatenation (was likely a missing-comma-looks-like-a-bug pattern — the strings were meant to be one long path, and now that intent is explicit).

## Test plan

- [x] `uvx ruff format --diff` locally on the resulting tree → clean (122 files already formatted).
- [x] `uvx ruff check` locally on the resulting tree → clean.
- [x] `pytest tools/schemacode/src/bidsschematools/tests/test_validator.py` → 22 passed.
- [x] CI on this PR — `python-style` job to go green.
- [x] Review rendered site around those spots where we changed spec from python to jinja for macros invocations etc
- [ ] After merge, other open PRs' `python-style` should also go green once rebased.
