### PR TITLE
[FIX] Update dbGaP advanced search URL

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -81,7 +81,7 @@ AnalyticalApproach:
     Methodology or methodologies used to analyze the `"GeneticLevel"`.
     Values MUST be taken from the
     [database of Genotypes and Phenotypes
-    (dbGaP)](https://www.ncbi.nlm.nih.gov/gap/advanced)
+    (dbGaP)](https://www.ncbi.nlm.nih.gov/gap/advanced_search/)
     under /Study/Molecular Data Type (for example, SNP Genotypes (Array) or
     Methylation (CpG).
   anyOf:


### PR DESCRIPTION
## Summary

Update the dbGaP Advanced Search link to its current NCBI URL.

## Why

The previous `/gap/advanced` endpoint now returns 404, which causes the external link check to fail on `master` and downstream pull requests.

## Checks

- confirmed that the new URL returns HTTP 200
- parsed `src/schema/objects/metadata.yaml`
- ran `git diff --check`