### PR TITLE
[FIX] BEP032: Fix remark list-item-spacing warning

### DIFF
--- a/src/modality-specific-files/microelectrode-electrophysiology.md
+++ b/src/modality-specific-files/microelectrode-electrophysiology.md
@@ -997,6 +997,7 @@ for practical guidance when curating a new dataset:
 
 -   [`microephys_toy`](https://github.com/bids-standard/bids-examples/tree/master/microephys_toy):
     the toy extracellular and intracellular datasets described above.
+
 -   [`microephys_ecephys_multielectrode_grasp`](https://github.com/bids-standard/bids-examples/tree/master/microephys_ecephys_multielectrode_grasp):
     the extracellular multielectrode array dataset published in
     [Brochier (2018)](https://doi.org/10.1038/sdata.2018.55), reorganized according to this specification


### PR DESCRIPTION
The remark check on #2307 fails after #2504 because the list in "Examples of Real Datasets" has multi-line items without a blank line between them. This adds the blank line. Verified locally with `remark --frail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPCasNDSUAn4ZcoqBhXU5p
