### PR TITLE
Fix mypy failure in pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
   skip: [shellcheck]
-  autoupdate_schedule: monthly
+  autoupdate_schedule: quarterly
 
 exclude: 'broken_dataset_description.json|uv.lock'
 repos:
@@ -46,7 +46,7 @@ repos:
       - id: taplo-format
         args: [-o, 'array_auto_collapse=false']
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: ["--config=.codespellrc", "--dictionary=-", "--dictionary=.codespell_dict"]
@@ -57,7 +57,7 @@ repos:
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         # Sync with project.optional-dependencies.typing

--- a/tools/schemacode/src/bidsschematools/types/_generator.py
+++ b/tools/schemacode/src/bidsschematools/types/_generator.py
@@ -198,7 +198,7 @@ def typespec_to_source(
     tp = typespec.get("type")
     if not tp:
         raise ValueError(f"Invalid typespec: {json.dumps(typespec)}")
-    metadata = {
+    metadata: dict[str, lt.Any] = {
         key: typespec[key] for key in ("name", "description", "required") if key in typespec
     }
     if tp == "object":

--- a/tools/schemacode/src/bidsschematools/utils.py
+++ b/tools/schemacode/src/bidsschematools/utils.py
@@ -185,9 +185,7 @@ class WarningsFilter:
     # Only using one positional arg for now. This type can get more complex.
     def __init__(
         self,
-        *filters: tuple[
-            lt.Literal["default", "error", "ignore", "always", "all", "module", "once"]
-        ],
+        *filters: tuple[lt.Literal["default", "error", "ignore", "always", "module", "once"]],
     ) -> None:
         self.filters = filters
 


### PR DESCRIPTION
## Changes

- Fixed the resulting mypy failures in `_generator.py`: `typespec_to_source`'s `metadata` dict comprehension was being inferred by mypy 2.3.0 as `dict[Literal['description', 'required', 'name'], Any]` instead of `dict[str, Any]`, which no longer matched the declared `create_protocol_source`/`typespec_to_source` signatures (`dict[str, Any]`). Added an explicit `dict[str, lt.Any]` annotation to the comprehension to restore compatibility.

---
🤖 Generated by [Claude Code](https://claude.ai/code/session_01DHpvunTdgH6vRSzVP5wEjM)