### PR TITLE
[FIX] Minor typos in Common principles - Filesystem structure

### DIFF
--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -113,11 +113,11 @@ Additional information on each participant MAY be provided in a
 in the root directory of the dataset.
 
 If data for the subject were acquired across multiple sessions, then within
-the subject directory resides subdirectories named "`ses-<label>`",
+the subject directory reside subdirectories named "`ses-<label>`",
 where string "`<label>`" is substituted with a unique identification
 label for each session.
 In datasets where at least one subject has more than one session, this
-additional subdirectory later SHOULD be added for all subjects in the dataset.
+additional subdirectory layer SHOULD be added for all subjects in the dataset.
 Additional information on each session MAY be provided in a
 [sessions file](modality-agnostic-files/data-summary-files.md#sessions-file)
 within the subject directory.

--- a/src/common-principles.md
+++ b/src/common-principles.md
@@ -106,16 +106,16 @@ BIDS datasets embedded within a larger BIDS dataset MAY follow some convention (
 ## Filesystem structure
 
 Data for each subject are placed in subdirectories named "`sub-<label>`",
-where string "`<label>`" is substituted with the unique identification
+where "`<label>`" is substituted with the unique identification
 label of each subject.
 Additional information on each participant MAY be provided in a
 [participants file](modality-agnostic-files/data-summary-files.md#participants-file)
 in the root directory of the dataset.
 
-If data for the subject were acquired across multiple sessions, then within
-the subject directory reside subdirectories named "`ses-<label>`",
-where string "`<label>`" is substituted with a unique identification
-label for each session.
+If data for the subject were acquired across multiple sessions,
+then subdirectories named "`ses-<label>`" reside within the subject directory,
+where "`<label>`" is substituted with the unique identification
+label of each session.
 In datasets where at least one subject has more than one session, this
 additional subdirectory layer SHOULD be added for all subjects in the dataset.
 Additional information on each session MAY be provided in a


### PR DESCRIPTION
* Grammar fix: multiple subdirectories "reside", not "resides".
* Subdirectories are a "layer", not a "later".