### PR TITLE
[ENH] Add optional 'duration' column to `_scans.tsv`

### DIFF
--- a/src/modality-agnostic-files/data-summary-files.md
+++ b/src/modality-agnostic-files/data-summary-files.md
@@ -190,11 +190,11 @@ All such included additional fields SHOULD be documented in an accompanying
 Example `_scans.tsv`:
 
 ```tsv
-filename	acq_time
-func/sub-control01_task-nback_bold.nii.gz	1877-06-15T13:45:30
-func/sub-control01_task-motor_bold.nii.gz	1877-06-15T13:55:33
-meg/sub-control01_task-rest_split-01_meg.nii.gz	1877-06-15T12:15:27
-meg/sub-control01_task-rest_split-02_meg.nii.gz	1877-06-15T12:15:27
+filename	acq_time	duration
+func/sub-control01_task-nback_bold.nii.gz	1877-06-15T13:45:30	420
+func/sub-control01_task-motor_bold.nii.gz	1877-06-15T13:55:33	390
+meg/sub-control01_task-rest_split-01_meg.nii.gz	1877-06-15T12:15:27	600
+meg/sub-control01_task-rest_split-02_meg.nii.gz	1877-06-15T12:15:27	600
 ```
 
 ## Sessions file

--- a/src/schema/meta/associations.yaml
+++ b/src/schema/meta/associations.yaml
@@ -129,3 +129,12 @@ atlas_description:
     suffix: description
     extension: .json
   inherit: true
+
+scans:
+  selectors:
+    - suffix != 'scans'
+    - extension != '.json'
+  target:
+    suffix: scans
+    extension: .tsv
+  inherit: true

--- a/src/schema/meta/context.yaml
+++ b/src/schema/meta/context.yaml
@@ -321,6 +321,21 @@ properties:
           path:
             description: 'Path to associated atlas description file'
             type: string
+      scans:
+        description: 'Row from the scans.tsv file corresponding to the current file'
+        type: object
+        required: [path]
+        additionalProperties: false
+        properties:
+          path:
+            description: 'Path to associated scans file'
+            type: string
+          duration:
+            description: 'Value of the duration column for the current file, if present'
+            type: number
+          acq_time:
+            description: 'Value of the acq_time column for the current file, if present'
+            type: string
   # The following properties are populated if the current file is of an appropriate type
   columns:
     description: 'TSV columns, indexed by column header, values are arrays with column contents'

--- a/src/schema/objects/columns.yaml
+++ b/src/schema/objects/columns.yaml
@@ -173,6 +173,18 @@ duration:
   type: number
   unit: s
   minimum: 0
+duration__scans:
+  name: duration
+  display_name: Scan duration
+  description: |
+    Wallclock duration of the recording in seconds,
+    from the acquisition of the first data sample to the end of the acquisition of the last data sample.
+    MUST be strictly positive.
+    For MRI data, this is equivalent to the `AcquisitionDuration` sidecar metadata field;
+    if both are present for the same file they SHOULD be equal.
+  type: number
+  unit: s
+  exclusiveMinimum: 0
 x_coordinate:
   name: x_coordinate
   display_name: Gaze x-coordinate

--- a/src/schema/rules/checks/mri.yaml
+++ b/src/schema/rules/checks/mri.yaml
@@ -173,3 +173,23 @@ SmallDeltaNotConsistent:
     - type(nifti_header) != "null"
   checks:
     - length(sidecar.SmallDelta) == nifti_header.dim[4]
+
+ScansAcquisitionDurationConsistency:
+  issue:
+    code: SCANS_DURATION_MISMATCH_ACQUISITION_DURATION
+    message: |
+      The 'duration' column in the scans.tsv file does not match the
+      'AcquisitionDuration' sidecar metadata field for this file.
+      Both fields record total acquisition duration in seconds and SHOULD be equal.
+    level: warning
+  selectors:
+    - modality == "mri"
+    - match(extension, "^\.nii(\.gz)?$")
+    - '"AcquisitionDuration" in sidecar'
+    - type(associations.scans) != "null"
+    - '"duration" in associations.scans'
+    # Exclude BOLD/ASL + VolumeTiming: there AcquisitionDuration was used (and is now
+    # deprecated) as a per-volume measure, not total-scan duration.
+    - '!intersects([suffix], ["bold", "asl"]) || type(sidecar.VolumeTiming) == "null"'
+  checks:
+    - associations.scans.duration == sidecar.AcquisitionDuration

--- a/src/schema/rules/tabular_data/modality_agnostic.yaml
+++ b/src/schema/rules/tabular_data/modality_agnostic.yaml
@@ -43,6 +43,7 @@ Scans:
       description_addendum: |
         There MUST be exactly one row for each file.
     acq_time__scans: optional
+    duration__scans: recommended
     HED: optional
   index_columns: [filename]
   additional_columns: allowed


### PR DESCRIPTION
## Summary

Add an OPTIONAL `duration` column to `_scans.tsv` files, recording the wallclock duration (in seconds) of each recording from first to last acquired data sample.   The column level is OPTIONAL, matching `acq_time__scans`, to avoid introducing warnings for the large number of existing BIDS datasets that do not include it.

Also added schema infrastructure to validate consistency between this column and the (deprecated) `AcquisitionDuration` sidecar metadata field when both are present for the same MRI file.  But we could  drop it if deemed excessive.

**Relationship to existing work:**  

- Related to issue #2362 
- and PR #2441 which propose adding `duration` primarily for concurrent-recording identification with `duration` conditionally REQUIRED.

This PR scoped more generally!  And our initial need with @vmdocua is to get clean information on each MRI volume  for  https://github.com/ReproNim/reprostim/ to align collection audiovideo of stimuli.  Since otherwise, please correct me if I am wrong, **In BIDS we do not have a uniform way to tell how long (in time) any particular data file is**.

We will need to add that to heudiconv, although may be we would agree to agree with @neurolabusc for dcm2niix to somehow extract it may be in continuation to https://github.com/rordenlab/dcm2niix/issues/991#issuecomment-4239706491 discussion.

To implement validation, claude said we need to extend the 'context'!  @effigies @rwblair -- is that true?  should I just not bother for this one?:

> **Note for validator implementers:** the `associations.scans` context requires
> a new lookup pattern — find the `_scans.tsv` at the appropriate directory level
> and return the column values for the row whose `filename` matches the current
> file's relative path (as a scalar, not an array of all values).

## Test plan

- [ ] Decide if worth keeping the check of equality to to `AcquisitionDuration`
- [ ] Validator implementations populate `associations.scans` and exercise
      `ScansAcquisitionDurationConsistency`.
- [x] Schema loads correctly (verified with `bidsschematools.schema.load_schema`).
- [x] All pre-commit hooks pass (yamllint, codespell, prettier, check-yaml).
- [x] CI (`validate_schema` job) on this PR.
- [ ] Finalize examples