### PR TITLE
[SCHEMA] BEP032: Resolve the units TODO on MicroephysCoordinateUnits

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2451,14 +2451,14 @@ MicroephysCoordinateUnits:
   display_name: Microephys Coordinate Units
   description: |
     Units of the coordinates of `"MicroephysCoordinateSystem"`.
+    MUST be `"pixels"` if `MicroephysCoordinateSystem` is `Pixels`.
   type: string
-  # TODO: Clarify if units need to be used or enums, if units, define pixels
   enum:
+    - $ref: objects.enums.pixels.value
     - m
     - mm
     - cm
     - um
-    - pixels
 MicroephysCoordinateSystemPhoto:
   name: MicroephysCoordinateSystemPhoto
   display_name: Microephys Coordinate System Photo


### PR DESCRIPTION
This addresses Chris's question on #2307 about the `TODO: Clarify if units need to be used or enums, if units, define pixels` comment on `MicroephysCoordinateUnits`. The answer is the pattern that `iEEGCoordinateUnits` already uses: the field is an enum of length units plus `pixels`, `pixels` references the shared enum entry, and the description states that the units MUST be `"pixels"` when `MicroephysCoordinateSystem` is `Pixels`. The prose in the "Allowed 2D coordinate systems" section already says this, so this only brings the schema definition in line with it and removes the TODO. Same as iEEG, there is no validator check pairing the two values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPCasNDSUAn4ZcoqBhXU5p
