### PR TITLE
[FIX] Update dbGaP URL

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -81,7 +81,7 @@ AnalyticalApproach:
     Methodology or methodologies used to analyze the `"GeneticLevel"`.
     Values MUST be taken from the
     [database of Genotypes and Phenotypes
-    (dbGaP)](https://www.ncbi.nlm.nih.gov/gap/advanced)
+    (dbGaP)](https://dbgap.ncbi.nlm.nih.gov/home/)
     under /Study/Molecular Data Type (for example, SNP Genotypes (Array) or
     Methylation (CpG).
   anyOf:


### PR DESCRIPTION
The dbGaP search builder (https://web.archive.org/web/20250205225946/https://www.ncbi.nlm.nih.gov/gap/advanced/) was removed without redirecting when https://www.ncbi.nlm.nih.gov/gap/ began to 301 to https://dbgap.ncbi.nlm.nih.gov/home/.

Note that the nearest equivalent search page is https://dbgap.ncbi.nlm.nih.gov/beta/search/, but I don't want to link to a beta page, since that's almost certainly setting up a future URL failure.

The NIH's commitment to persistent URLs is something to behold.